### PR TITLE
fix: color for interactive-focus-dark is blue-warm-70

### DIFF
--- a/packages/vanilla/src/sass/tokens/_animation.scss
+++ b/packages/vanilla/src/sass/tokens/_animation.scss
@@ -1,6 +1,6 @@
 
 // Do not edit directly
-// Generated on Thu, 27 Apr 2023 17:05:44 GMT
+// Generated on Thu, 28 Sep 2023 17:58:51 GMT
 
 $cbp-motion-duration-instant: 1ms;
 $cbp-motion-duration-shortest: 200ms;

--- a/packages/vanilla/src/sass/tokens/_border.scss
+++ b/packages/vanilla/src/sass/tokens/_border.scss
@@ -1,6 +1,6 @@
 
 // Do not edit directly
-// Generated on Mon, 31 Jul 2023 12:26:21 GMT
+// Generated on Thu, 28 Sep 2023 17:58:51 GMT
 
 $cbp-border-size-sm: .0625rem;
 $cbp-border-size-md: .125rem;

--- a/packages/vanilla/src/sass/tokens/_breakpoints.scss
+++ b/packages/vanilla/src/sass/tokens/_breakpoints.scss
@@ -1,6 +1,6 @@
 
 // Do not edit directly
-// Generated on Thu, 27 Apr 2023 17:05:44 GMT
+// Generated on Thu, 28 Sep 2023 17:58:51 GMT
 
 $cbp-breakpoint-sm: 37.5em;
 $cbp-breakpoint-md: 37.5em;

--- a/packages/vanilla/src/sass/tokens/_color.scss
+++ b/packages/vanilla/src/sass/tokens/_color.scss
@@ -1,6 +1,6 @@
 
 // Do not edit directly
-// Generated on Mon, 31 Jul 2023 12:26:21 GMT
+// Generated on Thu, 28 Sep 2023 17:58:51 GMT
 
 $cbp-color-black: #000000;
 $cbp-color-blue-5: #e8f5ff;

--- a/packages/vanilla/src/sass/tokens/_css-variables.scss
+++ b/packages/vanilla/src/sass/tokens/_css-variables.scss
@@ -1,6 +1,6 @@
 /**
  * Do not edit directly
- * Generated on Mon, 31 Jul 2023 12:26:21 GMT
+ * Generated on Thu, 28 Sep 2023 17:58:51 GMT
  */
 
 :root {
@@ -355,7 +355,7 @@
   --cbp-color-interactive-visited-light: var(--cbp-color-blue-cool-20);
   --cbp-color-interactive-selected-dark: var(--cbp-color-blue-warm-60);
   --cbp-color-interactive-selected-light: var(--cbp-color-blue-warm-20);
-  --cbp-color-interactive-focus-dark: var(--cbp-color-blue-60);
+  --cbp-color-interactive-focus-dark: var(--cbp-color-blue-warm-70);
   --cbp-color-interactive-focus-light: var(--cbp-color-blue-20);
   --cbp-color-interactive-disabled-dark: var(--cbp-color-gray-40);
   --cbp-color-interactive-disabled-light: var(--cbp-color-gray-10);

--- a/packages/vanilla/src/sass/tokens/_elevation.scss
+++ b/packages/vanilla/src/sass/tokens/_elevation.scss
@@ -1,6 +1,6 @@
 
 // Do not edit directly
-// Generated on Thu, 06 Jul 2023 14:05:00 GMT
+// Generated on Thu, 28 Sep 2023 17:58:51 GMT
 
 $cbp-shadow-level-1-center: 0px 0px 4px 0px rgba(0, 0, 0, 0.5);
 $cbp-shadow-level-1-up: 0px -2px 4px 0px rgba(0, 0, 0, 0.5);

--- a/packages/vanilla/src/sass/tokens/_space.scss
+++ b/packages/vanilla/src/sass/tokens/_space.scss
@@ -1,6 +1,6 @@
 
 // Do not edit directly
-// Generated on Thu, 27 Apr 2023 17:05:44 GMT
+// Generated on Thu, 28 Sep 2023 17:58:51 GMT
 
 $cbp-space-half-x: .125rem;
 $cbp-space-1x: .25rem;

--- a/packages/vanilla/src/sass/tokens/_theme.scss
+++ b/packages/vanilla/src/sass/tokens/_theme.scss
@@ -1,6 +1,6 @@
 
 // Do not edit directly
-// Generated on Fri, 14 Jul 2023 15:38:30 GMT
+// Generated on Thu, 28 Sep 2023 17:58:51 GMT
 
 $cbp-color-branding-cbp-light: #f5f6f7;
 $cbp-color-branding-cbp-dark: #2d2e2f;
@@ -66,7 +66,7 @@ $cbp-color-interactive-active-dark: #162e51;
 $cbp-color-interactive-disabled-light: #e6e6e6;
 $cbp-color-interactive-disabled-dark: #919191;
 $cbp-color-interactive-focus-light: #a1d3ff;
-$cbp-color-interactive-focus-dark: #005ea2;
+$cbp-color-interactive-focus-dark: #1a4480;
 $cbp-color-interactive-selected-light: #adcdff;
 $cbp-color-interactive-selected-dark: #0050d8;
 $cbp-color-interactive-visited-light: #97d4ea;

--- a/packages/vanilla/src/sass/tokens/_typography.scss
+++ b/packages/vanilla/src/sass/tokens/_typography.scss
@@ -1,6 +1,6 @@
 
 // Do not edit directly
-// Generated on Wed, 19 Jul 2023 19:22:53 GMT
+// Generated on Thu, 28 Sep 2023 17:58:51 GMT
 
 $cbp-font-family-roboto: 'Roboto', Calibri, Tahoma, -apple-system, BlinkMacSystemFont, 'Segoe UI', Helvetica, Arial, 'Apple color emoji', 'Segoe UI Emoji', 'Segoe Ui Symbol', sans-serif;
 $cbp-font-family-roboto-mono: 'Roboto-mono', 'Roboto Mono Web', Consolas, 'Bitstream Vera Sans Mono', Courier, monospace;

--- a/packages/vanilla/src/tokens/theme.json
+++ b/packages/vanilla/src/tokens/theme.json
@@ -307,7 +307,7 @@
           "attributes": { "use": "theme", "type": "focus" }
         },
         "dark": {
-          "value": "{ color.blue.60.value }",
+          "value": "{ color.blue.warm.70.value }",
           "attributes": { "use": "theme", "type": "focus" }
         }
       },


### PR DESCRIPTION
#### What's this PR do?
- Color in the token list for `cbp-interactive-focus-dark` was the same color as `cbp-interactive-primary-dark`. Changed `cbp-interactive-focus-dark` to `blue-warm-70`
- Rebuild tokens
