### PR TITLE
First cut at normalizing input patterns

### DIFF
--- a/packages/vanilla/src/components/checkbox/checkbox.stories.js
+++ b/packages/vanilla/src/components/checkbox/checkbox.stories.js
@@ -26,8 +26,8 @@ export default {
     (Story, context) => `
       <fieldset class="cbp-fieldset ${context.args.displayInline ? 'cbp-fieldset--inline' : ''}" ${context.args.disabled ? 'disabled' : ''}>
         <legend class="cbp-legend">${context.args.legend}</legend>
-        <p class="cbp-input__description">${context.args.inputDescription}</p>
-        <p class="cbp-input__description cbp-input__description--error" hidden><i class="fas fa-exclamation-triangle"></i>${context.args.errorMessage}</p>
+        <div class="cbp-input__description">${context.args.inputDescription}</div>
+        <div class="cbp-input__description cbp-input__description--error" hidden><i class="fas fa-exclamation-triangle"></i>${context.args.errorMessage}</div>
         ${Story().outerHTML || Story()}
       </fieldset>
     `

--- a/packages/vanilla/src/components/dropdown/dropdown.stories.js
+++ b/packages/vanilla/src/components/dropdown/dropdown.stories.js
@@ -5,10 +5,11 @@ export default {
 
 const Template = () => {
   return `
-    <div class="cbp-form-wrapper">
-      <label for="pod2" class="cbp-form__label">Variant Selector</label>
-      <span class="cbp-form__description cbp-form__description--error" hidden><i
-          class="fas fa-exclamation-triangle"></i>&nbsp;This field is required.</span>
+    <div class="cbp-input-pattern">
+      <label for="pod2" class="cbp-input__label">Variant Selector</label>
+      <div class="cbp-input__description cbp-form__description--error" hidden>
+        <i class="fas fa-exclamation-triangle"></i> This field is required.
+      </div>
       <div class="cbp-dropdown__wrapper" id="dropdown-demo-2">
         <button class="cbp-dropdown__custom" id="port-dropdown" data-toggle="dropdown">
           <span class="cbp-dropdown__placeholder">Choose Variant</span>

--- a/packages/vanilla/src/components/dropdown/multiSelectDropdown.stories.js
+++ b/packages/vanilla/src/components/dropdown/multiSelectDropdown.stories.js
@@ -5,53 +5,58 @@ export default {
 
 const Template = () => {
   return `
-    <label for="pod2" class="cbp-form__label">Port(s) of Departure</label>
-    <span class="cbp-form__description">
-      Required.
-    </span>
-    <span class="cbp-form__description cbp-form__description--error" hidden><i
-        class="fas fa-exclamation-triangle"></i>&nbsp;This field is required.</span>
-    <div class="cbp-dropdown__wrapper" id="dropdown-demo-3">
-      <button class="cbp-dropdown__custom" id="ports-dropdown" data-toggle="dropdown">
-        <span class="cbp-dropdown__placeholder">Choose Ports</span>
-      </button>
-      <div class="cbp-dropdown" id="custom-dropdown-menu">
-        <label class="cbp-dropdown__item cbp-dropdown__item--multiselect">
-          <input type="checkbox" value="22" autocomplete="off">
-          Port of Baltimore
-        </label>
-        <label class="cbp-dropdown__item cbp-dropdown__item--multiselect">
-          <input type="checkbox" value="82" autocomplete="off">
-          Port of Newark
-        </label>
-        <label class="cbp-dropdown__item cbp-dropdown__item--multiselect">
-          <input type="checkbox" value="11" autocomplete="off">
-          Port of Washington
-        </label>
-        <label class="cbp-dropdown__item cbp-dropdown__item--multiselect">
-          <input type="checkbox" value="667" autocomplete="off">
-          Port of Zoolily
-        </label>
-        <label class="cbp-dropdown__item cbp-dropdown__item--multiselect">
-          <input type="checkbox" value="2" autocomplete="off">
-          Port of Boston
-        </label>
-        <label class="cbp-dropdown__item cbp-dropdown__item--multiselect">
-          <input type="checkbox" value="65" autocomplete="off">
-          Port of San Ysidro
-        </label>
-        <label class="cbp-dropdown__item cbp-dropdown__item--multiselect">
-          <input type="checkbox" value="87" autocomplete="off">
-          Port of San Diego
-        </label>
-        <label class="cbp-dropdown__item cbp-dropdown__item--multiselect">
-          <input type="checkbox" value="998" autocomplete="off">
-          Port of Rhode Island
-        </label>
-        <label class="cbp-dropdown__item cbp-dropdown__item--multiselect">
-          <input type="checkbox" value="423" autocomplete="off">
-          Port of Galveston
-        </label>
+    <div class="cbp-input-pattern">
+      <label for="pod2" class="cbp-input__label">Port(s) of Departure</label>
+      <div class="cbp-input__description">
+        Required.
+      </div>
+      <div class="cbp-form__description cbp-form__description--error" hidden>
+        <i class="fas fa-exclamation-triangle"></i> This field is required.
+      </div>
+      
+      <div class="cbp-dropdown__wrapper" id="dropdown-demo-3">
+        <button class="cbp-dropdown__custom" id="ports-dropdown" data-toggle="dropdown">
+          <span class="cbp-dropdown__placeholder">Choose Ports</span>
+        </button>
+
+        <div class="cbp-dropdown" id="custom-dropdown-menu">
+          <label class="cbp-dropdown__item cbp-dropdown__item--multiselect">
+            <input type="checkbox" name="demo" value="22">
+            Port of Baltimore
+          </label>
+          <label class="cbp-dropdown__item cbp-dropdown__item--multiselect">
+            <input type="checkbox" name="demo" value="82">
+            Port of Newark
+          </label>
+          <label class="cbp-dropdown__item cbp-dropdown__item--multiselect">
+            <input type="checkbox" name="demo" value="11">
+            Port of Washington
+          </label>
+          <label class="cbp-dropdown__item cbp-dropdown__item--multiselect">
+            <input type="checkbox" name="demo" value="667">
+            Port of Zoolily
+          </label>
+          <label class="cbp-dropdown__item cbp-dropdown__item--multiselect">
+            <input type="checkbox" name="demo" value="2">
+            Port of Boston
+          </label>
+          <label class="cbp-dropdown__item cbp-dropdown__item--multiselect">
+            <input type="checkbox" name="demo" value="65" autocomplete="off">
+            Port of San Ysidro
+          </label>
+          <label class="cbp-dropdown__item cbp-dropdown__item--multiselect">
+            <input type="checkbox" name="demo"name="demo" value="87">
+            Port of San Diego
+          </label>
+          <label class="cbp-dropdown__item cbp-dropdown__item--multiselect">
+            <input type="checkbox" name="demo" value="998">
+            Port of Rhode Island
+          </label>
+          <label class="cbp-dropdown__item cbp-dropdown__item--multiselect">
+            <input type="checkbox" name="demo" value="423">
+            Port of Galveston
+          </label>
+        </div>
       </div>
     </div>
   `;

--- a/packages/vanilla/src/components/file-input/fileInput.stories.js
+++ b/packages/vanilla/src/components/file-input/fileInput.stories.js
@@ -53,12 +53,12 @@ export default {
 
 const FileInputTemplate = ({label, description, inputName, inputId, accept, multiple, disabled, required}) => {
   return `
-    <div class="cbp-file-input ${disabled ? 'disabled' : ''}">
+    <div class="cbp-input-pattern cbp-file-input ${disabled ? 'disabled' : ''}">
       <label for="${inputId}" class="cbp-input__label">
         ${label}
       </label>
       <div class="cbp-input__description cbp-form__label--error" hidden>
-        <i class="fas fa-exclamation-triangle"></i>&nbsp;Upload Files
+        <i class="fas fa-exclamation-triangle"></i> Upload Files
       </div>
       <div class="cbp-input__description">
         ${required ? 'Required.' : ''} ${description}

--- a/packages/vanilla/src/components/radio/radioButton.stories.js
+++ b/packages/vanilla/src/components/radio/radioButton.stories.js
@@ -44,8 +44,8 @@ export default {
     (Story, context) => `
       <fieldset class="cbp-fieldset ${context.args.displayInline ? 'cbp-fieldset--inline' : ''}" ${context.args.disabled ? 'disabled' : ''}>
         <legend class="cbp-legend">${context.args.legend}</legend>
-        <p class="cbp-input__description">${context.args.inputDescription}</p>
-        <p class="cbp-input__description cbp-input__description--error" hidden><i class="fas fa-exclamation-triangle"></i>${context.args.errorMessage}</p>
+        <div class="cbp-input__description">${context.args.inputDescription}</div>
+        <div class="cbp-input__description cbp-input__description--error" hidden><i class="fas fa-exclamation-triangle"></i>${context.args.errorMessage}</div>
         ${Story().outerHTML || Story()}
       </fieldset>
     `

--- a/packages/vanilla/src/components/text-input/inputs.md
+++ b/packages/vanilla/src/components/text-input/inputs.md
@@ -8,20 +8,41 @@ The Input component can accept a variety of data, relatively short in length, in
 
 * The input component renders an `input` tag with accompanying descriptive text in a predictable pattern supporting accessibility.
 * The input component accepts user input and supports an error state, but does not handle validation itself.
+* All input patterns shall have a common structure:
+
+```
+<div class="cbp-input-pattern">
+  <label class="cbp-input__label"></label>
+  <div class="cbp-input__description"></div>
+  <input />
+</div>
+```
+
+Input groups follow a similar pattern, reusing as many of the same pieces as possible:
+
+```
+<fieldset class="cbp-fieldset">
+  <legend class="cbp-legend"></legend>
+  <div class="cbp-input__description"></div>
+  {...inputs}
+</fieldset>
+```
+
 
 ## Technical Specifications
 
 ### User Interactions
 
-* The native `input` shows visible styling for hover and focus states.
+* The native `input` shows visible styling for hover and focus states, except when in a disabled state.
 
 ### Responsiveness
 
 * Inputs default to a `width` of 100% of their container, which may be overridden by custom CSS or the `size` attribute.
-* Inputs also have a `max-width` of 100%.
+* Inputs also have a `max-width` of 100% so that they do not overflow their container or small viewports.
 
 ### Accessibility
 
+* A `label` associated to the input should always be provided, even if hidden. A visible label should be the standard, however.
 * `aria-required` 
 * `aria-readonly`
 * `aria-invalid`

--- a/packages/vanilla/src/components/text-input/obfuscatedField.js
+++ b/packages/vanilla/src/components/text-input/obfuscatedField.js
@@ -1,7 +1,7 @@
 class ObfuscatedField {
   constructor(component) {
     this.input = component;
-    this.btn = component.nextElementSibling;
+    this.btn = component.nextElementSibling.querySelector('button');
 
     if (this.btn) {
       this.btn.setAttribute('aria-pressed', false);

--- a/packages/vanilla/src/components/text-input/textInput.stories.js
+++ b/packages/vanilla/src/components/text-input/textInput.stories.js
@@ -1,10 +1,5 @@
 export default {
   title: 'Patterns/Text Inputs',
-  parameters: {
-    html: {
-      root: '.cbp-form'
-    }
-  },
   argTypes: {
     label: {
       name: 'Label Element',
@@ -49,30 +44,34 @@ export default {
   },
   decorators: [
     (Story, context) => `
-      <form class="cbp-form">
+      <div class="cbp-input-pattern">
         <label for=${context.args.labelFor} class="cbp-input__label">${context.args.label}</label>
-        <p class="cbp-input__description" ${!context.args.required ? '' : 'hidden'}>${context.args.inputDescription}</p>
-        <p class="cbp-input__description ${context.args.required ? 'cbp-input__description--error': ''}" ${context.args.required ? '' : 'hidden'}><i class="fas fa-exclamation-triangle"></i>${context.args.errorMessage}</p>
+        <div class="cbp-input__description" ${!context.args.required ? '' : 'hidden'}>
+          ${context.args.inputDescription}
+        </div>
+        <div class="cbp-input__description ${context.args.required ? 'cbp-input__description--error': ''}" ${context.args.required ? '' : 'hidden'}>
+          <i class="fas fa-exclamation-triangle"></i> ${context.args.errorMessage}
+        </div>
         ${Story().outerHTML || Story()}
-      </form>
+      </div>
     `
   ]
 };
 
 const tagsExample = () => `
   <div class="cbp-display-flex cbp-padding-top-2x">
-  <button type="button" class="cbp-chip cbp-margin-right-2x" aria-pressed="false">
-    <span class="cbp-chip__label">Pepperoni</span>
-    <div class="cbp-chip__icon">
-      <i class="fas fa-plus"></i>
-    </div>
-  </button>
-  <button type="button" class="cbp-chip" aria-pressed="false">
-    <span class="cbp-chip__label">Mushroom</span>
-    <div class="cbp-chip__icon">
-      <i class="fas fa-plus"></i>
-    </div>
-  </button>
+    <button type="button" class="cbp-chip cbp-margin-right-2x" aria-pressed="false">
+      <span class="cbp-chip__label">Pepperoni</span>
+      <div class="cbp-chip__icon">
+        <i class="fas fa-plus"></i>
+      </div>
+    </button>
+    <button type="button" class="cbp-chip" aria-pressed="false">
+      <span class="cbp-chip__label">Mushroom</span>
+      <div class="cbp-chip__icon">
+        <i class="fas fa-plus"></i>
+      </div>
+    </button>
   </div>
 `
 
@@ -86,7 +85,6 @@ const TextfieldTemplate = ({ labelFor, inputType, inputName, disabled, required,
       ${disabled ? 'disabled' : ''}
       ${required ? 'required' : ''}
       ${readonly ? 'readonly' : ''}
-      placeholder="Enter first name."
     /> 
   `
 ) 
@@ -94,9 +92,11 @@ const TextfieldTemplate = ({ labelFor, inputType, inputName, disabled, required,
 // '\' Removes line break shown in Storybook HTML preview
 const PasswordFieldTemplate = ({ inputName, labelFor, disabled, required, readonly }) => (
   `\
-    <div class="cbp-input-group">
-      <input class="cbp-input" type="password" name=${inputName} id=${labelFor} ${disabled ? 'disabled' : ''} ${required ? 'required' : ''} ${readonly ? 'readonly' : ''} placeholder="Enter password" />
-      <button class="cbp-btn-square cbp-btn__secondary" type="button" ${disabled || readonly ? 'disabled' : ''} aria-controls=${labelFor}><i class="fas fa-eye-slash"></i></button>
+    <div class="cbp-input__wrapper">
+      <input class="cbp-input" type="password" name=${inputName} id=${labelFor} ${disabled ? 'disabled' : ''} ${required ? 'required' : ''} ${readonly ? 'readonly' : ''} />
+      <span class="cbp-input__overlay-right">
+        <button class="cbp-btn-square cbp-btn__secondary" type="button" ${disabled || readonly ? 'disabled' : ''} aria-controls=${labelFor}><i class="fas fa-eye-slash"></i></button>
+      </span>
     </div>  
   `
 )
@@ -104,7 +104,7 @@ const PasswordFieldTemplate = ({ inputName, labelFor, disabled, required, readon
 const NumericCounterFieldTemplate = ({ labelFor, inputName, disabled, required, readonly }) => (
   `\
     <div class="cbp-input__numeric-counter" id="number-counter">
-      <input class="cbp-input" type="number" name=${inputName} id=${labelFor}  ${disabled ? 'disabled' : ''} ${required ? 'required' : ''} ${readonly ? 'readonly' : ''} placeholder="Enter Number of Fish"></input>
+      <input class="cbp-input" type="number" name=${inputName} id=${labelFor}  ${disabled ? 'disabled' : ''} ${required ? 'required' : ''} ${readonly ? 'readonly' : ''} />
       <button class="cbp-btn-square cbp-btn__secondary" type="button" id="decrement"  ${disabled || readonly ? 'disabled' : ''} aria-label="decrement" aria-controls=${labelFor}>
         <i class="fas fa-minus"></i>
       </button>
@@ -118,12 +118,13 @@ const NumericCounterFieldTemplate = ({ labelFor, inputName, disabled, required, 
 const NumericSwitchTemplate = ({ labelFor, inputName, disabled, required, readonly }) => (
   `\
     <div class="cbp-input__numeric-switch">
-      <div>
-        <input class="cbp-input" type="number" name=${inputName} id=${labelFor} ${disabled ? 'disabled' : ''} ${required ? 'required' : ''} ${readonly ? 'readonly' : ''} placeholder="Enter Weight"></input>
+      <div class="cbp-input__wrapper">
+        <input class="cbp-input" type="number" name=${inputName} id=${labelFor} ${disabled ? 'disabled' : ''} ${required ? 'required' : ''} ${readonly ? 'readonly' : ''} />
+        <span class="cbp-input__overlay-right cbp-margin-right-4x" style="line-height:var(--cbp-space-9x)">lbs</span>
       </div>
       <div class="cbp-btn--segment" data-segmented-button-type="single">
-        <button type="button" value="lbs" ${disabled || readonly ? 'disabled' : ''} aria-controls=${labelFor}>LBS</button>
-        <button type="button" value="kg" ${disabled || readonly ? 'disabled' : ''} aria-controls=${labelFor}>KG</button>
+        <button class="cbp-btn" type="button" value="lbs" ${disabled || readonly ? 'disabled' : ''} aria-controls=${labelFor}>LBS</button>
+        <button class="cbp-btn" type="button" value="kg" ${disabled || readonly ? 'disabled' : ''} aria-controls=${labelFor}>KG</button>
       </div>
     </div>
   `
@@ -131,9 +132,11 @@ const NumericSwitchTemplate = ({ labelFor, inputName, disabled, required, readon
 
 const TextfieldButtonGroupTemplate = ({ square, labelFor, inputType, tags, inputName, disabled, buttonLabel, required, readonly }) => (
   `\
-    <div class="cbp-input-group">
-      <input class="cbp-input" type=${inputType} name=${inputName} id=${labelFor} ${disabled ? 'disabled' : ''} ${required ? 'required' : ''} ${readonly ? 'readonly' : ''} placeholder="Add Person" />
-      <button class="${square ? 'cbp-btn-square' : 'cbp-btn'} ${required ? 'cbp-btn__danger' : 'cbp-btn__secondary'}" type="button" ${disabled || readonly ? 'disabled' : ''} aria-controls=${labelFor}>${square ? '<i class="fas fa-plus"></i>' : buttonLabel}</button>
+    <div class="cbp-input__wrapper">
+      <input class="cbp-input" type=${inputType} name=${inputName} id=${labelFor} ${disabled ? 'disabled' : ''} ${required ? 'required' : ''} ${readonly ? 'readonly' : ''} />
+      <span class="cbp-input__overlay-right">
+        <button class="${square ? 'cbp-btn-square' : 'cbp-btn'} ${required ? 'cbp-btn__danger' : 'cbp-btn__secondary'}" type="button" ${disabled || readonly ? 'disabled' : ''} aria-controls=${labelFor}>${square ? '<i class="fas fa-plus"></i>' : buttonLabel}</button>
+      </span>
     </div>
     ${tags ? tagsExample() : ''}
   `
@@ -143,7 +146,7 @@ const TextfieldButtonGroupTemplate = ({ square, labelFor, inputType, tags, input
 const SearchFieldTemplate = ({ labelFor, inputName, disabled, required, readonly }) => (
   `\
     <div class="cbp-input-group">
-      <input class="cbp-input" type="search" name=${inputName} id=${labelFor} ${disabled ? 'disabled' : ''} ${required ? 'required' : ''} ${readonly ? 'readonly' : ''} placeholder="Enter Search Criteria"></input>
+      <input class="cbp-input" type="search" name=${inputName} id=${labelFor} ${disabled ? 'disabled' : ''} ${required ? 'required' : ''} ${readonly ? 'readonly' : ''} />
       <button type="button" class="cbp-btn-square ${required ? 'cbp-btn__danger' : 'cbp-btn__secondary'}" ${disabled || readonly ? 'disabled' : ''} aria-label="search"  aria-controls=${labelFor}>
         <i class="fas fa-search"></i>
       </button>

--- a/packages/vanilla/src/components/text-input/textInput.stories.js
+++ b/packages/vanilla/src/components/text-input/textInput.stories.js
@@ -145,11 +145,13 @@ const TextfieldButtonGroupTemplate = ({ square, labelFor, inputType, tags, input
 // TODO: Predictive search functionality
 const SearchFieldTemplate = ({ labelFor, inputName, disabled, required, readonly }) => (
   `\
-    <div class="cbp-input-group">
+    <div class="cbp-input__wrapper">
       <input class="cbp-input" type="search" name=${inputName} id=${labelFor} ${disabled ? 'disabled' : ''} ${required ? 'required' : ''} ${readonly ? 'readonly' : ''} />
-      <button type="button" class="cbp-btn-square ${required ? 'cbp-btn__danger' : 'cbp-btn__secondary'}" ${disabled || readonly ? 'disabled' : ''} aria-label="search"  aria-controls=${labelFor}>
-        <i class="fas fa-search"></i>
-      </button>
+      <span class="cbp-input__overlay-right">
+        <button type="button" class="cbp-btn-square ${required ? 'cbp-btn__danger' : 'cbp-btn__secondary'}" ${disabled || readonly ? 'disabled' : ''} aria-label="search"  aria-controls=${labelFor}>
+          <i class="fas fa-search"></i>
+        </button>
+      </span>
     </div>
   `
 )

--- a/packages/vanilla/src/components/textarea/textarea.stories.js
+++ b/packages/vanilla/src/components/textarea/textarea.stories.js
@@ -1,10 +1,5 @@
 export default {
   title: 'Patterns',
-  parameters: {
-    html: {
-      root: '.cbp-form'
-    }
-  },
   argTypes: {
     label: {
       name: 'Input Label',
@@ -39,23 +34,23 @@ export default {
   },
   decorators: [
     (Story, context) => `
-      <form class="cbp-form">
+      <div class="cbp-input-pattern">
         <label for=${context.args.labelFor} class="cbp-input__label">${context.args.label}</label>
         <p class="cbp-input__description">${context.args.inputDescription}</p>
         <p class="cbp-input__description cbp-input__description--error" hidden="true"><i class="fas fa-exclamation-triangle"></i>${context.args.errorMessage}</p>
         ${Story().outerHTML || Story()}
-      </form>
+      </div>
     `
   ]
 };
 
-const TextAreaTemplate = ({ labelFor, inputName, disabled }) => `<textarea class="cbp-input" name=${inputName} id=${labelFor} ${disabled ? 'disabled' : ''} placeholder="Enter a description"></textarea>`
+const TextAreaTemplate = ({ labelFor, inputName, disabled }) => `<textarea class="cbp-input" name=${inputName} id=${labelFor} ${disabled ? 'disabled' : ''}></textarea>`
 
 export const TextArea = TextAreaTemplate.bind({});
 TextArea.args = {
   label: 'Task Description',
   labelFor: 'description',
-  inputDescription: 'Required. 500/500 Characters remaining.',
+  inputDescription: 'Required.',
   inputName: 'description',
   errorMessage: 'You must enter a description.'
 }

--- a/packages/vanilla/src/components/textarea/textarea.stories.js
+++ b/packages/vanilla/src/components/textarea/textarea.stories.js
@@ -36,8 +36,8 @@ export default {
     (Story, context) => `
       <div class="cbp-input-pattern">
         <label for=${context.args.labelFor} class="cbp-input__label">${context.args.label}</label>
-        <p class="cbp-input__description">${context.args.inputDescription}</p>
-        <p class="cbp-input__description cbp-input__description--error" hidden="true"><i class="fas fa-exclamation-triangle"></i>${context.args.errorMessage}</p>
+        <div class="cbp-input__description">${context.args.inputDescription}</div>
+        <div class="cbp-input__description cbp-input__description--error" hidden="true"><i class="fas fa-exclamation-triangle"></i>${context.args.errorMessage}</div>
         ${Story().outerHTML || Story()}
       </div>
     `

--- a/packages/vanilla/src/sass/components/_dropdown.scss
+++ b/packages/vanilla/src/sass/components/_dropdown.scss
@@ -7,16 +7,16 @@
   align-items: center;
   background-color: var(--cbp-color-white);
   border: var(--cbp-border-size-md) solid var(--cbp-color-interactive-secondary-base);
-  border-radius: 3px;
+  border-radius: var(--cbp-border-radius-soft);
   border-right: 0;
   cursor: inherit;
   display: flex;
   font-family: inherit;
   font-size: inherit;
-  height: 36px;
+  height: var(--cbp-space-9x);
   line-height: inherit;
-    padding-left: 8px;
-  padding-right: 8px;
+  padding-left: var(--cbp-space-2x);
+  padding-right: var(--cbp-space-2x);
   position: relative;
   width: 100%;
 
@@ -67,7 +67,7 @@
   color: var(--cbp-color-white);
   display: flex;
   font-family: "Font Awesome 5 Free";
-  font-size: 20px;
+  font-size: var(--cbp-space-5x);
   font-weight: var(--cbp-font-weight-black);
   justify-content: center;
   text-align: center;
@@ -85,8 +85,8 @@
 }
 
 .cbp-dropdown__custom .cbp-chips {
-  font-size: 12px;
-  height: 20px;
+  font-size: var(--cbp-font-size-subhead);
+  height: var(--cbp-space-5x);
 }
 
 
@@ -97,7 +97,7 @@
   border: var(--cbp-border-size-md) solid var(--cbp-color-interactive-secondary-base);
   border-radius: 0 0 var(--cbp-border-radius-soft) var(--cbp-border-radius-soft);
   display: none;
-  max-height: 216px;
+  max-height: 216px; // TechDebt: What's the reasoning for this magic number?
   overflow-y: scroll;
   position: absolute;
   width: calc(100% - 2px);
@@ -114,8 +114,8 @@
     color: var(--cbp-color-text-darkest);
     display: flex;
     font-size: 1rem;
-    height: 36px;
-    padding-left: 16px;
+    height: var(--cbp-space-9x);
+    padding-left: var(--cbp-space-4x);
     position: relative;
     text-decoration: none;
 
@@ -147,7 +147,7 @@
       border-bottom: 1px solid var(--cbp-color-interactive-secondary-lighter);
       display: block;
       height: 1px;
-      left: 12px;
+      left: var(--cbp-space-3x);
       bottom: 0;
       position: absolute;
       width: calc(100% - 24px);
@@ -197,7 +197,7 @@
     }
 
     &:focus {
-      border: 2px solid var(--cbp-color-interactive-secondary-lighter);
+      border: var(--cbp-border-size-md) solid var(--cbp-color-interactive-secondary-lighter);
       box-shadow: initial;
       clip-path: initial;
       outline: 0 !important; // Overriding style from _focus.scss??
@@ -239,55 +239,51 @@
 .cbp-dropdown__custom--error {
   background-color: var(--cbp-color-danger-lighter);
   // TechDebt: this is why you would break border down into border-style, width, color. Less repetition.
-  border-left: 2px solid var(--cbp-color-danger-base);
+  border: var(--cbp-border-size-md) solid var(--cbp-color-danger-base);
   border-right: 0;
-  border-top: 2px solid var(--cbp-color-danger-base);
-  border-bottom: 2px solid var(--cbp-color-danger-base);
 
   &::after {
-    border: 2px solid var(--cbp-color-danger-base) !important;
+    border: var(--cbp-border-size-md) solid var(--cbp-color-danger-base) !important;
     background-color: var(--cbp-color-danger-base) !important;
   }
 
   &:hover {
     // TechDebt - same
-    border-left: 2px solid var(--cbp-color-danger-dark);
+    border: var(--cbp-border-size-md) solid var(--cbp-color-danger-dark);
     border-right: 0;
-    border-top: 2px solid var(--cbp-color-danger-dark);
-    border-bottom: 2px solid var(--cbp-color-danger-dark);
 
     &::after {
-      border: 2px solid var(--cbp-color-danger-dark) !important;
+      border: var(--cbp-border-size-md) solid var(--cbp-color-danger-dark) !important;
       background-color: var(--cbp-color-danger-dark) !important;
     }
   }
 
   &:focus:not([disabled]) {
-    border: 2px solid var(--cbp-color-interactive-focus-dark);
+    border: var(--cbp-border-size-md) solid var(--cbp-color-interactive-focus-dark);
     outline: 0;
 
     &::after {
-      border: 2px solid var(--cbp-color-interactive-focus-dark) !important;
+      border: var(--cbp-border-size-md) solid var(--cbp-color-interactive-focus-dark) !important;
       background-color: var(--cbp-color-interactive-focus-dark) !important;
     }
   }
 
   & + .cbp-dropdown {
     background-color: var(--cbp-color-danger-lighter);
-    border: 2px solid var(--cbp-color-danger-base);
+    border: var(--cbp-border-size-md) solid var(--cbp-color-danger-base);
     border-top: 0;
-    border-bottom-left-radius: 3px;
-    border-bottom-right-radius: 3px;
+    border-bottom-left-radius: var(--cbp-border-radius-soft);
+    border-bottom-right-radius: var(--cbp-border-radius-soft);
 
     &:hover {
       border-top: 0;
     }
 
     &:focus {
-      border: 2px solid var(--cbp-color-interactive-focus-dark);
+      border: var(--cbp-border-size-md) solid var(--cbp-color-interactive-focus-dark);
       border-top: 0;
-      border-bottom-left-radius: 3px;
-      border-bottom-right-radius: 3px;
+      //border-bottom-left-radius: var(--cbp-border-radius-soft);
+      //border-bottom-right-radius: var(--cbp-border-radius-soft);
       outline: 0;
     }
   }
@@ -295,7 +291,7 @@
   /* Caret Button */
   &::after {
     background-color: var(--cbp-color-danger-base);
-    border: 2px solid var(--cbp-color-danger-base);
+    border: var(--cbp-border-size-md) solid var(--cbp-color-danger-base);
   }
 }
 

--- a/packages/vanilla/src/sass/components/_dropdown.scss
+++ b/packages/vanilla/src/sass/components/_dropdown.scss
@@ -5,8 +5,8 @@
 /* Dropdown Button */
 .cbp-dropdown__custom {
   align-items: center;
-  background-color: transparent;
-  border: 1px solid var(--cbp-color-interactive-secondary-base);
+  background-color: var(--cbp-color-white);
+  border: var(--cbp-border-size-md) solid var(--cbp-color-interactive-secondary-base);
   border-radius: 3px;
   border-right: 0;
   cursor: inherit;
@@ -15,24 +15,30 @@
   font-size: inherit;
   height: 36px;
   line-height: inherit;
-  outline: 0;
-  padding-left: 8px;
+    padding-left: 8px;
   padding-right: 8px;
   position: relative;
   width: 100%;
 
   &:hover {
-    border: 2px solid var(--cbp-color-interactive-secondary-darker);
-    border-right: 0;
+    border-color: var(--cbp-color-interactive-secondary-darker);
   }
   
   &:hover::after {
     background-color: var(--cbp-color-interactive-secondary-darker);
-    // border: 2px solid $cbp-ui-neutral-darker;
+  }
+
+  &:focus:not([disabled]) {
+    outline: var(--cbp-border-size-md) solid var(--cbp-color-interactive-focus-dark);
+    border-color: var(--cbp-color-interactive-focus-dark);
+  }
+
+  &:focus:not([disabled])::after {
+    background-color: var(--cbp-color-interactive-focus-dark);
   }
 
   &:disabled {
-    border: 1px solid var(--cbp-color-interactive-disabled-dark);
+    border-color: var(--cbp-color-interactive-disabled-dark);
     background-color: var(--cbp-color-interactive-disabled-light);
     color: var(--cbp-color-interactive-disabled-dark);
     font-style: italic;
@@ -41,16 +47,6 @@
       background-color: var(--cbp-color-interactive-disabled-dark);
       border-color: var(--cbp-color-interactive-disabled-dark);
       font-style: initial;
-    }
-
-    &:hover {
-      border: 2px solid var(--cbp-color-interactive-secondary-darker);
-      border-right: 0;
-    }
-
-    &:disabled:hover::after {
-      background-color: var(--cbp-color-interactive-secondary-darker);
-      // border: 2px solid $cbp-ui-neutral-darker;
     }
   }
 
@@ -65,21 +61,20 @@
 .cbp-dropdown__custom::after {
   align-items: center;
   background-color: var(--cbp-color-interactive-secondary-base);
-  // border: 2px solid $cbp-ui-neutral-base;
-  border-top-right-radius: 3px;
-  border-bottom-right-radius: 3px;
+  border-top-right-radius: var(--cbp-border-radius-soft);
+  border-bottom-right-radius: var(--cbp-border-radius-soft);
   content: "\f107";
   color: var(--cbp-color-white);
   display: flex;
   font-family: "Font Awesome 5 Free";
   font-size: 20px;
-  font-weight: 900;
+  font-weight: var(--cbp-font-weight-black);
   justify-content: center;
   text-align: center;
-  height: 36px;
+  height: var(--cbp-space-9x);
   position: absolute;
   right: 0;
-  width: 36px;
+  width: var(--cbp-space-9x);
   z-index: 1;
 }
 
@@ -94,20 +89,19 @@
   height: 20px;
 }
 
+
+
 /* Dropdown Menu */
 .cbp-dropdown {
   background-color: var(--cbp-color-white);
-  border: 1px solid var(--cbp-color-interactive-secondary-base);
-  border-top-left-radius: 0px;
-  border-top-right-radius: 0px;
-  border-bottom-left-radius: 3px;
-  border-bottom-right-radius: 3px;
+  border: var(--cbp-border-size-md) solid var(--cbp-color-interactive-secondary-base);
+  border-radius: 0 0 var(--cbp-border-radius-soft) var(--cbp-border-radius-soft);
   display: none;
   max-height: 216px;
   overflow-y: scroll;
   position: absolute;
   width: calc(100% - 2px);
-  z-index: 9999;
+  z-index: var(--cbp-z-index-level-4);
 
   &:hover {
     border-top: 0;
@@ -129,7 +123,6 @@
       background-color: var(--cbp-color-interactive-secondary-darker);
       color: var(--cbp-color-text-lightest);
       cursor: pointer;
-      font-weight: 700;
 
       &::after {
         border-bottom: 1px solid var(--cbp-color-interactive-secondary-darker);
@@ -139,7 +132,6 @@
     &:focus:not([disabled]) {
       background-color: var(--cbp-color-interactive-focus-dark);
       color: var(--cbp-color-white);
-      font-weight: 700;
       outline: 0;
 
       &::after {
@@ -337,14 +329,14 @@
 
 /* Focus State */
 .cbp-dropdown__custom:focus:not([disabled]) {
-  border: 2px solid var(--cbp-color-interactive-focus-dark);
-  border-right: 0;
-  outline: 0;
+  //border: 2px solid var(--cbp-color-interactive-focus-dark);
+  //border-right: 0;
+  //outline: 0;
 }
 
 /* Focus Caret State */
 .cbp-dropdown__custom:focus-within::after {
-  background-color: var(--cbp-color-interactive-focus-dark);
+  //background-color: var(--cbp-color-interactive-focus-dark);
   // border: 2px solid $cbp-focus-dark;
 }
 

--- a/packages/vanilla/src/sass/components/_dropdown.scss
+++ b/packages/vanilla/src/sass/components/_dropdown.scss
@@ -215,7 +215,7 @@
     border-bottom: 1px solid var(--cbp-color-interactive-secondary-lighter);
     display: block;
     height: 1px;
-    left: 12px;
+    left: var(--cbp-space-3x);
     bottom: 0;
     position: absolute;
     width: calc(100% - 24px);

--- a/packages/vanilla/src/sass/components/checkbox/_index.scss
+++ b/packages/vanilla/src/sass/components/checkbox/_index.scss
@@ -2,6 +2,7 @@
   border: 0;
   padding: 0;
   margin: 0;
+  margin-bottom: var(--cbp-space-4x);
 
   &:disabled label {
     font-style: italic;

--- a/packages/vanilla/src/sass/components/text-input/_index.scss
+++ b/packages/vanilla/src/sass/components/text-input/_index.scss
@@ -125,37 +125,24 @@ textarea.cbp-input {
   .cbp-input__overlay-left {
     position: absolute;
     left: 0;
+
+    button {
+      border-top-right-radius: 0;
+      border-bottom-right-radius: 0;
+    }
   }
 
   .cbp-input__overlay-right {
     position: absolute;
     right: 0;
-  }
 
-}
-
-// Inputs with <button> attached to the end
-.cbp-input-group {
-  display: flex;
-
-  & > .cbp-input {
-    border-right: 0;
-    border-top-right-radius: 0;
-    border-bottom-right-radius: 0;
-    flex: 1 1 auto;
-
-    & + button {
-      border-bottom-left-radius: 0;
+    button {
       border-top-left-radius: 0;
-      white-space: nowrap;
+      border-bottom-left-radius: 0;
     }
 
-    & + button:disabled {
-      border-color: var(--cbp-color-interactive-disabled-dark);
-      background-color: var(--cbp-color-interactive-disabled-dark);
-      color: var(--cbp-color-interactive-disabled-light);
-    }
   }
+
 }
 
 .cbp-input__numeric-counter {

--- a/packages/vanilla/src/sass/components/text-input/_index.scss
+++ b/packages/vanilla/src/sass/components/text-input/_index.scss
@@ -1,3 +1,10 @@
+.cbp-input-pattern {
+  break-inside: avoid; // don't split up an input pattern if used in multi-col layout
+  max-width: 100%;
+  margin-bottom: var(--cbp-space-4x);
+}
+
+
 // Can be used on both <label> and <legend> elements
 .cbp-input__label,
 .cbp-legend {
@@ -6,7 +13,7 @@
   font-size: var(--cbp-font-size-body);
   font-style: italic;
   font-weight: var(--cbp-font-weight-bold);
-  margin-bottom: var(--cbp-space-2x);
+  line-height: var(--cbp-line-height-xs);
 }
 
 .cbp-input__description {
@@ -14,7 +21,7 @@
   font-size: var(--cbp-font-size-subhead);
   font-style: italic;
   font-weight: var(--cbp-font-weight-medium);
-  margin-bottom: var(--cbp-space-2x);
+  line-height: var(--cbp-line-height-xs);
 
   &--error {
     color: var(--cbp-color-danger-base);
@@ -34,7 +41,7 @@
   min-height: 2.25rem;
   padding: var(--cbp-space-2x);
   
-  &:not([size]) {
+  &:not(textarea):not([size]) {
     width: 100%;
   }
 
@@ -48,7 +55,7 @@
 
   &:focus {
     border-color: var(--cbp-color-interactive-focus-dark);
-    outline: 0;
+    outline: var(--cbp-border-size-md) solid var(--cbp-color-interactive-focus-dark);
   }
 
   &:read-only {
@@ -67,13 +74,14 @@
     border-color: var(--cbp-color-interactive-disabled-dark);
 
     &:hover {
-      border-color: var(--cbp-color-interactive-secondary-darker);
+      border-color: var(--cbp-color-interactive-disabled-dark);
     }
 
     &:focus {
-      border-color: var(--cbp-color-interactive-focus-dark);
+      border-color: var(--cbp-color-interactive-disabled-dark);
     }
   }
+
 
   &:invalid {
     background-color: var(--cbp-color-danger-lighter);
@@ -110,6 +118,22 @@ textarea.cbp-input {
   }
 }
 
+.cbp-input__wrapper {
+  position: relative;
+  max-width: 100%;
+
+  .cbp-input__overlay-left {
+    position: absolute;
+    left: 0;
+  }
+
+  .cbp-input__overlay-right {
+    position: absolute;
+    right: 0;
+  }
+
+}
+
 // Inputs with <button> attached to the end
 .cbp-input-group {
   display: flex;
@@ -141,12 +165,25 @@ textarea.cbp-input {
   & > .cbp-input {
     -moz-appearance: textfield; // Removes the default increment arrows in Firefox 
   }
+
+  & > button {
+    flex-shrink: 0;
+  }
 }
 
 .cbp-input__numeric-switch {
   display: flex;
   gap: var(--cbp-space-4x);
+
+  &:has(input:not([size])) {
+    width: 100%;
+
+    .cbp-input__wrapper {
+      width: 100%;
+    }
+  }
   
+  /*
   & > div:first-child {
     align-items: center;
     border-color: var(--cbp-color-interactive-secondary-dark);
@@ -214,7 +251,7 @@ textarea.cbp-input {
   & > div:first-child:has(.cbp-input:invalid)::after {
     background-color: var(--cbp-color-danger-lighter);
   }
-
+  */
 }
 
 // TODO: Refactor when <select> and Dropdown patterns are refactored.


### PR DESCRIPTION
Updates across all input patterns (including text input, textarea, checklist, radio list, file input, dropdowns) in attempts to make them consistent, fix and update designs, update stories, and fix some accessibility issues:

* Removed placeholder text from stories.
* Updated focus states to use the outline.
* Removed/updated some focus states on disabled fields. (this could probably use another pass to make consistent).
* Normalized a method of creating left and right-aligned overlays on inputs and updated stories with this implementation matching updated designs that show buttons "inside" of the input field on password and text fields with button patterns.
* Normalized tags and classes to make sure the pattern label and description have no margins and a 20px line-height for proper spacing.
* Applied a bottom margin of 4x to all patterns for default form-building stacked context.
* Applied a wrapper tag (`div.cbp-input-pattern`) to those patterns not using a `fieldset` to prevent breakage in multi-col and apply consistent bottom margin.
* Fixed numerous issues with dropdowns: 
  * No background color
  * Wrong border size
  * Removed bold font on hover/focus causing jumpiness
