### PR TITLE
Fix/drawer nav content

### DIFF
--- a/packages/vanilla/src/components/drawer/drawer.stories.js
+++ b/packages/vanilla/src/components/drawer/drawer.stories.js
@@ -36,56 +36,9 @@ const Template = ({drawerPosition}) => {
       </div>
 
       <nav class="cbp-drawer__content">
-        <ul class="cbp-drawer__nav">
-          <li class="cbp-drawer__nav-item--a">
-            <button type="button">
-              <span>
-                <i class="fas fa-home"></i>
-                Default/Home Page (A)
-              </span>
-              <i class="fas fa-angle-up"></i>
-            </button>
-            <ul>
-              <li>
-                <button type="button">Child Page 1 (B)</button>
-              </li>
-              <li>
-                <button type="button">Child Page 2 (B)<i class="fas fa-angle-up"></i></button>
-                <ul>
-                  <li>
-                    <button type="button">
-                      Grandchild Page 1 (C)
-                      <i class="fas fa-caret-up"></i>
-                    </button>
-                    <ul>
-                      <li>
-                        <button type="button" aria-selected="true">Great-Grandchild Page 1 (D)</button>
-                      </li>
-                      <li>
-                        <button type="button">Great-Grandchild Page 2 (D)</button>
-                      </li>
-                    </ul>
-                  </li>
-                  <li>
-                    <button type="button">Grandchild Page 2 (C)</button>
-                  </li>
-                </ul>
-              </li>
-            </ul>
-          </li>
-          <li>
-            <button type="button">
-              Sibling Page 1 (A)
-              <i class="fas fa-angle-up"></i>
-            </button>
-          </li>
-          <li>
-            <button type="button">Sibling Page 2 (A)</button>
-          </li>
-          <li>
-            <button type="button">Sibling Page 3 (A)</button>
-          </li>
-        </ul>
+        <section style="height: 100%; display: flex; justify-content: center; align-items: center;">
+          <p class="cbp-text-italic">Drawer Content</p>
+        </section>
       </nav>
     </div>
   `;

--- a/packages/vanilla/src/components/drawer/drawer.stories.js
+++ b/packages/vanilla/src/components/drawer/drawer.stories.js
@@ -35,11 +35,7 @@ const Template = ({drawerPosition}) => {
         </button>
       </div>
 
-      <nav class="cbp-drawer__content">
-        <section style="height: 100%; display: flex; justify-content: center; align-items: center;">
-          <p class="cbp-text-italic">Drawer Content</p>
-        </section>
-      </nav>
+      <div class="cbp-drawer__content"></div>
     </div>
   `;
 };

--- a/packages/vanilla/src/sass/components/drawer/_index.scss
+++ b/packages/vanilla/src/sass/components/drawer/_index.scss
@@ -1,8 +1,6 @@
-//@use '../../base/colors' as *;
 @use 'mixins' as *;
 
 @forward 'nav';
-
 
 /* Default Drawer Direction: 'left' */
 .cbp-drawer {
@@ -50,12 +48,6 @@
 .cbp-drawer__content {
   background-color: var(--cbp-color-white);
   height: 100%;
-
-  ul, ol {
-    list-style: none;
-    margin: 0;
-    padding: 0;
-  }
 }
 
 @include drawer-left;


### PR DESCRIPTION
#### What's this PR do?
- Removed old css set for nav items within `.cbp-drawer__content` that is unnecessary 
- Removed drawer "nav menu" and replace when a general nav/link menu is created in future. 
