### PR TITLE
Bugfix/input readonly darkmode

### DIFF
--- a/packages/web-components/src/components/cbp-form-input/cbp-form-field.scss
+++ b/packages/web-components/src/components/cbp-form-input/cbp-form-field.scss
@@ -36,19 +36,15 @@
 // Displays dark design based on mode or context
 [data-cbp-theme=light] cbp-form-field[context*=dark],
 [data-cbp-theme=dark] cbp-form-field:not([context=dark-inverts]):not([context=light-always]) {
-
   --cbp-form-field-color-label: var(--cbp-form-field-color-label-dark);
   --cbp-form-field-color-description: var(--cbp-form-field-color-description-dark);
-
-  //input,select,textarea {
-    --cbp-form-field-color: var(--cbp-form-field-color-dark);
-    --cbp-form-field-color-bg: var(--cbp-form-field-color-bg-dark);
-    --cbp-form-field-color-border: var(--cbp-form-field-color-border-dark);
-    --cbp-form-field-color-border-hover: var(--cbp-form-field-color-border-hover-dark);
-    --cbp-form-field-color-border-focus: var(--cbp-form-field-color-border-focus-dark);
-    --cbp-form-field-color-placeholder: var(--cbp-form-field-color-placeholder-dark);
-    --cbp-form-field-select-chevron: var(--cbp-form-field-select-chevron-dark);
-  //}
+  --cbp-form-field-color: var(--cbp-form-field-color-dark);
+  --cbp-form-field-color-bg: var(--cbp-form-field-color-bg-dark);
+  --cbp-form-field-color-border: var(--cbp-form-field-color-border-dark);
+  --cbp-form-field-color-border-hover: var(--cbp-form-field-color-border-hover-dark);
+  --cbp-form-field-color-border-focus: var(--cbp-form-field-color-border-focus-dark);
+  --cbp-form-field-color-placeholder: var(--cbp-form-field-color-placeholder-dark);
+  --cbp-form-field-select-chevron: var(--cbp-form-field-select-chevron-dark);
 }
 
 cbp-form-field {
@@ -221,7 +217,7 @@ cbp-form-field {
     --cbp-form-field-color-border-hover-dark: var(--cbp-color-danger-lighter);
     //--cbp-form-field-color-border-focus-dark: var(--cbp-color-interactive-focus-light);
     //--cbp-form-field-color-label-dark: var(--cbp-color-text-lightest);
-    --cbp-form-field-color-description-dark: var(--cbp-color-text-light);
+    --cbp-form-field-color-description-dark: var(--cbp-color-danger-light);
     //--cbp-form-field-color-placeholder-dark: var(--cbp-color-text-light);
   }
 }

--- a/packages/web-components/src/components/cbp-form-input/cbp-form-field.scss
+++ b/packages/web-components/src/components/cbp-form-input/cbp-form-field.scss
@@ -36,15 +36,19 @@
 // Displays dark design based on mode or context
 [data-cbp-theme=light] cbp-form-field[context*=dark],
 [data-cbp-theme=dark] cbp-form-field:not([context=dark-inverts]):not([context=light-always]) {
+
   --cbp-form-field-color-label: var(--cbp-form-field-color-label-dark);
   --cbp-form-field-color-description: var(--cbp-form-field-color-description-dark);
-  --cbp-form-field-color: var(--cbp-form-field-color-dark);
-  --cbp-form-field-color-bg: var(--cbp-form-field-color-bg-dark);
-  --cbp-form-field-color-border: var(--cbp-form-field-color-border-dark);
-  --cbp-form-field-color-border-hover: var(--cbp-form-field-color-border-hover-dark);
-  --cbp-form-field-color-border-focus: var(--cbp-form-field-color-border-focus-dark);
-  --cbp-form-field-color-placeholder: var(--cbp-form-field-color-placeholder-dark);
-  --cbp-form-field-select-chevron: var(--cbp-form-field-select-chevron-dark);
+
+  //input,select,textarea {
+    --cbp-form-field-color: var(--cbp-form-field-color-dark);
+    --cbp-form-field-color-bg: var(--cbp-form-field-color-bg-dark);
+    --cbp-form-field-color-border: var(--cbp-form-field-color-border-dark);
+    --cbp-form-field-color-border-hover: var(--cbp-form-field-color-border-hover-dark);
+    --cbp-form-field-color-border-focus: var(--cbp-form-field-color-border-focus-dark);
+    --cbp-form-field-color-placeholder: var(--cbp-form-field-color-placeholder-dark);
+    --cbp-form-field-select-chevron: var(--cbp-form-field-select-chevron-dark);
+  //}
 }
 
 cbp-form-field {
@@ -123,40 +127,41 @@ cbp-form-field {
       //border-color: var(--cbp-form-field-color-border-focus);
     }
 
-
-    //:read-only:where(input,textarea) {
-    &[readonly] {
-      --cbp-form-field-color-bg: var(--cbp-color-gray-cool-10);
-      --cbp-form-field-color-border: var(--cbp-color-interactive-secondary-light);
-      --cbp-form-field-color-border-hover: var(--cbp-color-interactive-secondary-light);
-      --cbp-form-field-color-border-focus: var(--cbp-color-interactive-secondary-light);
-      --cbp-form-field-color-bg-dark: var(--cbp-color-gray-cool-80);
-      --cbp-form-field-color-border-dark: var(--cbp-color-interactive-secondary-dark);
-      --cbp-form-field-color-border-hover-dark: var(--cbp-color-interactive-secondary-dark);
-      --cbp-form-field-color-border-focus: var(--cbp-color-interactive-secondary-dark);
-      --cbp-form-field-color-placeholder: transparent;
-      font-style: italic;
-      cursor: not-allowed;
-    }
-
+    &[readonly],
     &:disabled {
-      --cbp-form-field-color: var(--cbp-color-interactive-disabled-dark);
-      --cbp-form-field-color-bg: var(--cbp-color-interactive-disabled-light);
-      --cbp-form-field-color-border: var(--cbp-color-interactive-disabled-dark);
-      --cbp-form-field-color-border-hover: var(--cbp-color-interactive-disabled-dark);
-      //--cbp-form-field-color-border-focus: var(--cbp-color-interactive-disabled-dark);
-      --cbp-form-field-color-dark: var(--cbp-color-interactive-disabled-light);
-      --cbp-form-field-color-bg-dark: var(--cbp-color-interactive-disabled-dark);
-      --cbp-form-field-color-border-dark: var(--cbp-color-interactive-disabled-light);
-      --cbp-form-field-color-border-hover-dark: var(--cbp-color-interactive-disabled-light);
-      //--cbp-form-field-color-border-focus: var(--cbp-color-interactive-secondary-dark);
-      --cbp-form-field-color-placeholder: transparent;
       font-style: italic;
       cursor: not-allowed;
     }
   }
   
-  input::placeholder {
+  // These overrides need to be set at the component host level to work properly in dark mode
+  &:has(*[readonly]) {
+    --cbp-form-field-color-bg: var(--cbp-color-gray-cool-10);
+    --cbp-form-field-color-border: var(--cbp-color-interactive-secondary-light);
+    --cbp-form-field-color-border-hover: var(--cbp-color-interactive-secondary-light);
+    --cbp-form-field-color-border-focus: var(--cbp-color-interactive-secondary-light);
+    --cbp-form-field-color-bg-dark: var(--cbp-color-gray-cool-80);
+    --cbp-form-field-color-border-dark: var(--cbp-color-interactive-secondary-dark);
+    --cbp-form-field-color-border-hover-dark: var(--cbp-color-interactive-secondary-dark);
+    --cbp-form-field-color-border-focus: var(--cbp-color-interactive-secondary-dark);
+    --cbp-form-field-color-placeholder: transparent;
+  }
+
+  &:has(*:disabled) {
+    --cbp-form-field-color: var(--cbp-color-interactive-disabled-dark);
+    --cbp-form-field-color-bg: var(--cbp-color-interactive-disabled-light);
+    --cbp-form-field-color-border: var(--cbp-color-interactive-disabled-dark);
+    --cbp-form-field-color-border-hover: var(--cbp-color-interactive-disabled-dark);
+    //--cbp-form-field-color-border-focus: var(--cbp-color-interactive-disabled-dark);
+    --cbp-form-field-color-dark: var(--cbp-color-interactive-disabled-light);
+    --cbp-form-field-color-bg-dark: var(--cbp-color-interactive-disabled-dark);
+    --cbp-form-field-color-border-dark: var(--cbp-color-interactive-disabled-light);
+    --cbp-form-field-color-border-hover-dark: var(--cbp-color-interactive-disabled-light);
+    //--cbp-form-field-color-border-focus: var(--cbp-color-interactive-secondary-dark);
+    --cbp-form-field-color-placeholder: transparent;
+  }
+
+  ::placeholder {
     color: var(--cbp-form-field-color-placeholder);
     font-style: italic;
   }
@@ -194,7 +199,7 @@ cbp-form-field {
     //padding-inline-end: var(--cbp-space-5x);
 
     // Chevron on a colored background (via linear gradient)
-    background: right calc(1.125rem - 8px) top calc(1.125rem - 8px) no-repeat var(--cbp-form-field-select-chevron), 
+    background: right calc(1.125rem - 8px) top calc(1rem - 8px) no-repeat var(--cbp-form-field-select-chevron), 
                 right 0px top 0px repeat-y linear-gradient( 90deg, var(--cbp-form-field-color-bg) calc(100% - var(--cbp-space-9x)), var(--cbp-form-field-color-border) var(--cbp-space-9x) );
     padding-inline-end: var(--cbp-space-9x);
     

--- a/packages/web-components/src/components/cbp-form-input/cbp-form-field.specs.mdx
+++ b/packages/web-components/src/components/cbp-form-input/cbp-form-field.specs.mdx
@@ -1,6 +1,6 @@
 import { Meta } from '@storybook/addon-docs';
 
-<Meta title="Components/Form Field/Specifications" />
+<Meta title="Components/Form Fields/Specifications" />
 
 # cbp-form-field
 

--- a/packages/web-components/src/components/cbp-form-input/cbp-form-field.stories.tsx
+++ b/packages/web-components/src/components/cbp-form-input/cbp-form-field.stories.tsx
@@ -1,5 +1,5 @@
 export default {
-  title: 'Components/Form Field',
+  title: 'Components/Form Fields',
   tags: ['autodocs'],
   argTypes: {
     label: {

--- a/packages/web-components/src/components/cbp-form-input/cbp-form-field.tsx
+++ b/packages/web-components/src/components/cbp-form-input/cbp-form-field.tsx
@@ -90,6 +90,7 @@ export class CbpFormField {
           id={`${this.fieldId}-description`}
           class="cbp-form-field-description"
         >
+          {this.error && <cbp-icon name="triangle-exclamation" color="var(--cbp-form-field-color-description)" sx='{"margin-inline-end":"var(--cbp-space-1x)","vertical-align":"text-top"}'></cbp-icon>}
           {this.description}
           <slot name="cbp-form-field-description" />
         </div>

--- a/packages/web-components/src/components/cbp-icon/cbp-icon.tsx
+++ b/packages/web-components/src/components/cbp-icon/cbp-icon.tsx
@@ -11,14 +11,22 @@ export class CbpIcon {
 
   /** Specifies which icon to use from the built-in set of icons. */
   @Prop({ reflect: true }) name: string;
+  
   /** Specifies the exact `src` of an SVG file to use. */
   @Prop() src: string;
 
+  /** Optionally specifies the size of the icon, which defaults to `1em`, matching the context of nearby text. */
   @Prop() size: string = '1em';
+
+  /** Optionally specifies the color of the icon (ideally using design-token-based CSS variables). Defaults to "currentColor." */
   @Prop() color: string = "currentColor";
+
+  /** Optionally specify the degrees of rotation. */
   @Prop() rotate: number = 0;
 
+  /** For icons that are not decorative, accessibilityText is rendered as an `aria-label` on the `svg` tag. */
   @Prop() accessibilityText: string;
+
   /** Supports adding inline styles as an object */
   @Prop() sx: any = {};
 


### PR DESCRIPTION
* Fixed select chevron vertical spacing
* Fixed disabled and readonly in dark mode (this was selector-scoping related)
* Fixed field description color in error state in dark mode (danger-light)
* Added icon to field description in error state
* Added JSDocs to icon props