### PR TITLE
Fix button-styled anchors' width by making them inline-flex.

### DIFF
--- a/packages/vanilla/src/components/button/button.stories.js
+++ b/packages/vanilla/src/components/button/button.stories.js
@@ -1,8 +1,5 @@
 export default {
   title: 'Patterns/Button',
-  parameters: {
-    layout: 'centered',
-  },
   argTypes: {
     element: {
       name: 'Semantic Element',

--- a/packages/vanilla/src/sass/components/button/_base.scss
+++ b/packages/vanilla/src/sass/components/button/_base.scss
@@ -1,6 +1,6 @@
 // Base Button CSS
 .cbp-btn {
-  display: flex;
+  display: inline-flex;
   align-items: center;
   justify-content: center;
   border-width: var(--cbp-border-size-md);


### PR DESCRIPTION
* Fix button-styled anchors' width by making them inline-flex.
* Updated the button story to remove centering, which was hiding this bug.
* Regression-tested regular buttons across all patterns in storybook.