### PR TITLE
Set focus on clicked tab to correct Safari button behavior

### DIFF
--- a/packages/vanilla/src/components/tabs/tabs.js
+++ b/packages/vanilla/src/components/tabs/tabs.js
@@ -67,8 +67,9 @@ class Tabset {
       }
     });
     this.tabset.dispatchEvent(tabActivatedEvent);
+    // Set focus manually because Safari doesn't do this automatically, which breaks the keyboard navigation event listeners
+    clickedButton.focus();
   }
-
 
   handleNavigation(e) {
     e.key == 'ArrowRight' && this.keyboardNavigateForward(e);


### PR DESCRIPTION
* Fixed keyboard navigation of Tabs in Safari by manually setting focus to the tab button when clicked with a mouse. Safari's native behavior is to *not* keep focus on the button, which returns to the document body, breaking keyboard navigation event listeners targeted to the tab component (DOM node).
* Tested keyboard navigation of the Menu but was unsuccessful in "fixing" this in Safari. There is forking behavior within Safari based on browser settings:
  * By default this works, because buttons and links don't even appear in the tab order. So if I click the menu control to open it, arrow navigation works within and `tab` closes the menu by sending focus out of it to the next tabbable element.
  * If I enable the Safari Setting "Press tab to highlight each item on a webpage", which is highly recommended for proper keyboard navigation, then the menu works, but pressing tab within it navigates to the next menu item (like down arrow) despite the `tabindex="-1"` on the menu items (buttons and links). There doesn't seem to be anything I can do about this unless we want to force-close the menu just by pressing tab. It should not force-close when pressing SHIFT-tab, however, sending focus back to the menu control with stateful aria-attributes. I don't feel that this is breaking behavior that tab works in addition to the arrows within the menu - I'd chalk it up as a Safari quirk.
