### PR TITLE
Change storybook static output location for testing GH Pages deployment.

### DIFF
--- a/.github/workflows/publish-gh-pages.yml
+++ b/.github/workflows/publish-gh-pages.yml
@@ -37,5 +37,5 @@ jobs:
         with:
           install_command: npm ci # default: npm ci
           build_command: npm run build-wc-package # default: npm run build-storybook
-          path: .public/web-components-sb # default: dist/storybook
-          checkout: false # default: true
+          path: packages/web-components/storybook-static # default: dist/storybook
+          checkout: false # default: true   

--- a/packages/web-components/package.json
+++ b/packages/web-components/package.json
@@ -34,7 +34,7 @@
     "generate": "stencil generate",
     "storybook": "stencil build --docs && storybook dev -p 6006",
     "build-storybook": "storybook build",
-    "build-pages": "storybook build --output-dir ../../.public/web-components-sb"
+    "build-pages": "storybook build --output-dir storybook-static"
   },
   "dependencies": {
     "@stencil/core": "^4.15.0"


### PR DESCRIPTION
Change storybook static output location for testing GH Pages deployment (possible issues with period in directory name of previous location)
