### PR TITLE
Feature/form field wrapper

### DIFF
--- a/packages/react-components/components/stencil-generated/index.ts
+++ b/packages/react-components/components/stencil-generated/index.ts
@@ -25,6 +25,7 @@ export const CbpFlex = /*@__PURE__*/createReactComponent<JSX.CbpFlex, HTMLCbpFle
 export const CbpFlexItem = /*@__PURE__*/createReactComponent<JSX.CbpFlexItem, HTMLCbpFlexItemElement>('cbp-flex-item');
 export const CbpFooter = /*@__PURE__*/createReactComponent<JSX.CbpFooter, HTMLCbpFooterElement>('cbp-footer');
 export const CbpFormField = /*@__PURE__*/createReactComponent<JSX.CbpFormField, HTMLCbpFormFieldElement>('cbp-form-field');
+export const CbpFormFieldWrapper = /*@__PURE__*/createReactComponent<JSX.CbpFormFieldWrapper, HTMLCbpFormFieldWrapperElement>('cbp-form-field-wrapper');
 export const CbpGrid = /*@__PURE__*/createReactComponent<JSX.CbpGrid, HTMLCbpGridElement>('cbp-grid');
 export const CbpGridItem = /*@__PURE__*/createReactComponent<JSX.CbpGridItem, HTMLCbpGridItemElement>('cbp-grid-item');
 export const CbpHide = /*@__PURE__*/createReactComponent<JSX.CbpHide, HTMLCbpHideElement>('cbp-hide');

--- a/packages/web-components/src/components/cbp-form-field-wrapper/cbp-form-field-wrapper.scss
+++ b/packages/web-components/src/components/cbp-form-field-wrapper/cbp-form-field-wrapper.scss
@@ -1,0 +1,55 @@
+/*
+ * @prop --cbp-form-field-wrapper-padding-start: inherit; 
+ * @prop --cbp-form-field-wrapper-padding-end: inherit;
+ */
+:root {
+  --cbp-form-field-wrapper-padding-start: var(--cbp-form-field-padding-inline);
+  --cbp-form-field-wrapper-padding-end: var(--cbp-form-field-padding-inline);
+
+  --cbp-form-field-overlay-start-width: 0;
+  --cbp-form-field-overlay-end-width: 0;
+  --cbp-form-field-attached-buttons-width: 0;
+
+}
+
+cbp-form-field-wrapper {
+  //display: block;
+  position: relative;
+
+  .cbp-form-field-wrapper-shrinkwrap {
+    display: block;
+    position: relative;
+
+    // Override the input padding based on overlay size to prevent input text from being obscured
+    input {
+      padding-inline-start: calc(var(--cbp-form-field-overlay-start-width) + var(--cbp-form-field-wrapper-padding-start));
+      padding-inline-end: calc(var(--cbp-form-field-overlay-end-width) + var(--cbp-form-field-wrapper-padding-end));
+    }
+
+    // All named slots within the shrinkwrap element are overlays
+    [slot] {
+      position: absolute;
+      display: inline-flex;
+      align-items: center;
+      height: 100%;
+      color: var(--cbp-form-field-color);
+    }
+
+    [slot="cbp-form-field-overlay-start"] {
+      inset-inline-start: var(--cbp-space-2x);
+      font-weight: var(--cbp-font-weight-bold);
+      font-style: italic;
+    }
+
+    [slot="cbp-form-field-overlay-end"] {
+      inset-inline-end: calc(var(--cbp-form-field-attached-buttons-width) + var(--cbp-space-2x)); //var(--cbp-space-2x);
+      font-style: italic;
+    }
+
+    // Attached buttons act like an overlay in order to wrap the input focus highlight around them.
+    [slot="cbp-form-field-attached-buttons"] {
+      --cbp-button-border-radius: 0 var(--cbp-border-radius-soft) var(--cbp-border-radius-soft) 0;
+      inset-inline-end: 0;
+    }
+  }
+}

--- a/packages/web-components/src/components/cbp-form-field-wrapper/cbp-form-field-wrapper.scss
+++ b/packages/web-components/src/components/cbp-form-field-wrapper/cbp-form-field-wrapper.scss
@@ -6,21 +6,20 @@
   --cbp-form-field-wrapper-padding-start: var(--cbp-form-field-padding-inline);
   --cbp-form-field-wrapper-padding-end: var(--cbp-form-field-padding-inline);
 
+  // These are used by the component and are not intended to be used by consumers
   --cbp-form-field-overlay-start-width: 0;
   --cbp-form-field-overlay-end-width: 0;
-  --cbp-form-field-attached-buttons-width: 0;
-
+  --cbp-form-field-attached-button-width: 0;
 }
 
 cbp-form-field-wrapper {
-  //display: block;
   position: relative;
 
   .cbp-form-field-wrapper-shrinkwrap {
     display: block;
     position: relative;
 
-    // Override the input padding based on overlay size to prevent input text from being obscured
+    // Override the input padding based on overlay size to prevent input text from being obscured (text may still be obscured if there's not enough space for it)
     input {
       padding-inline-start: calc(var(--cbp-form-field-overlay-start-width) + var(--cbp-form-field-wrapper-padding-start));
       padding-inline-end: calc(var(--cbp-form-field-overlay-end-width) + var(--cbp-form-field-wrapper-padding-end));
@@ -42,12 +41,12 @@ cbp-form-field-wrapper {
     }
 
     [slot="cbp-form-field-overlay-end"] {
-      inset-inline-end: calc(var(--cbp-form-field-attached-buttons-width) + var(--cbp-space-2x)); //var(--cbp-space-2x);
+      inset-inline-end: calc(var(--cbp-form-field-attached-button-width) + var(--cbp-space-2x));
       font-style: italic;
     }
 
     // Attached buttons act like an overlay in order to wrap the input focus highlight around them.
-    [slot="cbp-form-field-attached-buttons"] {
+    [slot="cbp-form-field-attached-button"] {
       --cbp-button-border-radius: 0 var(--cbp-border-radius-soft) var(--cbp-border-radius-soft) 0;
       inset-inline-end: 0;
     }

--- a/packages/web-components/src/components/cbp-form-field-wrapper/cbp-form-field-wrapper.specs.mdx
+++ b/packages/web-components/src/components/cbp-form-field-wrapper/cbp-form-field-wrapper.specs.mdx
@@ -1,0 +1,37 @@
+import { Meta } from '@storybook/addon-docs';
+
+<Meta title="Components/Form Field Wrapper/Specifications" />
+
+# cbp-form-field-wrapper
+
+## Purpose
+
+The Form Field Wrapper component offers means for applying overlays and button controls to inputs in accordance with design requirements.
+
+## Functional Requirements
+
+* The Form Field Wrapper component is meant to be used in the default slot of the `cbp-form-field` component, wrapping the native input.
+* The Form Field Wrapper component provides a structured way to add additional overlays and related controls to an input field via named slots:
+  * A left-aligned overlay (e.g., "$")
+  * A right-aligned overlay (e.g., "kg")
+  * Buttons that appear attached to the input (e.g., search or password toggle)
+  * Buttons that appear next to the input, but not attached (e.g., increment/decrement on numeric inputs)
+
+## Technical Specifications
+
+### User Interactions
+
+* The Form Field Wrapper component does not provide any native interactions.
+* Any user interactions based on the slotted button controls are application-specified.
+
+### Responsiveness
+
+* Form controls such as text input, textarea, and selects are styled at 100% of their container by default, with a max-width of 100% so that they cannot break out of their container.
+
+### Accessibility
+
+* TBD
+
+### Additional Notes and Considerations
+
+* TBD

--- a/packages/web-components/src/components/cbp-form-field-wrapper/cbp-form-field-wrapper.stories.tsx
+++ b/packages/web-components/src/components/cbp-form-field-wrapper/cbp-form-field-wrapper.stories.tsx
@@ -13,7 +13,7 @@ export default {
     },
     inputType:{
       control: 'select',
-      options: [ "text", "number", "password", "search"] // email, tel, url
+      options: [ "text", "number", "password", "search"] // additional types: email, tel, url, color, range, date, datetime-local, month, week, time
     },
     error: {
       control: 'boolean',
@@ -60,8 +60,10 @@ const InputWithOverlaysTemplate = ({ label, description, inputType, overlayStart
         ${sx ? `sx=${JSON.stringify(sx)}` : ''}
       >  
         <input type="${inputType}" name="textinput" ${value ? `value="${value}"` : ''}  ${readonly ? `readonly` : ''} ${disabled ? `disabled` : ''} />
+
         ${overlayStart != undefined ? `<span slot="cbp-form-field-overlay-start">${overlayStart}</span>` : ''}
         ${overlayEnd != undefined ? `<span slot="cbp-form-field-overlay-end">${overlayEnd}</span>` : ''}
+
       </cbp-form-field-wrapper>
     </cbp-form-field>
   `;
@@ -72,6 +74,57 @@ InputWithOverlays.args = {
   value: '',
 };
 
+// TechDebt: needs an event listener to swap the button's icon and input type (password | text)
+const PasswordTemplate = ({ label, description, inputType,  overlayStart, overlayEnd, fieldId, error, readonly, disabled, value, context, sx }) => {
+  return ` 
+    <cbp-form-field
+      ${label ? `label="${label}"` : ''}
+      ${description ? `description="${description}"` : ''}
+      ${fieldId ? `field-id="${fieldId}"` : ''}
+      ${error ? `error` : ''}
+      ${readonly ? `readonly` : ''}
+      ${disabled ? `disabled` : ''}
+      ${context && context != 'light-inverts' ? `context=${context}` : ''}
+      ${sx ? `sx=${JSON.stringify(sx)}` : ''}
+    >
+      <cbp-form-field-wrapper
+        ${sx ? `sx=${JSON.stringify(sx)}` : ''}
+      >
+        <input
+          type="${inputType}"
+          name="search"
+          ${value ? `value="${value}"` : ''}
+        />
+
+        ${overlayStart != undefined ? `<span slot="cbp-form-field-overlay-start">${overlayStart}</span>` : ''}
+        ${overlayEnd != undefined ? `<span slot="cbp-form-field-overlay-end">${overlayEnd}</span>` : ''}
+        
+        <span slot="cbp-form-field-attached-button">
+          <cbp-button
+            type="submit"
+            fill="solid"
+            color="secondary"
+            variant="square"
+            accessibility-text="Toggle visibility"
+            aria-controls="${fieldId}"
+          >
+            <cbp-icon name="eye"></cbp-icon>
+          </cbp-button>
+        </span>
+        
+      </cbp-form-field-wrapper>
+    </cbp-form-field>
+  `;
+};
+
+export const Password = PasswordTemplate.bind({});
+Password.args = {
+  label: 'Password',
+  description: '',
+  fieldId: 'pw',
+  inputType: 'password',
+  value: '',
+};
 
 
 const SearchTemplate = ({ label, description, inputType,  overlayStart, overlayEnd, fieldId, error, readonly, disabled, value, context, sx }) => {
@@ -81,6 +134,8 @@ const SearchTemplate = ({ label, description, inputType,  overlayStart, overlayE
       ${description ? `description="${description}"` : ''}
       ${fieldId ? `field-id="${fieldId}"` : ''}
       ${error ? `error` : ''}
+      ${readonly ? `readonly` : ''}
+      ${disabled ? `disabled` : ''}
       ${context && context != 'light-inverts' ? `context=${context}` : ''}
       ${sx ? `sx=${JSON.stringify(sx)}` : ''}
     >
@@ -98,13 +153,12 @@ const SearchTemplate = ({ label, description, inputType,  overlayStart, overlayE
         ${overlayStart != undefined ? `<span slot="cbp-form-field-overlay-start">${overlayStart}</span>` : ''}
         ${overlayEnd != undefined ? `<span slot="cbp-form-field-overlay-end">${overlayEnd}</span>` : ''}
         
-        <span slot="cbp-form-field-attached-buttons">
+        <span slot="cbp-form-field-attached-button">
           <cbp-button
             type="submit"
             fill="solid"
             color="secondary"
             variant="square"
-            ${disabled ? `disabled` : ''}
             accessibility-text="Search"
           >
             <cbp-icon name="magnifying-glass"></cbp-icon>

--- a/packages/web-components/src/components/cbp-form-field-wrapper/cbp-form-field-wrapper.stories.tsx
+++ b/packages/web-components/src/components/cbp-form-field-wrapper/cbp-form-field-wrapper.stories.tsx
@@ -1,0 +1,126 @@
+export default {
+  title: 'Components/Form Field Wrapper',
+  tags: ['autodocs'],
+  argTypes: {
+    label: {
+      control: 'text',
+    },
+    description: {
+      control: 'text',
+    },
+    fieldId: {
+      control: 'text',
+    },
+    inputType:{
+      control: 'select',
+      options: [ "text", "number", "password", "search"] // email, tel, url
+    },
+    error: {
+      control: 'boolean',
+    },
+    readonly: {
+      control: 'boolean',
+    },
+    disabled: {
+      control: 'boolean',
+    },
+    overlayStart: {
+      control: 'text',
+    },
+    overlayEnd: {
+      control: 'text',
+    },
+    context : {
+      control: 'select',
+      options: [ "light-inverts", "light-always", "dark-inverts", "dark-always"]
+    },
+    sx: {
+      description: 'Supports adding inline styles as an object of key-value pairs comprised of CSS properties and values. Values should reference design tokens when possible.',
+      control: 'object',
+    },
+  },
+  args: {
+    label: 'Field Label',
+    description: 'Field description.',
+    inputType: 'text'
+  },
+};
+
+const InputWithOverlaysTemplate = ({ label, description, inputType, overlayStart, overlayEnd, fieldId, error, readonly, disabled, value, context, sx }) => {
+  return ` 
+    <cbp-form-field
+      ${label ? `label="${label}"` : ''}
+      ${description ? `description="${description}"` : ''}
+      ${fieldId ? `field-id="${fieldId}"` : ''}
+      ${error ? `error` : ''}
+      ${context && context != 'light-inverts' ? `context=${context}` : ''}
+      ${sx ? `sx=${JSON.stringify(sx)}` : ''}
+    >
+      <cbp-form-field-wrapper
+        ${sx ? `sx=${JSON.stringify(sx)}` : ''}
+      >  
+        <input type="${inputType}" name="textinput" ${value ? `value="${value}"` : ''}  ${readonly ? `readonly` : ''} ${disabled ? `disabled` : ''} />
+        ${overlayStart != undefined ? `<span slot="cbp-form-field-overlay-start">${overlayStart}</span>` : ''}
+        ${overlayEnd != undefined ? `<span slot="cbp-form-field-overlay-end">${overlayEnd}</span>` : ''}
+      </cbp-form-field-wrapper>
+    </cbp-form-field>
+  `;
+};
+
+export const InputWithOverlays = InputWithOverlaysTemplate.bind({});
+InputWithOverlays.args = {
+  value: '',
+};
+
+
+
+const SearchTemplate = ({ label, description, inputType,  overlayStart, overlayEnd, fieldId, error, readonly, disabled, value, context, sx }) => {
+  return ` 
+    <cbp-form-field
+      ${label ? `label="${label}"` : ''}
+      ${description ? `description="${description}"` : ''}
+      ${fieldId ? `field-id="${fieldId}"` : ''}
+      ${error ? `error` : ''}
+      ${context && context != 'light-inverts' ? `context=${context}` : ''}
+      ${sx ? `sx=${JSON.stringify(sx)}` : ''}
+    >
+      <cbp-form-field-wrapper
+        ${sx ? `sx=${JSON.stringify(sx)}` : ''}
+      >  
+        <input
+          type="${inputType}"
+          name="search"
+          ${value ? `value="${value}"` : ''}
+          ${readonly ? `readonly` : ''}
+          ${disabled ? `disabled` : ''}
+        />
+
+        ${overlayStart != undefined ? `<span slot="cbp-form-field-overlay-start">${overlayStart}</span>` : ''}
+        ${overlayEnd != undefined ? `<span slot="cbp-form-field-overlay-end">${overlayEnd}</span>` : ''}
+        
+        <span slot="cbp-form-field-attached-buttons">
+          <cbp-button
+            type="submit"
+            fill="solid"
+            color="secondary"
+            variant="square"
+            ${disabled ? `disabled` : ''}
+            accessibility-text="Search"
+          >
+            <cbp-icon name="magnifying-glass"></cbp-icon>
+          </cbp-button>
+        </span>
+        
+      </cbp-form-field-wrapper>
+    </cbp-form-field>
+  `;
+};
+
+export const Search = SearchTemplate.bind({});
+Search.args = {
+  label: 'Search',
+  description: '',
+  fieldId: 'search',
+  inputType: 'search',
+  value: '',
+};

--- a/packages/web-components/src/components/cbp-form-field-wrapper/cbp-form-field-wrapper.tsx
+++ b/packages/web-components/src/components/cbp-form-field-wrapper/cbp-form-field-wrapper.tsx
@@ -5,7 +5,7 @@ import { setCSSProps } from '../../utils/utils';
  * @slot - The default slot holds the form control.
  * @slot cbp-form-field-overlay-start - Holds an overlay positioned on the left side of the form field.
  * @slot cbp-form-field-overlay-end - Holds an overlay positioned on the right side of the form field.
- * @slot cbp-form-field-attached-buttons
+ * @slot cbp-form-field-attached-button
  * @slot cbp-form-field-unattached-buttons
  */
 @Component({
@@ -17,7 +17,7 @@ export class CbpFormFieldWrapper {
 
   private overlayStartWidth;
   private overlayEndWidth;
-  private attachedButtonsWidth;
+  private attachedButtonWidth;
     
   @Element() host: HTMLElement;
 
@@ -30,19 +30,16 @@ export class CbpFormFieldWrapper {
     const overlayEnd: HTMLElement = this.host.querySelector('[slot="cbp-form-field-overlay-end"]');
     this.overlayEndWidth = overlayEnd ? overlayEnd.offsetWidth + 8 : 0;
 
-    const attachedButtons: HTMLElement = this.host.querySelector('[slot="cbp-form-field-attached-buttons"]');
-    this.attachedButtonsWidth = attachedButtons ? attachedButtons.offsetWidth : 0;
+    const attachedButton: HTMLElement = this.host.querySelector('[slot="cbp-form-field-attached-button"]');
+    this.attachedButtonWidth = attachedButton ? attachedButton.offsetWidth : 0;
 
     // Update this with the buttons size
-    this.overlayEndWidth = this.overlayEndWidth +  this.attachedButtonsWidth
-
-    //this.attachedButtonWidth = (this.host.querySelector('[slot="cbp-form-field-attached-buttons"]') as HTMLElement).offsetWidth  || 0;
-    console.log(this.overlayStartWidth, this.overlayEndWidth);
+    this.overlayEndWidth = this.overlayEndWidth +  this.attachedButtonWidth
 
     setCSSProps(this.host, {
       "--cbp-form-field-overlay-start-width": `${this.overlayStartWidth}px`,
       "--cbp-form-field-overlay-end-width": `${this.overlayEndWidth}px`,
-      "--cbp-form-field-attached-buttons-width": `${this.attachedButtonsWidth}px`,
+      "--cbp-form-field-attached-button-width": `${this.attachedButtonWidth}px`,
     });
   }
 
@@ -53,7 +50,7 @@ export class CbpFormFieldWrapper {
           <slot name="cbp-form-field-overlay-start" />
           <slot />
           <slot name="cbp-form-field-overlay-end" />
-          <slot name="cbp-form-field-attached-buttons" />
+          <slot name="cbp-form-field-attached-button" />
         </div>
         <slot name="cbp-form-field-unattached-buttons" />
       </Host>

--- a/packages/web-components/src/components/cbp-form-field-wrapper/cbp-form-field-wrapper.tsx
+++ b/packages/web-components/src/components/cbp-form-field-wrapper/cbp-form-field-wrapper.tsx
@@ -1,0 +1,63 @@
+import { Component, Element, Host, h } from '@stencil/core';
+import { setCSSProps } from '../../utils/utils';
+
+/**
+ * @slot - The default slot holds the form control.
+ * @slot cbp-form-field-overlay-start - Holds an overlay positioned on the left side of the form field.
+ * @slot cbp-form-field-overlay-end - Holds an overlay positioned on the right side of the form field.
+ * @slot cbp-form-field-attached-buttons
+ * @slot cbp-form-field-unattached-buttons
+ */
+@Component({
+  tag: 'cbp-form-field-wrapper',
+  styleUrl: 'cbp-form-field-wrapper.scss'
+})
+
+export class CbpFormFieldWrapper {
+
+  private overlayStartWidth;
+  private overlayEndWidth;
+  private attachedButtonsWidth;
+    
+  @Element() host: HTMLElement;
+
+  componentDidLoad() {
+    // Calculate the size of the overlays to set the input padding accordingly
+    // TechDebt: as a first cut, this is not reactive. How reactive does it need to be?
+    const overlayStart: HTMLElement = this.host.querySelector('[slot="cbp-form-field-overlay-start"]');
+    this.overlayStartWidth = overlayStart ? overlayStart.offsetWidth + 8 : 0;
+
+    const overlayEnd: HTMLElement = this.host.querySelector('[slot="cbp-form-field-overlay-end"]');
+    this.overlayEndWidth = overlayEnd ? overlayEnd.offsetWidth + 8 : 0;
+
+    const attachedButtons: HTMLElement = this.host.querySelector('[slot="cbp-form-field-attached-buttons"]');
+    this.attachedButtonsWidth = attachedButtons ? attachedButtons.offsetWidth : 0;
+
+    // Update this with the buttons size
+    this.overlayEndWidth = this.overlayEndWidth +  this.attachedButtonsWidth
+
+    //this.attachedButtonWidth = (this.host.querySelector('[slot="cbp-form-field-attached-buttons"]') as HTMLElement).offsetWidth  || 0;
+    console.log(this.overlayStartWidth, this.overlayEndWidth);
+
+    setCSSProps(this.host, {
+      "--cbp-form-field-overlay-start-width": `${this.overlayStartWidth}px`,
+      "--cbp-form-field-overlay-end-width": `${this.overlayEndWidth}px`,
+      "--cbp-form-field-attached-buttons-width": `${this.attachedButtonsWidth}px`,
+    });
+  }
+
+  render() {
+    return (
+      <Host>
+        <div class="cbp-form-field-wrapper-shrinkwrap">
+          <slot name="cbp-form-field-overlay-start" />
+          <slot />
+          <slot name="cbp-form-field-overlay-end" />
+          <slot name="cbp-form-field-attached-buttons" />
+        </div>
+        <slot name="cbp-form-field-unattached-buttons" />
+      </Host>
+    );
+  }
+
+}

--- a/packages/web-components/src/components/cbp-form-field/cbp-form-field.scss
+++ b/packages/web-components/src/components/cbp-form-field/cbp-form-field.scss
@@ -132,18 +132,7 @@ cbp-form-field {
   }
   
   // These overrides need to be set at the component host level to work properly in dark mode
-  &:has(*[readonly]) {
-    --cbp-form-field-color-bg: var(--cbp-color-gray-cool-10);
-    --cbp-form-field-color-border: var(--cbp-color-interactive-secondary-light);
-    --cbp-form-field-color-border-hover: var(--cbp-color-interactive-secondary-light);
-    --cbp-form-field-color-border-focus: var(--cbp-color-interactive-secondary-light);
-    --cbp-form-field-color-bg-dark: var(--cbp-color-gray-cool-80);
-    --cbp-form-field-color-border-dark: var(--cbp-color-interactive-secondary-dark);
-    --cbp-form-field-color-border-hover-dark: var(--cbp-color-interactive-secondary-dark);
-    --cbp-form-field-color-border-focus: var(--cbp-color-interactive-secondary-dark);
-    --cbp-form-field-color-placeholder: transparent;
-  }
-
+  &[disabled],
   &:has(*:disabled) {
     --cbp-form-field-color: var(--cbp-color-interactive-disabled-dark);
     --cbp-form-field-color-bg: var(--cbp-color-interactive-disabled-light);
@@ -156,6 +145,31 @@ cbp-form-field {
     --cbp-form-field-color-border-hover-dark: var(--cbp-color-interactive-disabled-light);
     //--cbp-form-field-color-border-focus: var(--cbp-color-interactive-secondary-dark);
     --cbp-form-field-color-placeholder: transparent;
+  }
+
+  &[readonly],
+  &:has(*[readonly]) {
+    --cbp-form-field-color-bg: var(--cbp-color-gray-cool-10);
+    --cbp-form-field-color-border: var(--cbp-color-interactive-secondary-light);
+    --cbp-form-field-color-border-hover: var(--cbp-color-interactive-secondary-light);
+    --cbp-form-field-color-border-focus: var(--cbp-color-interactive-secondary-light);
+    --cbp-form-field-color-bg-dark: var(--cbp-color-gray-cool-80);
+    --cbp-form-field-color-border-dark: var(--cbp-color-interactive-secondary-dark);
+    --cbp-form-field-color-border-hover-dark: var(--cbp-color-interactive-secondary-dark);
+    --cbp-form-field-color-border-focus: var(--cbp-color-interactive-secondary-dark);
+    --cbp-form-field-color-placeholder: transparent;
+
+    // For readonly inputs, attached buttons become disabled but with different styling.
+    // These overrides are fairly minimal because the disabled state already sets the interactive states to the base color.
+    cbp-button:has(button:disabled) {
+      --cbp-button-color: var(--cbp-color-text-lightest);
+      --cbp-button-color-bg: var(--cbp-color-interactive-secondary-light);
+      --cbp-button-color-border: var(--cbp-color-interactive-secondary-light);
+
+      --cbp-button-color-dark: var(--cbp-color-text-base);
+      --cbp-button-color-bg-dark: var(--cbp-color-interactive-secondary-dark);
+      --cbp-button-color-border-dark: var(--cbp-color-interactive-secondary-dark);
+    }
   }
 
   ::placeholder {
@@ -171,8 +185,6 @@ cbp-form-field {
   }
 
   select {
-    //-webkit-appearance: none;
-    //-moz-appearance: none;
     appearance: none;
     text-overflow: ellipsis;
     padding-block: calc(var(--cbp-space-2x) - 2px) ; // Fixes Firefox vertical alignment
@@ -202,6 +214,7 @@ cbp-form-field {
     
   }
 
+  // Leave commented styles until verified everything's correct. If so, these are being inherited and can be removed.
   &[error] {
     //--cbp-form-field-color: var(--cbp-color-text-darkest);
     --cbp-form-field-color-bg: var(--cbp-color-danger-lighter);

--- a/packages/web-components/src/components/cbp-form-field/cbp-form-field.scss
+++ b/packages/web-components/src/components/cbp-form-field/cbp-form-field.scss
@@ -20,6 +20,7 @@
   --cbp-form-field-color-description-dark: var(--cbp-color-text-lightest);
   --cbp-form-field-color-placeholder-dark: var(--cbp-color-text-light);
 
+  --cbp-form-field-padding-inline: var(--cbp-space-2x);
   --cbp-form-field-margin-bottom: var(--cbp-space-4x);
 
   // TechDebt: Ideally, it would be better if the icon could inherit the text color, but I can't seem to get this working so we have 2 copies with different colors
@@ -80,7 +81,7 @@ cbp-form-field {
     width: 100%;
     max-width: 100%;
     min-height: var(--cbp-space-9x);
-    padding-inline: var(--cbp-space-2x);
+    padding-inline: var(--cbp-form-field-padding-inline);
     font-family: inherit;
     font-size: var(--cbp-font-size-body);
     line-height: var(--cbp-line-height-xs);

--- a/packages/web-components/src/components/cbp-form-field/cbp-form-field.specs.mdx
+++ b/packages/web-components/src/components/cbp-form-field/cbp-form-field.specs.mdx
@@ -41,11 +41,15 @@ The Form Field component represents a generic, reusable pattern for form fields 
 
 ### Additional Notes and Considerations
 
-* This component is essentially required for bringing in the style for all form controls/inputs. It should be flexible enough for various cases such as:
+* This component is required for bringing in the style for all form controls/inputs. It should be flexible enough for various cases such as:
   * when the label is hidden
-* Overlays and attached buttons may be better handled by another component, e.g., `cbp-form-field-wrapper`
-  * Right aligned overlays need to still work with inputs that have button controls attached to the right. This might get tricky. 
-* Handling of groups of inputs can be done via role=group or a legend tag. The legend tag can accept a disabled attribute, which is an advantage.
-* Needs to handle an error state
-* When autocomplete/autofill is used to fill the field, the browser adds styling...
+* This component may manage the form field (and associated buttons) disabled/readonly/error states, but does its best to get out of the way if the application wants to manage those states directly on the slotted elements.
+* Overlays and attached buttons are currently handled by child component, `cbp-form-field-wrapper`
+* TODO: Handling of groups of inputs can be done via role=group or a legend tag. The legend tag can accept a disabled attribute, which is an advantage.
+* When autocomplete/autofill is used to fill the field, the browser adds styling (only visible in light mode).
 * Textareas now support `field-sizing: content`, which causes the textarea to expand vertically to the size of its content (within the bounds of min- and max-heights). This may not be desireable as a default, but could make a useful option.
+* Additional notes on slotted form fields and their use, since these are not strictly controlled by the design system:
+  * Some input types, such as `email`, `tel`, and `url`, should not be used because they invoke browser-based validation, which is inconsistent across browsers and with the design system, and not always accessible.
+  * Use `inputmode` instead of HTML5 input types to provide a browser hint for the proper virtual keyboard on mobile devices without side effects noted above.
+  * The `select` with `multiple` (and `size`) attribute should not be used, as they have terrible usability. Use our `cbp-multiselect` (coming soon) instead.
+  * Input types such as `date`, `datetime` (deprecated), `datetime-local`, `month`, `week`, `time` may also vary by browser and not be styleable in accordance with the design system.

--- a/packages/web-components/src/components/cbp-form-field/cbp-form-field.specs.mdx
+++ b/packages/web-components/src/components/cbp-form-field/cbp-form-field.specs.mdx
@@ -33,7 +33,7 @@ The Form Field component represents a generic, reusable pattern for form fields 
 
 ### Accessibility
 
-* Disabled form controls and buttons are non-interactive and cannot be navigated to using the keyboard and should be used with caution (if at all).
+* Overlays may Disabled form controls and buttons are non-interactive and cannot be navigated to using the keyboard and should be used with caution (if at all).
 * Placeholder text should rarely, if ever, be used.
   * Especially in forms where the user is expected to enter data, placeholder text with sufficient contrast to the background color may be mistaken as entered input.
   * In high contrast mode, placeholder text is displayed exactly the same as entered text, making this issue more likely.
@@ -43,7 +43,7 @@ The Form Field component represents a generic, reusable pattern for form fields 
 
 * This component is essentially required for bringing in the style for all form controls/inputs. It should be flexible enough for various cases such as:
   * when the label is hidden
-* Overlays and attached buttons may be better handled by another component, e.g., `cbp-form-input-extras`
+* Overlays and attached buttons may be better handled by another component, e.g., `cbp-form-field-wrapper`
   * Right aligned overlays need to still work with inputs that have button controls attached to the right. This might get tricky. 
 * Handling of groups of inputs can be done via role=group or a legend tag. The legend tag can accept a disabled attribute, which is an advantage.
 * Needs to handle an error state

--- a/packages/web-components/src/components/cbp-form-field/cbp-form-field.stories.tsx
+++ b/packages/web-components/src/components/cbp-form-field/cbp-form-field.stories.tsx
@@ -191,3 +191,33 @@ export const MultiSelect = MultiSelectTemplate.bind({});
 MultiSelect.args = {
 };
 */
+
+
+
+const PasswordTemplate = ({ label, description, fieldId, error, readonly, disabled, value, context, sx }) => {
+  return ` 
+    <cbp-form-field
+      ${label ? `label="${label}"` : ''}
+      ${description ? `description="${description}"` : ''}
+      ${fieldId ? `field-id="${fieldId}"` : ''}
+      ${error ? `error` : ''}
+      ${context && context != 'light-inverts' ? `context=${context}` : ''}
+      ${sx ? `sx=${JSON.stringify(sx)}` : ''}
+    >
+      <cbp-form-field-wrapper>
+        <input 
+          type="password" 
+          name="hashedinput" 
+          ${value ? `value="${value}"` : ''}  
+          ${readonly ? `readonly` : ''} 
+          ${disabled ? `disabled` : ''}
+        />
+      </cbp-form-field-wrapper>
+    </cbp-form-field>
+  `;
+};
+
+export const Password = PasswordTemplate.bind({});
+Password.args = {
+  value: '',
+};

--- a/packages/web-components/src/components/cbp-form-field/cbp-form-field.stories.tsx
+++ b/packages/web-components/src/components/cbp-form-field/cbp-form-field.stories.tsx
@@ -201,6 +201,8 @@ const PasswordTemplate = ({ label, description, fieldId, error, readonly, disabl
       ${description ? `description="${description}"` : ''}
       ${fieldId ? `field-id="${fieldId}"` : ''}
       ${error ? `error` : ''}
+      ${readonly ? `readonly` : ''} 
+      ${disabled ? `disabled` : ''}
       ${context && context != 'light-inverts' ? `context=${context}` : ''}
       ${sx ? `sx=${JSON.stringify(sx)}` : ''}
     >
@@ -209,8 +211,6 @@ const PasswordTemplate = ({ label, description, fieldId, error, readonly, disabl
           type="password" 
           name="hashedinput" 
           ${value ? `value="${value}"` : ''}  
-          ${readonly ? `readonly` : ''} 
-          ${disabled ? `disabled` : ''}
         />
       </cbp-form-field-wrapper>
     </cbp-form-field>

--- a/packages/web-components/src/components/cbp-form-field/cbp-form-field.tsx
+++ b/packages/web-components/src/components/cbp-form-field/cbp-form-field.tsx
@@ -25,8 +25,14 @@ export class CbpFormField {
   @Prop() fieldId: string = createNamespaceKey('cbp-formfield');
   
   @Prop({ reflect: true }) error: boolean;
-  
+
   @Prop() errorMessages: string | any;
+
+  /** Specifies that the field is readonly; sets all form fields as readonly and related button controls to disabled.  */
+  @Prop({ reflect: true }) readonly: boolean;
+  
+  /** Specifies that the field is disabled; sets all form fields and button controls as disabled. */
+  @Prop({ reflect: true }) disabled: boolean;
 
   /** Specifies the context of the component as it applies to the visual design and whether it inverts when light/dark mode is toggled. Default behavior is "light-inverts" and does not have to be specified. */
   @Prop({ reflect: true }) context: 'light-inverts' | 'light-always' | 'dark-inverts' | 'dark-always';
@@ -73,6 +79,18 @@ export class CbpFormField {
     }
   }
 
+  componentDidRender() {
+    // Manage disabled/readonly/error states after each render because this potentially cascades down across multiple slotted controls.
+    this.formField.forEach( el => {
+      el.setAttribute('disabled', this.disabled);
+      el.setAttribute('readonly', this.readonly);
+    });
+
+    const buttons: any = this.host.querySelector('cbp-button');
+    buttons.forEach( el => {
+      el.setAttribute('disabled', this.disabled || this.readonly);
+    });
+  }
 
   render() {
     return (

--- a/packages/web-components/src/components/cbp-form-field/cbp-form-field.tsx
+++ b/packages/web-components/src/components/cbp-form-field/cbp-form-field.tsx
@@ -47,8 +47,8 @@ export class CbpFormField {
   handleChange() {
     this.valueChange.emit({
       host: this.host,
-      //nativeElement: this.formField,
-      //value: this.formField.value,
+      nativeElement: this.formField,
+      value: this.formField.value,
     });
   }
 


### PR DESCRIPTION
* First cut of `cbp-form-field-wrapper` for handling overlays and attached buttons
* Add styling for disabled buttons on readonly form fields. (slightly different than plain disabled buttons)
* Update `cbp-form-field` handling of disabled/readonly/error states to not fight with an app managing these things on the slotted elements separately.

I will probably reorg the stories at some point, but this is good enough for now. I'll be iterating on this with more input work.