### PR TITLE
Feature/tabs darkmode

### DIFF
--- a/packages/web-components/.storybook/theme.js
+++ b/packages/web-components/.storybook/theme.js
@@ -1,7 +1,7 @@
 import { create } from '@storybook/theming/create';
 
 export default create({
-  //base: 'light',
+  base: globalThis.matchMedia('(prefers-color-scheme: dark)').matches ? 'dark' : 'light', //'light',
   brandTitle: 'CBP Design System | Web Components',
   brandImage: '../assets/images/cbp-seal.svg',
   brandTarget: '_self',

--- a/packages/web-components/src/components/cbp-button/cbp-button.scss
+++ b/packages/web-components/src/components/cbp-button/cbp-button.scss
@@ -17,7 +17,10 @@
  * @Prop --cbp-button-border-radius: var(--cbp-border-radius-soft);
  */
 
-/* Buttons get customized and overridden often within the design system and may benefit from a fully fleshed-out CSS API */
+/* 
+ * TechDebt: This dark-mode implementation is not up to speed with the latest techniques
+ * Buttons get customized and overridden often within the design system and may benefit from a fully fleshed-out CSS API
+ */
 :root {
   --cbp-button-color-text: var(--cbp-color-text-lightest);
   --cbp-button-color-text-hover: var(--cbp-color-text-lightest);

--- a/packages/web-components/src/components/cbp-button/cbp-button.tsx
+++ b/packages/web-components/src/components/cbp-button/cbp-button.tsx
@@ -68,8 +68,8 @@ export class CbpButton {
    */
   @Prop() accessibilityText: string;
 
-  /** @Internal Specifies that a button should not be keyboard navigable by setting its tabindex to -1. This property should only be used in very specific cases. */
-  @Prop() pointerOnly: boolean;
+  /* @Internal Specifies that a button should not be keyboard navigable by setting its tabindex to -1. This property should only be used in very specific cases. */
+  //@Prop() pointerOnly: boolean;
 
   /** Marks the rendered button/link in a disabled state when specified. */
   @Prop() disabled: boolean;
@@ -79,6 +79,7 @@ export class CbpButton {
 
   /** Supports adding inline styles as an object */
   @Prop() sx: any = {};
+
 
   /** A custom event emitted when the click event occurs for either a rendered button or anchor/link. */
   @Event() buttonClick!: EventEmitter;
@@ -128,7 +129,7 @@ export class CbpButton {
     let hostattrs = getElementAttrs(this.host);
     this.persistedAttrs = Object.fromEntries(
       Object.entries(hostattrs).filter(
-        ([key]) => ( key.includes('aria') || key == 'role' )
+        ([key]) => ( key.includes('aria-') || key == 'role' )
       )
     );
   }
@@ -190,7 +191,7 @@ export class CbpButton {
           <button
             {...this.persistedAttrs}
             {...attrs}
-            tabindex={this.pointerOnly || this.disabled ? -1 : 0}
+            //tabindex={this.pointerOnly || this.disabled ? -1 : 0}
             aria-label={this.accessibilityText}
             aria-pressed={pressed ? 'true' : null}
             aria-expanded={expanded ? 'true' : null}
@@ -209,7 +210,7 @@ export class CbpButton {
           <a
             {...this.persistedAttrs}
             {...attrs}
-            tabindex={this.pointerOnly || this.disabled ? -1 : 0}
+            //tabindex={this.pointerOnly || this.disabled ? -1 : 0}
             aria-label={this.accessibilityText}
             aria-pressed={pressed ? 'true' : null}
             aria-expanded={expanded ? 'true' : null}

--- a/packages/web-components/src/components/cbp-tab/cbp-tab.scss
+++ b/packages/web-components/src/components/cbp-tab/cbp-tab.scss
@@ -1,50 +1,86 @@
+/* 
+ * Dark Mode - display dark design based on mode or context
+ * CSS API originates in parent cbp-tabs component; dark mode override happens here due to color=danger variant.
+ */
+ [data-cbp-theme=light] cbp-tabs[context*=dark] cbp-tab,
+ [data-cbp-theme=dark] cbp-tabs:not([context=dark-inverts]):not([context=light-always]) cbp-tab {
+  --cbp-tab-color: var(--cbp-tab-color-dark);
+  --cbp-tab-color-hover: var(--cbp-tab-color-hover-dark);
+  --cbp-tab-color-focus: var(--cbp-tab-color-focus-dark);
+  --cbp-tab-color-active: var(--cbp-tab-color-active-dark);
+  --cbp-tab-color-selected: var(--cbp-tab-color-selected-dark);
+
+  --cbp-tab-color-bg: var(--cbp-tab-color-bg-dark);
+  --cbp-tab-color-bg-hover: var(--cbp-tab-color-bg-hover-dark);
+  --cbp-tab-color-bg-focus: var(--cbp-tab-color-bg-focus-dark);
+  --cbp-tab-color-bg-active: var(--cbp-tab-color-bg-active-dark);
+  --cbp-tab-color-bg-selected: var(--cbp-tab-color-bg-selected-dark);
+
+  --cbp-tab-color-border: var(--cbp-tab-color-border-dark);
+  --cbp-tab-color-border-hover: var(--cbp-tab-color-border-hover-dark);
+  --cbp-tab-color-border-focus: var(--cbp-tab-color-border-focus-dark);
+  --cbp-tab-color-border-active: var(--cbp-tab-color-border-active-dark);
+  --cbp-tab-color-border-selected: var(--cbp-tab-color-border-selected-dark);
+}
+
 cbp-tab {
-
-  &[color=danger] {
-    button {
-      color: var(--cbp-color-danger-base);
-
-      &:hover:not([aria-selected='true']):not(:focus) {
-        background-color: var(--cbp-color-danger-lighter);
-        border-color: var(--cbp-color-danger-dark);
-      }
-    }
-  }
-
   button {
     all: unset;
-    color: var(--cbp-color-interactive-secondary-darker);
+    color: var(--cbp-tab-color);
+    background-color: var(--cbp-tab-color-bg);
     box-sizing: border-box;
     min-height: var(--cbp-space-14x);
     padding: 0 var(--cbp-space-3x);
-    border-bottom: var(--cbp-border-size-xl) solid transparent;
     font-size: var(--cbp-font-size-heading-xs);
     font-weight: var(--cbp-font-weight-medium);
     white-space: nowrap;
+    border-bottom: var(--cbp-border-size-xl) solid var(--cbp-tab-color-border);
+    border-radius: var(--cbp-tab-border-radius);
+    outline-width: var(--cbp-border-size-md);
+    outline-style: none;
+    outline-color: var(--cbp-button-color-outline-focus);
+    outline-offset: calc(-1 * var(--cbp-space-1x));
     
-    &:hover:not([aria-selected='true']):not(:focus) {
-      background-color: var(--cbp-color-interactive-secondary-lighter);
-      border-bottom-color: var(--cbp-color-interactive-secondary-darker);
+    // The selected tab should appear non-interactive on the surface because selecting it again won't do anything
+    &:hover {
+      --cbp-tab-color: var(--cbp-tab-color-hover);
+      --cbp-tab-color-bg: var(--cbp-tab-color-bg-hover);
+      --cbp-tab-color-border: var(--cbp-tab-color-border-hover);
     }
 
     &[aria-selected='true'] {
-      color: var(--cbp-color-interactive-active-dark);
-      border-color: var(--cbp-color-interactive-active-dark);
+      --cbp-tab-color: var(--cbp-tab-color-selected);
+      --cbp-tab-color-bg: var(--cbp-tab-color-bg-selected);
+      --cbp-tab-color-border: var(--cbp-tab-color-border-selected);
       font-style: italic;
     }
 
     &:focus {
-      color: var(--cbp-color-text-lightest);
-      background: var(--cbp-color-interactive-focus-dark);
-      border-color: var(--cbp-color-interactive-focus-dark);
-      outline: var(--cbp-border-size-md) solid var(--cbp-color-white);
-      outline-offset: calc(-1 * var(--cbp-space-1x));
+      --cbp-tab-color: var(--cbp-tab-color-focus);
+      --cbp-tab-color-bg: var(--cbp-tab-color-bg-focus);
+      --cbp-tab-color-border: var(--cbp-tab-color-border-focus);
+      outline-style: solid;
     }
 
     &:active {
-      color: var(--cbp-color-text-lightest);
-      background-color: var(--cbp-color-interactive-active-dark);
+      --cbp-tab-color: var(--cbp-tab-color-active);
+      --cbp-tab-color-bg: var(--cbp-tab-color-bg-active);
+      --cbp-tab-color-border: var(--cbp-tab-color-border-active);
       outline: none;
     }
+  }
+
+  &[color=danger] {
+    --cbp-tab-color: var(--cbp-color-danger-base);
+    --cbp-tab-color-dark: var(--cbp-color-danger-light);
+
+    --cbp-tab-color-hover: var(--cbp-color-danger-base);
+    --cbp-tab-color-hover-dark: var(--cbp-color-danger-lighter);
+    
+    --cbp-tab-color-bg-hover: var(--cbp-color-danger-lighter);
+    --cbp-tab-color-bg-hover-dark: var(--cbp-color-danger-darker);
+    
+    --cbp-tab-color-border-hover: var(--cbp-color-danger-dark);
+    --cbp-tab-color-border-hover-dark: var(--cbp-color-danger-lighter);
   }
 }

--- a/packages/web-components/src/components/cbp-tabs/cbp-tabs.scss
+++ b/packages/web-components/src/components/cbp-tabs/cbp-tabs.scss
@@ -104,12 +104,14 @@ cbp-tabs {
   // TechDebt - dark colors CSS API not yet implemented in cbp-button
   cbp-button:not(#fakeId) {
     align-self: flex-start;
+    /* Restore this when button CSS API is fixed
     --cbp-button-color-text: var(--cbp-tab-color);
     --cbp-button-color-text-dark: var(--cbp-tab-color-dark);
     --cbp-button-color-fill: var(--cbp-color-background-light);
     --cbp-button-color-fill-dark: var(--cbp-color-background-dark);
     --cbp-button-color-border: var(--cbp-color-gray-cool-30);
     --cbp-button-color-border-dark: var(--cbp-color-gray-cool-60);
+    */
     --cbp-button-border-radius: 0;
   }
 

--- a/packages/web-components/src/components/cbp-tabs/cbp-tabs.scss
+++ b/packages/web-components/src/components/cbp-tabs/cbp-tabs.scss
@@ -1,14 +1,115 @@
+/**
+ * @prop --cbp-tabs-color-border: var(--cbp-color-gray-cool-30);
+ * @prop --cbp-tabs-color-border-dark: var(--cbp-color-gray-cool-60);
+
+ * @prop --cbp-tab-color: var(--cbp-color-interactive-secondary-darker);
+ * @prop --cbp-tab-color-hover: var(--cbp-color-interactive-secondary-darker);
+ * @prop --cbp-tab-color-focus: var(--cbp-color-text-lightest);
+ * @prop --cbp-tab-color-active: var(--cbp-color-text-lightest);
+ * @prop --cbp-tab-color-selected: var(--cbp-color-interactive-active-dark);
+
+ * @prop --cbp-tab-color-bg: transparent;
+ * @prop --cbp-tab-color-bg-hover: var(--cbp-color-interactive-secondary-lighter);
+ * @prop --cbp-tab-color-bg-focus: var(--cbp-color-interactive-focus-dark);
+ * @prop --cbp-tab-color-bg-active: var(--cbp-color-interactive-active-dark);
+ * @prop --cbp-tab-color-bg-selected: transparent;
+
+ * @prop --cbp-tab-color-border: transparent;
+ * @prop --cbp-tab-color-border-hover: var(--cbp-color-interactive-secondary-lighter);
+ * @prop --cbp-tab-color-border-focus: var(--cbp-color-interactive-focus-dark);
+ * @prop --cbp-tab-color-border-active: var(--cbp-color-interactive-active-dark);
+ * @prop --cbp-tab-color-border-selected: var(--cbp-color-interactive-active-dark);
+
+ * @prop --cbp-tab-color-dark: var(--cbp-color-interactive-secondary-lighter);
+ * @prop --cbp-tab-color-hover-dark: var(--cbp-color-interactive-secondary-lighter);
+ * @prop --cbp-tab-color-focus-dark: var(--cbp-color-text-darkest);
+ * @prop --cbp-tab-color-active-dark: var(--cbp-color-text-darkest);
+ * @prop --cbp-tab-color-selected-dark: var(--cbp-color-interactive-active-light);
+
+ * @prop --cbp-tab-color-bg-dark: transparent;
+ * @prop --cbp-tab-color-bg-hover-dark: var(--cbp-color-interactive-secondary-darker);
+ * @prop --cbp-tab-color-bg-focus-dark: var(--cbp-color-interactive-focus-light);
+ * @prop --cbp-tab-color-bg-active-dark: var(--cbp-color-interactive-active-light);
+ * @prop --cbp-tab-color-bg-selected-dark: transparent;
+
+ * @prop --cbp-tab-color-border-dark: transparent;
+ * @prop --cbp-tab-color-border-hover-dark: var(--cbp-color-interactive-secondary-lighter);
+ * @prop --cbp-tab-color-border-focus-dark: var(--cbp-color-interactive-focus-light);
+ * @prop --cbp-tab-color-border-active-dark: var(--cbp-color-interactive-active-light);
+ * @prop --cbp-tab-color-border-selected-dark: var(--cbp-color-interactive-active-light);
+
+ * @prop --cbp-tab-border-radius: 0;
+*/
+:root {
+
+  --cbp-tabs-color-border: var(--cbp-color-gray-cool-30);
+  --cbp-tabs-color-border-dark: var(--cbp-color-gray-cool-60);
+
+  --cbp-tab-color: var(--cbp-color-interactive-secondary-darker);
+  --cbp-tab-color-hover: var(--cbp-color-interactive-secondary-darker);
+  --cbp-tab-color-focus: var(--cbp-color-text-lightest);
+  --cbp-tab-color-active: var(--cbp-color-text-lightest);
+  --cbp-tab-color-selected: var(--cbp-color-interactive-active-dark);
+
+  --cbp-tab-color-bg: transparent;
+  --cbp-tab-color-bg-hover: var(--cbp-color-interactive-secondary-lighter);
+  --cbp-tab-color-bg-focus: var(--cbp-color-interactive-focus-dark);
+  --cbp-tab-color-bg-active: var(--cbp-color-interactive-active-dark);
+  --cbp-tab-color-bg-selected: transparent;
+
+  --cbp-tab-color-border: transparent;
+  --cbp-tab-color-border-hover: var(--cbp-color-interactive-secondary-lighter);
+  --cbp-tab-color-border-focus: var(--cbp-color-interactive-focus-dark);
+  --cbp-tab-color-border-active: var(--cbp-color-interactive-active-dark);
+  --cbp-tab-color-border-selected: var(--cbp-color-interactive-active-dark);
+
+  --cbp-tab-color-dark: var(--cbp-color-interactive-secondary-lighter);
+  --cbp-tab-color-hover-dark: var(--cbp-color-interactive-secondary-lighter);
+  --cbp-tab-color-focus-dark: var(--cbp-color-text-darkest);
+  --cbp-tab-color-active-dark: var(--cbp-color-text-darkest);
+  --cbp-tab-color-selected-dark: var(--cbp-color-interactive-active-light);
+  
+  --cbp-tab-color-bg-dark: transparent;
+  --cbp-tab-color-bg-hover-dark: var(--cbp-color-interactive-secondary-darker);
+  --cbp-tab-color-bg-focus-dark: var(--cbp-color-interactive-focus-light);
+  --cbp-tab-color-bg-active-dark: var(--cbp-color-interactive-active-light);
+  --cbp-tab-color-bg-selected-dark: transparent;
+
+  --cbp-tab-color-border-dark: transparent;
+  --cbp-tab-color-border-hover-dark: var(--cbp-color-interactive-secondary-lighter);
+  --cbp-tab-color-border-focus-dark: var(--cbp-color-interactive-focus-light);
+  --cbp-tab-color-border-active-dark: var(--cbp-color-interactive-active-light);
+  --cbp-tab-color-border-selected-dark: var(--cbp-color-interactive-active-light);
+  
+  --cbp-tab-border-radius: 0;
+}
+
+/* 
+ * Dark Mode - display dark design based on mode or context
+ * 
+ */
+[data-cbp-theme=light] cbp-tabs[context*=dark],
+[data-cbp-theme=dark] cbp-tabs:not([context=dark-inverts]):not([context=light-always]) {
+  --cbp-tabs-color-border: var(--cbp-tabs-color-border-dark);
+}
+
 cbp-tabs {
   display: flex;
   max-width: 100%;
   overflow: hidden;
-  background: linear-gradient(to top, var(--cbp-color-gray-cool-30) var(--cbp-border-size-md), transparent var(--cbp-border-size-md));
+  background: linear-gradient(to top, var(--cbp-tabs-color-border) var(--cbp-border-size-md), transparent var(--cbp-border-size-md));
   margin-bottom: var(--cbp-space-4x);
 
-  cbp-button {
+  // overrides for responsive controls
+  // TechDebt - dark colors CSS API not yet implemented in cbp-button
+  cbp-button:not(#fakeId) {
     align-self: flex-start;
-    --cbp-button-color-fill: var(--cbp-color-background-light) !important;
-    --cbp-button-color-border: var(--cbp-color-gray-cool-30) !important;
+    --cbp-button-color-text: var(--cbp-tab-color);
+    --cbp-button-color-text-dark: var(--cbp-tab-color-dark);
+    --cbp-button-color-fill: var(--cbp-color-background-light);
+    --cbp-button-color-fill-dark: var(--cbp-color-background-dark);
+    --cbp-button-color-border: var(--cbp-color-gray-cool-30);
+    --cbp-button-color-border-dark: var(--cbp-color-gray-cool-60);
     --cbp-button-border-radius: 0;
   }
 

--- a/packages/web-components/src/components/cbp-tabs/cbp-tabs.stories.tsx
+++ b/packages/web-components/src/components/cbp-tabs/cbp-tabs.stories.tsx
@@ -10,6 +10,10 @@ export default {
     accessibilityText: {
       control: 'text',
     },
+    context : {
+      control: 'select',
+      options: [ "light-inverts", "light-always", "dark-inverts", "dark-always"]
+    },
     sx: {
       description: 'Supports adding inline styles as an object of key-value pairs comprised of CSS properties and values. Values should reference design tokens when possible.',
       control: 'object',
@@ -43,10 +47,11 @@ function createTabPanels(tabs) {
   return html.join('');
 }
 
-const Template = ({ tabs, accessibilityText, sx }) => {
+const Template = ({ tabs, accessibilityText, context, sx }) => {
   return ` 
     <cbp-tabs
       ${accessibilityText ? `accessibility-text="${accessibilityText}"` : ''}
+      ${context && context != 'light-inverts' ? `context=${context}` : ''}
       ${sx ? `sx=${JSON.stringify(sx)}` : ''}
     >
       ${createTabs(tabs)}

--- a/packages/web-components/src/components/cbp-tabs/cbp-tabs.tsx
+++ b/packages/web-components/src/components/cbp-tabs/cbp-tabs.tsx
@@ -23,6 +23,9 @@ export class CbpTabs {
   /** The accessible label of the tablist. Required unless `aria-labelledby` is specified on the host tag directly. */
   @Prop() accessibilityText: string;
 
+  /** Specifies the context of the component as it applies to the visual design and whether it inverts when light/dark mode is toggled. Default behavior is "light-inverts" and does not have to be specified. */
+  @Prop({ reflect: true }) context: 'light-inverts' | 'light-always' | 'dark-inverts' | 'dark-always';
+
   /** Supports adding inline styles as an object */
   @Prop() sx: any = {};
 
@@ -146,18 +149,25 @@ export class CbpTabs {
         }}
       >
         <cbp-button
-          type="button"
+          //type="button"
           color="secondary"
           fill="outline"
           variant="square"
-          pointerOnly={true}
-          aria-label="Previous Tab"
-          width='3.5rem'
-          height='3.5rem'
+          //pointerOnly={true}
+          //aria-label="Previous Tab"
+          width="3.5rem"
+          height="3.5rem"
           onClick={ () => this.responsiveNav('previous')}
           ref={el => (this.previousControl = el)}
         >
-          <cbp-icon name="chevron-right" size="var(--cbp-space-5x)" rotate={180}></cbp-icon>
+          <button
+            type="button"
+            tabindex="-1"
+            aria-label="Previous Tab"
+            slot="cbp-button-custom"
+          >
+            <cbp-icon name="chevron-right" size="var(--cbp-space-5x)" rotate={180}></cbp-icon>
+          </button>
         </cbp-button>
 
         <div
@@ -168,18 +178,25 @@ export class CbpTabs {
         </div>
 
         <cbp-button
-          type="button"
+          //type="button"
           color="secondary"
           fill="outline"
           variant="square"
-          pointerOnly={true}
-          aria-label="Next Tab"
-          width='3.5rem'
-          height='3.5rem'
+          //pointerOnly={true}
+          //aria-label="Next Tab"
+          width="3.5rem"
+          height="3.5rem"
           onClick={ () => this.responsiveNav('next')}
           ref={el => (this.nextControl = el)}
         >
-          <cbp-icon name="chevron-right" size="var(--cbp-space-5x)"></cbp-icon>
+          <button
+            type="button"
+            tabindex="-1"
+            aria-label="Next Tab"
+            slot="cbp-button-custom"
+          >
+            <cbp-icon name="chevron-right" size="var(--cbp-space-5x)"></cbp-icon>
+          </button>
         </cbp-button>
       </Host>
     );

--- a/packages/web-components/src/components/cbp-tabs/cbp-tabs.tsx
+++ b/packages/web-components/src/components/cbp-tabs/cbp-tabs.tsx
@@ -154,6 +154,7 @@ export class CbpTabs {
           variant="square"
           width="3.5rem"
           height="3.5rem"
+          context={this.context}
           onClick={ () => this.responsiveNav('previous')}
           ref={el => (this.previousControl = el)}
         >
@@ -180,6 +181,7 @@ export class CbpTabs {
           variant="square"
           width="3.5rem"
           height="3.5rem"
+          context={this.context}
           onClick={ () => this.responsiveNav('next')}
           ref={el => (this.nextControl = el)}
         >

--- a/packages/web-components/src/components/cbp-tabs/cbp-tabs.tsx
+++ b/packages/web-components/src/components/cbp-tabs/cbp-tabs.tsx
@@ -149,12 +149,9 @@ export class CbpTabs {
         }}
       >
         <cbp-button
-          //type="button"
           color="secondary"
           fill="outline"
           variant="square"
-          //pointerOnly={true}
-          //aria-label="Previous Tab"
           width="3.5rem"
           height="3.5rem"
           onClick={ () => this.responsiveNav('previous')}
@@ -178,12 +175,9 @@ export class CbpTabs {
         </div>
 
         <cbp-button
-          //type="button"
           color="secondary"
           fill="outline"
           variant="square"
-          //pointerOnly={true}
-          //aria-label="Next Tab"
           width="3.5rem"
           height="3.5rem"
           onClick={ () => this.responsiveNav('next')}


### PR DESCRIPTION
* Added dark mode to tabs
* Added `context` prop to `cbp-tabs` and story
* Removed `pointerOnly` prop from button in favor of slotting a custom button (this was only used internally by the responsive tabs controls)

Everything should be good now except for dark mode of the responsive button controls, which requires button CSS to be refactored with a dark mode API (already in backlog).