### PR TITLE
Feat/implement dark mode

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,8 @@ The CBP Design System (1.0) exists to provide a unifying user experience and red
 $ cd design-system
 $ npm install
 $ npm run styles-dev      # run the styles dev server
-$ npm run styles-build    # runs vite build
+$ npm run styles-build    # runs vite build to build out css and js
+$ npm run styles-sb       # runs storybook for the styles package
 ```
 
 The CBP Design System repo is set up as a monorepo that uses the "workspaces" feature from `npm` for managing multiple packages from a singular top-level, root package. [[NPM Workspaces]](https://docs.npmjs.com/cli/v8/using-npm/workspaces)

--- a/package.json
+++ b/package.json
@@ -9,6 +9,7 @@
     "build-tokens": "npm run sd -w packages/styles",
     "styles-dev": "npm run dev -w packages/styles",
     "styles-build": "npm run build -w packages/styles",
+    "styles-sb": "npm run storybook -w packages/styles",
     "test": "echo \"Error: no test specified\" && exit 1"
   },
   "repository": {

--- a/packages/styles/index.html
+++ b/packages/styles/index.html
@@ -238,7 +238,13 @@
                 <div class="sandbox__demo-container">
                   <div class="sandbox__demo">
                     <!-- *COMPONENT GOES HERE* -->
-
+                    <label class="cbp-toggle demo-toggle" data-component="cbp-toggle">
+                      <input type="checkbox" data-theme-toggle>
+                      <span class="slider">
+                        <i class="fas fa-moon" style="color: yellow;"></i>
+                        <i class="fas fa-sun" style="color: orange;"></i>
+                      </span>
+                    </label>
                   </div>
                   <aside class="sandbox__modifiers">
                     <h2>State Modifiers</h2>

--- a/packages/styles/src/index.js
+++ b/packages/styles/src/index.js
@@ -10,6 +10,7 @@ import HashedField from './components/form/hashed-field/hashedField';
 import NumberCounter from './components/form/number-counter/numberCounter';
 
 import './sass/main.scss';
+import DarkMode from './utilities/darkMode';
 
 const addOrInstantiate = (Klass, node) => {
   return new Klass(node);
@@ -91,5 +92,9 @@ document.addEventListener('DOMContentLoaded', (event) => {
    */
   SelectorEngine.findAll('.cbp-form__number--counter').forEach((counter) => {
     addOrInstantiate(NumberCounter, counter);
+  });
+
+  SelectorEngine.findAll('[data-theme-toggle]').forEach((themeToggle) => {
+    new DarkMode();
   });
 });

--- a/packages/styles/src/index.js
+++ b/packages/styles/src/index.js
@@ -95,6 +95,6 @@ document.addEventListener('DOMContentLoaded', (event) => {
   });
 
   SelectorEngine.findAll('[data-theme-toggle]').forEach((themeToggle) => {
-    new DarkMode();
+    addOrInstantiate(DarkMode, themeToggle);
   });
 });

--- a/packages/styles/src/index.js
+++ b/packages/styles/src/index.js
@@ -8,9 +8,9 @@ import Toggle from './components/toggle/toggle';
 import FileUploader from './components/fileupload/fileupload';
 import HashedField from './components/form/hashed-field/hashedField';
 import NumberCounter from './components/form/number-counter/numberCounter';
+import DarkMode from './utilities/darkMode';
 
 import './sass/main.scss';
-import DarkMode from './utilities/darkMode';
 
 const addOrInstantiate = (Klass, node) => {
   return new Klass(node);

--- a/packages/styles/src/sass/base/_core.scss
+++ b/packages/styles/src/sass/base/_core.scss
@@ -1,37 +1,26 @@
 @use 'colors' as *;
 @use '../tokens/font' as *;
 
-:root {
-  --cbp-color-background: #{$cbp-bg-light};
-  --cbp-color-text: #{$cbp-text-darkest};
-}
-
 html {
-  color: var(--cbp-color-text);
-  background-color: var(--cbp-color-background);
+  background-color: $cbp-bg-light;
+  color: $cbp-text-darkest;
 }
 
 @media (prefers-color-scheme: dark) {
-  :root {
-    --cbp-color-background: #{$cbp-bg-dark};
-    --cbp-color-text: #{$cbp-text-lightest};
+  html {
+    background-color: $cbp-bg-dark;
+    color: $cbp-text-lightest;
   }
 
   html[data-cbp-theme="light"] {
-    --cbp-color-background: #{$cbp-bg-light};
-    --cbp-color-text: #{$cbp-text-darkest};
-    
-    color: var(--cbp-color-text);
-    background-color: var(--cbp-color-background);
+    color: $cbp-text-darkest;
+    background-color: $cbp-bg-light;
   }
 }
 
 html[data-cbp-theme="dark"] {
-  --cbp-color-background: #{$cbp-bg-dark};
-  --cbp-color-text: #{$cbp-text-lightest};
-
-  color: var(--cbp-color-text);
-  background-color: var(--cbp-color-background);
+  color: $cbp-text-lightest;
+  background-color: $cbp-bg-dark;
 }
 
 body {

--- a/packages/styles/src/sass/base/_core.scss
+++ b/packages/styles/src/sass/base/_core.scss
@@ -1,12 +1,39 @@
 @use 'colors' as *;
 @use '../tokens/font' as *;
 
-html {
-  color: $cbp-text-darkest;
-  font-family: $cbp-font-family-roboto;
+:root {
+  --cbp-color-background: #{$cbp-bg-light};
+  --cbp-color-text: #{$cbp-text-darkest};
 }
 
-[data-theme="dark"] {
-  background-color: $cbp-bg-dark;
-  color: $cbp-text-lightest;
+html {
+  color: var(--cbp-color-text);
+  background-color: var(--cbp-color-background);
+}
+
+@media (prefers-color-scheme: dark) {
+  :root {
+    --cbp-color-background: #{$cbp-bg-dark};
+    --cbp-color-text: #{$cbp-text-lightest};
+  }
+
+  html[data-cbp-theme="light"] {
+    --cbp-color-background: #{$cbp-bg-light};
+    --cbp-color-text: #{$cbp-text-darkest};
+    
+    color: var(--cbp-color-text);
+    background-color: var(--cbp-color-background);
+  }
+}
+
+html[data-cbp-theme="dark"] {
+  --cbp-color-background: #{$cbp-bg-dark};
+  --cbp-color-text: #{$cbp-text-lightest};
+
+  color: var(--cbp-color-text);
+  background-color: var(--cbp-color-background);
+}
+
+body {
+  font-family: $cbp-font-family-roboto;
 }

--- a/packages/styles/src/sass/base/_core.scss
+++ b/packages/styles/src/sass/base/_core.scss
@@ -1,21 +1,9 @@
 @use 'colors' as *;
 @use '../tokens/font' as *;
 
-html {
-  background-color: $cbp-bg-light;
+html[data-cbp-theme="light"] {
   color: $cbp-text-darkest;
-}
-
-@media (prefers-color-scheme: dark) {
-  html {
-    background-color: $cbp-bg-dark;
-    color: $cbp-text-lightest;
-  }
-
-  html[data-cbp-theme="light"] {
-    color: $cbp-text-darkest;
-    background-color: $cbp-bg-light;
-  }
+  background-color: $cbp-bg-light;
 }
 
 html[data-cbp-theme="dark"] {

--- a/packages/styles/src/utilities/darkMode.js
+++ b/packages/styles/src/utilities/darkMode.js
@@ -1,0 +1,41 @@
+class DarkMode {
+  constructor() {
+    // Toggle component needs to have 'data-theme-toggle' attribute in order for this to work.
+    this.themeToggle = document.querySelector("[data-theme-toggle]");
+    this.prefersDarkMode = window.matchMedia('(prefers-color-scheme: dark)');
+    this.storedTheme = localStorage.getItem('theme');
+
+    this.setTheme(this.preferredTheme());
+
+    this.handleThemeToggle(this.themeToggle);
+  }
+
+  preferredTheme() {
+    if (this.storedTheme) {
+      return this.storedTheme;
+    }
+    return this.prefersDarkMode.matches ? 'dark' : 'light';
+  }
+
+  setTheme(theme) {
+    theme === 'dark' ? this.themeToggle.checked = true : this.themeToggle.checked = false;
+
+    if (this.storedTheme === 'light' || this.storedTheme === 'dark') {
+      document.documentElement.setAttribute('data-cbp-theme', theme);
+    }
+  }
+
+  handleThemeToggle(themeToggle) {
+    themeToggle.addEventListener('click', () => {
+      if (themeToggle.checked) {
+        localStorage.setItem('theme', 'dark')
+        document.documentElement.setAttribute('data-cbp-theme', 'dark');
+      } else {
+        localStorage.setItem('theme', 'light')
+        document.documentElement.setAttribute('data-cbp-theme', 'light');
+      }
+    })
+  }
+}
+
+export default DarkMode;

--- a/packages/styles/src/utilities/darkMode.js
+++ b/packages/styles/src/utilities/darkMode.js
@@ -5,6 +5,8 @@ class DarkMode {
     this.prefersDarkMode = window.matchMedia('(prefers-color-scheme: dark)');
     this.storedTheme = localStorage.getItem('theme');
 
+    this.preferredTheme() === 'dark' ? this.themeToggle.checked = true : this.themeToggle.checked = false;
+
     this.setTheme(this.preferredTheme());
 
     this.handleThemeToggle(this.themeToggle);
@@ -18,22 +20,13 @@ class DarkMode {
   }
 
   setTheme(theme) {
-    theme === 'dark' ? this.themeToggle.checked = true : this.themeToggle.checked = false;
-
-    if (this.storedTheme === 'light' || this.storedTheme === 'dark') {
-      document.documentElement.setAttribute('data-cbp-theme', theme);
-    }
+    localStorage.setItem('theme', theme)
+    document.documentElement.setAttribute('data-cbp-theme', theme);
   }
 
   handleThemeToggle(themeToggle) {
     themeToggle.addEventListener('click', () => {
-      if (themeToggle.checked) {
-        localStorage.setItem('theme', 'dark')
-        document.documentElement.setAttribute('data-cbp-theme', 'dark');
-      } else {
-        localStorage.setItem('theme', 'light')
-        document.documentElement.setAttribute('data-cbp-theme', 'light');
-      }
+      themeToggle.checked ? this.setTheme('dark') : this.setTheme('light');
     })
   }
 }

--- a/packages/styles/src/utilities/darkMode.js
+++ b/packages/styles/src/utilities/darkMode.js
@@ -1,7 +1,7 @@
 class DarkMode {
-  constructor() {
+  constructor(themeToggle) {
     // Toggle component needs to have 'data-theme-toggle' attribute in order for this to work.
-    this.themeToggle = document.querySelector("[data-theme-toggle]");
+    this.themeToggle = themeToggle;
     this.prefersDarkMode = window.matchMedia('(prefers-color-scheme: dark)');
     this.storedTheme = localStorage.getItem('theme');
 


### PR DESCRIPTION
#### What's this PR do?
1. Setup `[data-cbp-theme=light]`, `[data-cbp-theme=light]` and `prefers-color-scheme` media query scss
2. Implement JS to toggle dark mode using the toggle component and `localStorage`
#### Where should the reviewer start?
- `styles/src/utilities/darkMode.js`
- `/styles/src/sass/base/_core.scss`
- `styles/src/index.js`
- `styles/index.html` (Toggle component has a bug when icons are placed inside)
#### How should this be manually tested?
- `npm run styles-build`
- `npm run styles-dev`
  1. Run locally and click on the toggle component in localhost:8000 (in sandbox)
  2. Check `localStorage` 'theme' is set when dark or light mode is toggled. 
- `npm run storybook -w packages/styles`
  1. Toggle dark mode addon in storybook toolbar
#### Any background context you want to provide?
#### What are the relevant tickets?
#### Screenshots (if appropriate)
#### Questions:
- Is there a blog post?
- Does the knowledge base need an update?
