### PR TITLE
Removed font awesome 6 from dependencies and build

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -19551,38 +19551,6 @@
         }
       }
     },
-    "node_modules/vite-plugin-static-copy": {
-      "version": "0.13.0",
-      "resolved": "https://registry.npmjs.org/vite-plugin-static-copy/-/vite-plugin-static-copy-0.13.0.tgz",
-      "integrity": "sha512-cln+fvKMgwNBjxQ59QVblmExZrc9gGEdRmfqcPOOGpxT5KInfpkGMvmK4L+kCAeHHSSGNU1bM7BA9PQgaAJc6g==",
-      "dev": true,
-      "dependencies": {
-        "chokidar": "^3.5.3",
-        "fast-glob": "^3.2.11",
-        "fs-extra": "^11.1.0",
-        "picocolors": "^1.0.0"
-      },
-      "engines": {
-        "node": "^14.18.0 || >=16.0.0"
-      },
-      "peerDependencies": {
-        "vite": "^3.0.0 || ^4.0.0"
-      }
-    },
-    "node_modules/vite-plugin-static-copy/node_modules/fs-extra": {
-      "version": "11.1.0",
-      "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-11.1.0.tgz",
-      "integrity": "sha512-0rcTq621PD5jM/e0a3EJoGC/1TC5ZBCERW82LQuwfGnCa1V8w7dpYH1yNu+SLb6E5dkeCBzKEyLGlFrnr+dUyw==",
-      "dev": true,
-      "dependencies": {
-        "graceful-fs": "^4.2.0",
-        "jsonfile": "^6.0.1",
-        "universalify": "^2.0.0"
-      },
-      "engines": {
-        "node": ">=14.14"
-      }
-    },
     "node_modules/vm-browserify": {
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/vm-browserify/-/vm-browserify-1.1.2.tgz",
@@ -20768,8 +20736,7 @@
         "react-syntax-highlighter": "^15.5.0",
         "sass": "^1.58.0",
         "style-dictionary": "^3.7.2",
-        "vite": "^4.0.0",
-        "vite-plugin-static-copy": "^0.13.0"
+        "vite": "^4.0.0"
       }
     }
   },
@@ -22179,8 +22146,7 @@
         "react-syntax-highlighter": "^15.5.0",
         "sass": "^1.58.0",
         "style-dictionary": "^3.7.2",
-        "vite": "^4.0.0",
-        "vite-plugin-static-copy": "^0.13.0"
+        "vite": "^4.0.0"
       }
     },
     "@cnakazawa/watch": {
@@ -35635,31 +35601,6 @@
         "postcss": "^8.4.20",
         "resolve": "^1.22.1",
         "rollup": "^3.7.0"
-      }
-    },
-    "vite-plugin-static-copy": {
-      "version": "0.13.0",
-      "resolved": "https://registry.npmjs.org/vite-plugin-static-copy/-/vite-plugin-static-copy-0.13.0.tgz",
-      "integrity": "sha512-cln+fvKMgwNBjxQ59QVblmExZrc9gGEdRmfqcPOOGpxT5KInfpkGMvmK4L+kCAeHHSSGNU1bM7BA9PQgaAJc6g==",
-      "dev": true,
-      "requires": {
-        "chokidar": "^3.5.3",
-        "fast-glob": "^3.2.11",
-        "fs-extra": "^11.1.0",
-        "picocolors": "^1.0.0"
-      },
-      "dependencies": {
-        "fs-extra": {
-          "version": "11.1.0",
-          "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-11.1.0.tgz",
-          "integrity": "sha512-0rcTq621PD5jM/e0a3EJoGC/1TC5ZBCERW82LQuwfGnCa1V8w7dpYH1yNu+SLb6E5dkeCBzKEyLGlFrnr+dUyw==",
-          "dev": true,
-          "requires": {
-            "graceful-fs": "^4.2.0",
-            "jsonfile": "^6.0.1",
-            "universalify": "^2.0.0"
-          }
-        }
       }
     },
     "vm-browserify": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -2533,16 +2533,6 @@
         "url": "https://opencollective.com/eslint"
       }
     },
-    "node_modules/@fortawesome/fontawesome-free": {
-      "version": "6.3.0",
-      "resolved": "https://registry.npmjs.org/@fortawesome/fontawesome-free/-/fontawesome-free-6.3.0.tgz",
-      "integrity": "sha512-qVtd5i1Cc7cdrqnTWqTObKQHjPWAiRwjUPaXObaeNPcy7+WKxJumGBx66rfSFgK6LNpIasVKkEgW8oyf0tmPLA==",
-      "dev": true,
-      "hasInstallScript": true,
-      "engines": {
-        "node": ">=6"
-      }
-    },
     "node_modules/@gar/promisify": {
       "version": "1.1.3",
       "resolved": "https://registry.npmjs.org/@gar/promisify/-/promisify-1.1.3.tgz",
@@ -20765,7 +20755,6 @@
       "license": "CC0-1.0",
       "devDependencies": {
         "@babel/core": "^7.20.12",
-        "@fortawesome/fontawesome-free": "^6.3.0",
         "@storybook/addon-actions": "^6.5.16",
         "@storybook/addon-essentials": "^6.5.16",
         "@storybook/addon-interactions": "^6.5.16",
@@ -22177,7 +22166,6 @@
       "version": "file:packages/styles",
       "requires": {
         "@babel/core": "^7.20.12",
-        "@fortawesome/fontawesome-free": "^6.3.0",
         "@storybook/addon-actions": "^6.5.16",
         "@storybook/addon-essentials": "^6.5.16",
         "@storybook/addon-interactions": "^6.5.16",
@@ -22483,12 +22471,6 @@
         "minimatch": "^3.1.2",
         "strip-json-comments": "^3.1.1"
       }
-    },
-    "@fortawesome/fontawesome-free": {
-      "version": "6.3.0",
-      "resolved": "https://registry.npmjs.org/@fortawesome/fontawesome-free/-/fontawesome-free-6.3.0.tgz",
-      "integrity": "sha512-qVtd5i1Cc7cdrqnTWqTObKQHjPWAiRwjUPaXObaeNPcy7+WKxJumGBx66rfSFgK6LNpIasVKkEgW8oyf0tmPLA==",
-      "dev": true
     },
     "@gar/promisify": {
       "version": "1.1.3",

--- a/packages/styles/package.json
+++ b/packages/styles/package.json
@@ -18,7 +18,6 @@
   },
   "devDependencies": {
     "@babel/core": "^7.20.12",
-    "@fortawesome/fontawesome-free": "^6.3.0",
     "@storybook/addon-actions": "^6.5.16",
     "@storybook/addon-essentials": "^6.5.16",
     "@storybook/addon-interactions": "^6.5.16",

--- a/packages/styles/package.json
+++ b/packages/styles/package.json
@@ -31,8 +31,7 @@
     "react-syntax-highlighter": "^15.5.0",
     "sass": "^1.58.0",
     "style-dictionary": "^3.7.2",
-    "vite": "^4.0.0",
-    "vite-plugin-static-copy": "^0.13.0"
+    "vite": "^4.0.0"
   },
   "dependencies": {}
 }

--- a/packages/styles/vite.config.js
+++ b/packages/styles/vite.config.js
@@ -1,7 +1,6 @@
 // vite.config.js
 import { resolve } from 'path'
 import { defineConfig, normalizePath } from 'vite'
-//import { viteStaticCopy } from 'vite-plugin-static-copy'
 
 export default defineConfig({
   server: {

--- a/packages/styles/vite.config.js
+++ b/packages/styles/vite.config.js
@@ -1,7 +1,7 @@
 // vite.config.js
 import { resolve } from 'path'
 import { defineConfig, normalizePath } from 'vite'
-import { viteStaticCopy } from 'vite-plugin-static-copy'
+//import { viteStaticCopy } from 'vite-plugin-static-copy'
 
 export default defineConfig({
   server: {
@@ -10,16 +10,7 @@ export default defineConfig({
   preview: {
     port: 8080,
   },
-  plugins: [
-    viteStaticCopy({
-      targets: [
-        {
-          src: '../../node_modules/@fortawesome/fontawesome-free/svgs/*',
-          dest: 'assets/icons'
-        }
-      ]
-    })
-  ],
+  plugins: [],
   build: {
     lib: {
       // Could also be a dictionary or array of multiple entry points


### PR DESCRIPTION
Removed fontawesome 6 npm package and removed from build process while we continue to use font icons in the short term (vs SVGs).