### PR TITLE
Bugfix/panel header

### DIFF
--- a/packages/web-components/src/components/cbp-drawer/cbp-drawer.stories.tsx
+++ b/packages/web-components/src/components/cbp-drawer/cbp-drawer.stories.tsx
@@ -60,7 +60,6 @@ const Template = ({ position, open, uid, accessibilityText, context, sx }) => {
           tag="h3"
           variant="heading-lg"
           id="panelheader"
-          context="dark-always"
         >
           Sidebar Header
         </cbp-typography>
@@ -108,7 +107,6 @@ const UserPreferencesTemplate = ({ position, open, uid, accessibilityText, conte
           tag="h3"
           variant="heading-lg"
           id="panelheader"
-          context="dark-always"
         >
           User Preferences
         </cbp-typography>

--- a/packages/web-components/src/components/cbp-panel/cbp-panel.scss
+++ b/packages/web-components/src/components/cbp-panel/cbp-panel.scss
@@ -23,7 +23,6 @@
  */
 [data-cbp-theme=light] cbp-panel[context*=dark],
 [data-cbp-theme=dark] cbp-panel:not([context=dark-inverts]):not([context=light-always]) {
-  --cbp-panel-header-color: var(--cbp-color-text-lighter);
   --cbp-panel-header-color-bg: var(--cbp-color-branding-dhs-blue);
   --cbp-panel-header-color-bottom-border: var(--cbp-color-gray-cool-50);
   --cbp-panel-content-color: var(--cbp-color-text-lightest);

--- a/packages/web-components/src/components/cbp-panel/cbp-panel.stories.tsx
+++ b/packages/web-components/src/components/cbp-panel/cbp-panel.stories.tsx
@@ -61,7 +61,6 @@ const PanelTemplate = ({ role, headingLevel, header, headerId, content, ariaLabe
         tag=${headingLevel}
         variant="heading-lg"
         ${headerId ? `id="${headerId}"` : ''}
-        context="dark-always"
       >
         ${showIcon ? '<cbp-icon name="star" sx=\'{"margin-right":"var(--cbp-space-4x)"}\'></cbp-icon>' : ''}${header}
       </cbp-typography

--- a/packages/web-components/src/components/cbp-typography/cbp-typography.scss
+++ b/packages/web-components/src/components/cbp-typography/cbp-typography.scss
@@ -1,9 +1,14 @@
 :root {
-  --cbp-typography-color-text: inherit;
+  --cbp-typography-color: inherit;
+  --cbp-typography-color-dark: inherit;
   --cbp-typography-color-small-text: var(--cbp-color-text-darkest);
+  --cbp-typography-color-small-text-dark: var(--cbp-color-text-lightest);
   --cbp-typography-color-large-text: var(--cbp-color-text-darker);
+  --cbp-typography-color-large-text-dark: var(--cbp-color-text-lighter);
   --cbp-typography-color-divider-fill: var(--cbp-color-gray-cool-10);
+  --cbp-typography-color-divider-fill-dark: var(--cbp-color-gray-cool-70);
   --cbp-typography-color-divider-underline: var(--cbp-color-gray-cool-30);
+  --cbp-typography-color-divider-underline-dark: var(--cbp-color-gray-cool-50);
 }
 
 // Displays dark design based on mode or context
@@ -11,10 +16,10 @@
 // 0,3,1
 [data-cbp-theme=light] cbp-typography[context*=dark],
 [data-cbp-theme=dark] cbp-typography:not([context=dark-inverts]):not([context=light-always]) {
-  --cbp-typography-color-small-text: var(--cbp-color-text-lightest);
-  --cbp-typography-color-large-text: var(--cbp-color-text-lighter);
-  --cbp-typography-color-divider-fill: var(--cbp-color-gray-cool-70);
-  --cbp-typography-color-divider-underline: var(--cbp-color-gray-cool-50);
+  --cbp-typography-color-small-text: var(--cbp-typography-color-small-text-dark);
+  --cbp-typography-color-large-text: var(--cbp-typography-color-large-text-dark);
+  --cbp-typography-color-divider-fill: var(--cbp-typography-color-divider-fill-dark);
+  --cbp-typography-color-divider-underline: var(--cbp-typography-color-divider-underline-dark);
 }
 
 /* Inherits body text:
@@ -24,11 +29,10 @@
     h6 is same as body text, all others are lighter/darker
 */
 cbp-typography {
-  color: inherit;
-  color: var(--cbp-typography-color-small-text);
+  color: var(--cbp-typography-color);
   
   & > * {
-    color: var(--cbp-typography-color-small-text);
+    color: var(--cbp-typography-color);
   }
 
   &[variant=masthead-1] > *,
@@ -38,7 +42,7 @@ cbp-typography {
   &[variant=heading-lg] > *, h3,
   &[variant=heading-md] > *, h4,
   &[variant=heading-sm] > *, h5 {
-    color: var(--cbp-typography-color-large-text);
+    --cbp-typography-color: var(--cbp-typography-color-large-text);
   }
 
   


### PR DESCRIPTION
* Update the way typography sets dark mode colors.
* Update panel and drawer stories, removing cbp-typography context prop in the panel header (no longer needed).
* Remove panel heading color dark mode variable that doesn't change.

Verified expected behavior in Panel, Drawer, and Typography stories, in both light and dark modes and toggling the context property on the parent component (this gets pretty confusing with all the combos).