### PR TITLE
Feat/actions gh pages

### DIFF
--- a/.github/workflows/publish-gh-pages.yml
+++ b/.github/workflows/publish-gh-pages.yml
@@ -1,0 +1,64 @@
+name: Deploy Github Pages
+run-name: ${{ github.actor }} is deploying the design system to Github Pages
+on: 
+  workflow_dispatch:
+
+  push:
+    branches:
+      - main
+
+
+# Grant GITHUB_TOKEN the permissions required to make a Pages deployment
+permissions:
+  contents: read
+  pages: write      # to deploy to Pages
+  id-token: write   # to verify the deployment originates from an appropriate source
+
+jobs: 
+  build: 
+    name: build static content
+    timeout-minutes: 15
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v3
+      - uses: actions/setup-node@v3
+        with:
+          node-version: "16.x"
+          cache: npm
+      - run: npm ci # runs clean-install
+      - run: npm run build-all # build all static sites in all packages
+
+      - name: Archive artifact
+        shell: sh
+        if: runner.os == 'Linux'
+        run: |
+          tar \
+            --dereference --hard-dereference \
+            --directory ".public" \
+            -cvf "$RUNNER_TEMP/artifact.tar" \
+            --exclude=.git \
+            --exclude=.github \
+            .
+
+      - uses: actions/upload-artifact@v3
+        with:
+          name: github-pages
+          path: ${{ runner.temp }}/artifact.tar
+          retention-days: "1"
+          if-no-files-found: error
+
+  deploy:
+    needs: build
+
+    # Deploy to the github-pages environment
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+
+    # Specify runner + deployment step
+    runs-on: ubuntu-latest
+    steps:
+      - name: Deploy to GitHub Pages
+        id: deployment
+        uses: actions/deploy-pages@v2

--- a/.gitignore
+++ b/.gitignore
@@ -137,3 +137,6 @@ _site
 .yarn/build-state.yml
 .yarn/install-state.gz
 .pnp.*
+
+# .public folder houses all static builds of /packages
+.public

--- a/.gitignore
+++ b/.gitignore
@@ -138,5 +138,5 @@ _site
 .yarn/install-state.gz
 .pnp.*
 
-# .public folder houses all static builds of /packages
+# .public folder holds all static builds of /packages for github pages artifact
 .public

--- a/package.json
+++ b/package.json
@@ -14,7 +14,8 @@
     "ux-build": "npm run build -w packages/ux-guidelines",
     "react-sb": "npm run storybook -w packages/react-components",
     "react-build": "npm run build -w packages/react-components",
-    "test": "echo \"Error: no test specified\" && exit 1"
+    "test": "echo \"Error: no test specified\" && exit 1",
+    "build-all": "npm run vanilla-build && npm run build-pages -w packages/ux-guidelines && npm run build-pages -w packages/vanilla && npm run build-pages -w packages/react-components"
   },
   "repository": {
     "type": "git",

--- a/packages/react-components/package.json
+++ b/packages/react-components/package.json
@@ -19,7 +19,8 @@
     "lint": "eslint . --ext js,jsx --report-unused-disable-directives --max-warnings 0",
     "preview": "vite preview",
     "storybook": "storybook dev -p 6007",
-    "build-storybook": "storybook build"
+    "build-storybook": "storybook build",
+    "build-pages": "storybook build -o ../../.public/react-sb"
   },
   "dependencies": {
     "react": "^18.2.0",

--- a/packages/ux-guidelines/package.json
+++ b/packages/ux-guidelines/package.json
@@ -9,7 +9,8 @@
   "scripts": {
     "test": "echo \"Error: no test specified\" && exit 1",
     "dev": "npx @11ty/eleventy --serve",
-    "build": "npx @11ty/eleventy"
+    "build": "npx @11ty/eleventy",
+    "build-pages": "npx @11ty/eleventy --output=../../.public/ux-guidelines"
   },
   "repository": {
     "type": "git",

--- a/packages/vanilla/package.json
+++ b/packages/vanilla/package.json
@@ -23,7 +23,8 @@
     "preview": "vite preview",
     "storybook": "storybook dev -p 6006",
     "build-storybook": "storybook build",
-    "storybook-static": "npm run build && npm run build-storybook && copy dist storybook-static/assets && npx http-server storybook-static"
+    "storybook-static": "npm run build && npm run build-storybook && copy dist storybook-static/assets && npx http-server storybook-static",
+    "build-pages": "storybook build -o ../../.public/vanilla-sb"
   },
   "devDependencies": {
     "@babel/core": "^7.20.12",


### PR DESCRIPTION
#### What's this PR do?

- Created `npm` scripts in packages under `build-pages`
- Added workflow file to build and deploy design system storybooks and ux-guideline site to github-pages environment. 

Initial Github Action workflow for deploying the design system storybooks and ux-guidelines site to the `github-pages` environment. The artifact to deploy to github-pages environment is created by building:

1.  `/package/vanilla` CSS and JS files
2. `/packages/ux-guidelines` static site
3. `/packages/vanilla` static storybook files
4. `/packages/react-components` static storybook files

The storybooks and ux-guidelines static files/content are output into the root `.public` directory that is created by the build process and not checked into version control. The `.public` folder is used to create the artifact by Github Actions, uploaded as an artifact and then deployed to the `github-pages` environment.