### PR TITLE
Update --cbp-border-radius-softest to softer in component CSS

### DIFF
--- a/packages/vanilla/src/sass/components/_menu.scss
+++ b/packages/vanilla/src/sass/components/_menu.scss
@@ -33,7 +33,7 @@
     max-width: 100%;
     margin: 0 5% var(--cbp-space-6x);
     padding: 0;
-    border-radius: var(--cbp-border-radius-softest);
+    border-radius: var(--cbp-border-radius-softer);
     box-shadow: var(--cbp-shadow-level-1-down);
     list-style-type: none;
     z-index: var(--cbp-z-index-level-0); // TechDebt: revisit - this likely needs to be higher as it should overlay anything on the content-level including sticky items
@@ -55,8 +55,8 @@
     background-color: var(--cbp-color-base-neutral-darker);
 
     &:first-child {
-      border-top-left-radius: var(--cbp-border-radius-softest);
-      border-top-right-radius: var(--cbp-border-radius-softest);
+      border-top-left-radius: var(--cbp-border-radius-softer);
+      border-top-right-radius: var(--cbp-border-radius-softer);
 
       a {
         border-top-left-radius: inherit;
@@ -65,7 +65,7 @@
     }
 
     &:last-child {
-      border-radius: 0 0 var(--cbp-border-radius-softest) var(--cbp-border-radius-softest);
+      border-radius: 0 0 var(--cbp-border-radius-softer) var(--cbp-border-radius-softer);
       
       a, button {
         border-bottom-left-radius: inherit;

--- a/packages/vanilla/src/sass/components/_modal.scss
+++ b/packages/vanilla/src/sass/components/_modal.scss
@@ -1,6 +1,6 @@
 .cbp-modal {
   background-color: var(--cbp-color-white);
-  border-radius: var(--cbp-border-radius-softest);
+  border-radius: var(--cbp-border-radius-softer);
   border-width: 0;
   box-shadow: var(--cbp-shadow-level-1-down);
   width: 22rem;
@@ -57,11 +57,11 @@
     height: var(--cbp-space-11x);
     
     &:first-child {
-      border-bottom-left-radius: var(--cbp-border-radius-softest);
+      border-bottom-left-radius: var(--cbp-border-radius-softer);
     }
 
     &:last-child {
-      border-bottom-right-radius: var(--cbp-border-radius-softest);
+      border-bottom-right-radius: var(--cbp-border-radius-softer);
     }
   }
 }

--- a/packages/vanilla/src/sass/components/card/_banner.scss
+++ b/packages/vanilla/src/sass/components/card/_banner.scss
@@ -16,8 +16,8 @@
 .cbp-card__banner-title {
   align-items: center;
   background-color: var(--cbp-color-gray-cool-60);
-  border-top-left-radius: var(--cbp-border-radius-softest);
-  border-top-right-radius: var(--cbp-border-radius-softest);;
+  border-top-left-radius: var(--cbp-border-radius-softer);
+  border-top-right-radius: var(--cbp-border-radius-softer);;
   color: var(--cbp-color-text-lightest);
   display: flex;
   font-size: var(--cbp-font-size-heading-xl);
@@ -36,8 +36,8 @@
   border-style: solid;
   border-width: var(--cbp-border-size-md);
   border-top: 0;
-  border-bottom-left-radius: var(--cbp-border-radius-softest);
-  border-bottom-right-radius: var(--cbp-border-radius-softest);
+  border-bottom-left-radius: var(--cbp-border-radius-softer);
+  border-bottom-right-radius: var(--cbp-border-radius-softer);
   padding: var(--cbp-space-4x) var(--cbp-space-4x) var(--cbp-space-5x) var(--cbp-space-4x);
 }
 

--- a/packages/vanilla/src/sass/components/card/_base.scss
+++ b/packages/vanilla/src/sass/components/card/_base.scss
@@ -1,6 +1,6 @@
 .cbp-card {
   border: var(--cbp-border-size-md) solid var(--cbp-color-base-neutral-lighter);
-  border-radius: var(--cbp-border-radius-softest);
+  border-radius: var(--cbp-border-radius-softer);
   max-width: 100%;
 }
 

--- a/packages/vanilla/src/sass/components/card/_decision.scss
+++ b/packages/vanilla/src/sass/components/card/_decision.scss
@@ -5,8 +5,8 @@
 
   & .cbp-card__content {
     border: var(--cbp-border-size-md) solid var(--cbp-color-base-neutral-lighter);
-    border-top-left-radius: var(--cbp-border-radius-softest);
-    border-top-right-radius: var(--cbp-border-radius-softest);
+    border-top-left-radius: var(--cbp-border-radius-softer);
+    border-top-right-radius: var(--cbp-border-radius-softer);
     border-bottom: 0;
   }
 }
@@ -26,12 +26,12 @@
 
   & > button:first-child,
   & > a[href]:first-child {
-    border-bottom-left-radius: var(--cbp-border-radius-softest);
+    border-bottom-left-radius: var(--cbp-border-radius-softer);
   }
 
   & > button:last-child,
   & > a[href]:last-child {
-    border-bottom-right-radius: var(--cbp-border-radius-softest);
+    border-bottom-right-radius: var(--cbp-border-radius-softer);
   }
 }
 

--- a/packages/vanilla/src/sass/components/footer/_external.scss
+++ b/packages/vanilla/src/sass/components/footer/_external.scss
@@ -96,7 +96,7 @@
   // Secondary Ghost Button (Dark) Stylings
   & > a[href] {
     display: inline-block;
-    border-radius: var(--cbp-border-radius-softest);
+    border-radius: var(--cbp-border-radius-softer);
     color: var(--cbp-color-interactive-secondary-lighter);
     font-weight: var(--cbp-font-weight-medium);
     margin-top: var(--cbp-space-4x);


### PR DESCRIPTION
Updated component CSS using  `--cbp-border-radius-softest` to `--cbp-border-radius-softer`. Both values were updated and it was noted that "softest" was not officially in the token list and all components using it were supposed to be using "softer", which was updated in the previous PR with the correct value.