### PR TITLE
fix: re-order modules for utlity classes in main.scss and breakdown padding css for fluid-container

### DIFF
--- a/packages/vanilla/src/sass/layout/_container.scss
+++ b/packages/vanilla/src/sass/layout/_container.scss
@@ -1,13 +1,16 @@
 @use './../tokens/breakpoints' as *;
 
 .cbp-fluid-container {
-  padding: 0 var(--cbp-space-4x);
+  padding-left: var(--cbp-space-4x);
+  padding-right: var(--cbp-space-4x);
 
   @media (min-width: $cbp-breakpoint-md) and (max-width: $cbp-breakpoint-xl) {
-    padding: 0 var(--cbp-space-8x);
+    padding-left: var(--cbp-space-8x);
+    padding-right: var(--cbp-space-8x);
   }
   
   @media (min-width: $cbp-breakpoint-xl) {
-    padding: 0 var(--cbp-space-11x);
+    padding-left: var(--cbp-space-11x);
+    padding-right: var(--cbp-space-11x);
   }
 }

--- a/packages/vanilla/src/sass/main.scss
+++ b/packages/vanilla/src/sass/main.scss
@@ -10,9 +10,6 @@
 // CBP Typography
 @use "typography";
 
-// CBP Utilities
-@use "utilities";
-
 // CBP Grid
 @use "grid";
 
@@ -24,3 +21,6 @@
 
 // Demo SCSS - figure out a way to exclude these files from compile
 //@use "demo";
+
+// CBP Utilities
+@use "utilities";


### PR DESCRIPTION
#### What's this PR do?
- Replace `padding` shorthand in `.cbp-fluid-container`
- Re-order `main.scss` modules so utility classes are last
