### PR TITLE
Feature/story decorators

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -22755,6 +22755,7 @@
         "@storybook/testing-library": "^0.2.2",
         "@types/jest": "^27.5.2",
         "@types/node": "^16.18.11",
+        "@whitespace/storybook-addon-html": "^5.1.6",
         "jest": "^27.5.1",
         "jest-cli": "^27.5.1",
         "puppeteer": "21.1.1",

--- a/packages/web-components/.storybook/preview.js
+++ b/packages/web-components/.storybook/preview.js
@@ -73,16 +73,22 @@ export const parameters = {
     viewports: CUSTOM_VIEWPORTS,
   },
   html: {
+    root: "cbp-app", // default: #root
+    removeComments: true,
+    removeEmptyComments: true,
     prettier: {
+      parser: 'html',
       tabWidth: 2,
       useTabs: false,
-      htmlWhitespaceSensitivity: 'strict',
-      removeEmptyComments: true,
-      removeComments: /^\s*remove me\s*$/,
+      htmlWhitespaceSensitivity: 'css',
+      proseWrap: "always",
+      bracketSameLine: true,
+      singleAttributePerLine: true,
     },
     highlighter: {
       showLineNumbers: true,
       wrapLines: true,
+      language: 'html'
     },
     transform: (code) => {
       // DEG: keeping this as an example because it may solve other issues I've encountered
@@ -92,7 +98,14 @@ export const parameters = {
   },
 };
 
+
+// Wrap every story with `cbp-app` component, which brings in the high level CSS resets, settings, and variables.
+const withWrapper = (story) => {
+  return `<cbp-app>${story()}</cbp-app>`;
+};
+
 export const decorators = [
+  withWrapper,
   withThemeByDataAttribute({
     themes: {
       light: 'light',

--- a/packages/web-components/package.json
+++ b/packages/web-components/package.json
@@ -40,6 +40,7 @@
     "@storybook/html": "^7.5.1",
     "@storybook/html-vite": "^7.5.1",
     "@storybook/testing-library": "^0.2.2",
+    "@whitespace/storybook-addon-html": "^5.1.6",
     "@types/jest": "^27.5.2",
     "@types/node": "^16.18.11",
     "jest": "^27.5.1",

--- a/packages/web-components/src/components/cbp-button/cbp-button.stories.tsx
+++ b/packages/web-components/src/components/cbp-button/cbp-button.stories.tsx
@@ -89,7 +89,6 @@ export default {
 
 const Template = ({ label, tag, type, href, rel, target, download, fill, color, variant, accessibilityText, disabled, sx }) => { 
   return ` 
-      <cbp-app>
       <cbp-button
         ${tag !== 'button' ? `tag=${tag}` : ''}
         type="${type}"
@@ -106,7 +105,6 @@ const Template = ({ label, tag, type, href, rel, target, download, fill, color, 
       >
         ${label}
       </cbp-button>
-      </cbp-app>
     `
 }
 

--- a/packages/web-components/src/components/cbp-card/cbp-card.stories.tsx
+++ b/packages/web-components/src/components/cbp-card/cbp-card.stories.tsx
@@ -46,35 +46,29 @@ const renderActions = (layout, { btn1, btn2, btn3 }) => {
 
 const GeneralTemplate = ({ color, title, bodyText, sx }) => {
   return ` 
-    <cbp-app>
-      <cbp-card ${color ? `color=${color}` : ''} ${sx ? 'sx='+JSON.stringify(sx) : ''}>
-        <h4 slot="cbp-card-title">${title}</h4>
-        <p>${bodyText}</p>
-      </cbp-card>
-    </cbp-app>
+    <cbp-card ${color ? `color=${color}` : ''} ${sx ? 'sx='+JSON.stringify(sx) : ''}>
+      <h4 slot="cbp-card-title">${title}</h4>
+      <p>${bodyText}</p>
+    </cbp-card>
   `;
 };
 
 const DecisionTemplate = ({ title, color, bodyText, actionsLayout, actionsConfig, sx }) => {
   return ` 
-      <cbp-app>
-        <cbp-card variant="decision"  ${color ? `color=${color}` : ''} ${sx ? 'sx='+JSON.stringify(sx) : ''}>
-          <h4 slot="cbp-card-title" id="card-heading-1">${title}</h4>
-          <p>${bodyText}</p>  
-          ${renderActions(actionsLayout, actionsConfig)}
-        </cbp-card>
-      </cbp-app>
+      <cbp-card variant="decision"  ${color ? `color=${color}` : ''} ${sx ? 'sx='+JSON.stringify(sx) : ''}>
+        <h4 slot="cbp-card-title" id="card-heading-1">${title}</h4>
+        <p>${bodyText}</p>  
+        ${renderActions(actionsLayout, actionsConfig)}
+      </cbp-card>
     `;
 };
 
 const BannerTemplate = ({ title, color, bodyText, sx }) => {
   return ` 
-    <cbp-app>
-      <cbp-card variant="banner" ${color ? `color=${color}` : ''} ${sx ? 'sx='+JSON.stringify(sx) : ''}>
-        <h4 slot="cbp-card-title">${title}</h4>
-        <p>${bodyText}</p>  
-      </cbp-card>
-    </cbp-app>
+    <cbp-card variant="banner" ${color ? `color=${color}` : ''} ${sx ? 'sx='+JSON.stringify(sx) : ''}>
+      <h4 slot="cbp-card-title">${title}</h4>
+      <p>${bodyText}</p>  
+    </cbp-card>
   `;
 };
 

--- a/packages/web-components/src/components/cbp-container/cbp-container.stories.tsx
+++ b/packages/web-components/src/components/cbp-container/cbp-container.stories.tsx
@@ -35,17 +35,15 @@ export default {
   
   const Template = ({ content, background, textColor, width, margins, sx }) => { 
     return ` 
-        <cbp-app>
-        <cbp-container
-          ${background ? `background=${background}` : ''}
-          ${textColor ? `text-color=${textColor}` : ''}
-          ${width ? `width=${width}` : ''}
-          ${margins ? `margins=${margins}` : ''}
-          ${sx ? `sx=${JSON.stringify(sx)}` : ''}
-        >
-          ${content}
-        </cbp-container>
-        </cbp-app>
+      <cbp-container
+        ${background ? `background=${background}` : ''}
+        ${textColor ? `text-color=${textColor}` : ''}
+        ${width ? `width=${width}` : ''}
+        ${margins ? `margins=${margins}` : ''}
+        ${sx ? `sx=${JSON.stringify(sx)}` : ''}
+      >
+        ${content}
+      </cbp-container>
       `
   }
   

--- a/packages/web-components/src/components/cbp-universal-header/cbp-universal-header.stories.tsx
+++ b/packages/web-components/src/components/cbp-universal-header/cbp-universal-header.stories.tsx
@@ -3,12 +3,12 @@ export default {
     tags: ['autodocs'],
     parameters: {
       layout: 'fullscreen',
+      root: '#custom-root'
     },
   };
   
   const UniversalHeaderTemplate = ({ username, isLoggedIn }) => {
     return `
-      <cbp-app>
       <cbp-universal-header>
         <ul>
           ${isLoggedIn ? `
@@ -36,7 +36,6 @@ export default {
           `}
         </ul>
       </cbp-universal-header>
-      </cbp-app>
     `;
   };
   


### PR DESCRIPTION
* Implemented the story decorator to wrap each story with the `cbp-app` component and set it as the story root element (so everything inside shows in the story HTML).
* Made sure the html add-on was installed as a dev dependency in the web components package
* Tweaked the HTML output settings for cleaner markup in the HTML tab.
* Removed `cbp-app` from individual stories.