### PR TITLE
Fixed loader errors on new install

### DIFF
--- a/packages/web-components/.storybook/preview.js
+++ b/packages/web-components/.storybook/preview.js
@@ -1,6 +1,6 @@
 /** @type { import('@storybook/html').Preview } */
 import { withThemeByDataAttribute } from '@storybook/addon-styling';
-import {defineCustomElements} from '../loader';
+import {defineCustomElements} from '../dist/loader';
 
 defineCustomElements();
 

--- a/packages/web-components/package.json
+++ b/packages/web-components/package.json
@@ -15,8 +15,7 @@
     "url": "https://github.com/ionic-team/stencil-component-starter.git"
   },
   "files": [
-    "dist/",
-    "loader/"
+    "dist/"
   ],
   "scripts": {
     "build": "stencil build --docs",
@@ -24,7 +23,7 @@
     "test": "stencil test --spec --e2e",
     "test.watch": "stencil test --spec --e2e --watchAll",
     "generate": "stencil generate",
-    "storybook": "storybook dev -p 6008",
+    "storybook": "stencil build --docs && storybook dev -p 6008",
     "build-storybook": "storybook build"
   },
   "dependencies": {

--- a/packages/web-components/stencil.config.ts
+++ b/packages/web-components/stencil.config.ts
@@ -2,7 +2,7 @@ import { Config } from '@stencil/core';
 import { sass } from '@stencil/sass';
 
 export const config: Config = {
-  namespace: 'web-components',
+  namespace: 'cbp-web-components',
   outputTargets: [
     {
       type: 'dist',


### PR DESCRIPTION
* Fixed loader error on new install
* Concatenated stencil build command into storybook command. Just run `npm run storybook` in the package or `npm run stencil-sb` from the root.
