### PR TITLE
Updates to square button and use in segmented buttons

### DIFF
--- a/packages/vanilla/src/components/segmented-button-group/segmented-button-group.stories.js
+++ b/packages/vanilla/src/components/segmented-button-group/segmented-button-group.stories.js
@@ -6,9 +6,9 @@ export default {
 const SingleSelectTemplate = () => {
   return `
     <div class="cbp-btn--segment" data-segmented-button-type="single">
-      <button type="button" value="sm">Small</button>
-      <button type="button" value="md">Medium</button>
-      <button type="button" value="lg">Large</button>
+      <button class="cbp-btn" type="button" value="sm">Small</button>
+      <button class="cbp-btn" type="button" value="md">Medium</button>
+      <button class="cbp-btn" type="button" value="lg">Large</button>
     </div>
   `;
 };
@@ -16,10 +16,10 @@ const SingleSelectTemplate = () => {
 const MultiSelectTemplate = () => {
   return `
     <div class="cbp-btn--segment" data-segmented-button-type="multi">
-      <button type="button" value="sauce">Sauce</button>
-      <button type="button" value="cheese">Cheese</button>
-      <button type="button" value="crust">Crust</button>
-      <button type="button" value="toppings">Toppings</button>
+      <button class="cbp-btn" type="button" value="sauce">Sauce</button>
+      <button class="cbp-btn" type="button" value="cheese">Cheese</button>
+      <button class="cbp-btn" type="button" value="crust">Crust</button>
+      <button class="cbp-btn" type="button" value="toppings">Toppings</button>
     </div>
   `;
 };
@@ -27,14 +27,14 @@ const MultiSelectTemplate = () => {
 const IconSelectTemplate = () => {
   return `
     <div class="cbp-btn--segment" data-segmented-button-type="multi">
-      <button type="button" value="bold" aria-label="bold"><i class="fas fa-bold"></i></button>
-      <button type="button" value="italic" aria-label="italic"><i class="fas fa-italic"></i></button>
-      <button type="button" value="underline" aria-label="underline"><i class="fas fa-underline"></i></button>
-      <button type="button" value="ordered list" aria-label="ordered list"><i class="fas fa-list-ol"></i></button>
-      <button type="button" value="list" aria-label="unordered list"><i class="fas fa-list"></i></button>
-      <button type="button" value="superscript" aria-label="superscript"><i class="fas fa-superscript"></i></button>
-      <button type="button" value="subscript" aria-label="subscript"><i class="fas fa-subscript"></i></button>
-      <button type="button" value="eye dropper" aria-label="eye dropper"><i class="fas fa-eye-dropper"></i></button>
+      <button class="cbp-btn-square" type="button" value="bold" aria-label="bold"><i class="fas fa-bold"></i></button>
+      <button class="cbp-btn-square" type="button" value="italic" aria-label="italic"><i class="fas fa-italic"></i></button>
+      <button class="cbp-btn-square" type="button" value="underline" aria-label="underline"><i class="fas fa-underline"></i></button>
+      <button class="cbp-btn-square" type="button" value="ordered list" aria-label="ordered list"><i class="fas fa-list-ol"></i></button>
+      <button class="cbp-btn-square" type="button" value="list" aria-label="unordered list"><i class="fas fa-list"></i></button>
+      <button class="cbp-btn-square" type="button" value="superscript" aria-label="superscript"><i class="fas fa-superscript"></i></button>
+      <button class="cbp-btn-square" type="button" value="subscript" aria-label="subscript"><i class="fas fa-subscript"></i></button>
+      <button class="cbp-btn-square" type="button" value="eye dropper" aria-label="eye dropper"><i class="fas fa-eye-dropper"></i></button>
     </div>
   `;
 };

--- a/packages/vanilla/src/sass/components/button/_base.scss
+++ b/packages/vanilla/src/sass/components/button/_base.scss
@@ -53,8 +53,8 @@
   @extend .cbp-btn;
   padding: unset;
   letter-spacing: unset;
-  min-height: 2.25rem;
-  min-width: 2.25rem;
+  height: 2.25rem;
+  width: 2.25rem;
 
   & > i {
     margin-right: 0;

--- a/packages/vanilla/src/sass/components/button/_segmentedbuttongroup.scss
+++ b/packages/vanilla/src/sass/components/button/_segmentedbuttongroup.scss
@@ -7,7 +7,6 @@
   width: fit-content;
 
   button {
-    @extend .cbp-btn;
     background-color: var(--cbp-color-white);
     border-style: solid;
     border-color: var(--cbp-color-interactive-secondary-dark);


### PR DESCRIPTION
* Fixed sizing of square buttons
* Use classes within the segmented button story markup and remove mixin, which was causing specificity issues. This method is more in line with reusable components (a button would always have the buttons classes and doesn't need to be styled again in the segmented button component)
