### PR TITLE
First cut of cbp-checkbox component

### DIFF
--- a/packages/react-components/components/stencil-generated/index.ts
+++ b/packages/react-components/components/stencil-generated/index.ts
@@ -16,6 +16,7 @@ export const CbpBadge = /*@__PURE__*/createReactComponent<JSX.CbpBadge, HTMLCbpB
 export const CbpBanner = /*@__PURE__*/createReactComponent<JSX.CbpBanner, HTMLCbpBannerElement>('cbp-banner');
 export const CbpButton = /*@__PURE__*/createReactComponent<JSX.CbpButton, HTMLCbpButtonElement>('cbp-button');
 export const CbpCard = /*@__PURE__*/createReactComponent<JSX.CbpCard, HTMLCbpCardElement>('cbp-card');
+export const CbpCheckbox = /*@__PURE__*/createReactComponent<JSX.CbpCheckbox, HTMLCbpCheckboxElement>('cbp-checkbox');
 export const CbpChip = /*@__PURE__*/createReactComponent<JSX.CbpChip, HTMLCbpChipElement>('cbp-chip');
 export const CbpContainer = /*@__PURE__*/createReactComponent<JSX.CbpContainer, HTMLCbpContainerElement>('cbp-container');
 export const CbpDialog = /*@__PURE__*/createReactComponent<JSX.CbpDialog, HTMLCbpDialogElement>('cbp-dialog');

--- a/packages/web-components/src/components/cbp-checkbox/cbp-checkbox.scss
+++ b/packages/web-components/src/components/cbp-checkbox/cbp-checkbox.scss
@@ -1,0 +1,259 @@
+/**
+ *
+ */
+:root {
+  --cbp-checkbox-color: var(--cbp-color-text-lightest);
+  --cbp-checkbox-color-bg: var(--cbp-color-white);
+  --cbp-checkbox-color-border: var(--cbp-color-interactive-secondary-dark);
+  --cbp-checkbox-color-border-hover: var(--cbp-color-interactive-secondary-darker);
+  --cbp-checkbox-color-border-focus: var(--cbp-color-interactive-focus-dark);
+  --cbp-checkbox-color-halo: transparent;
+  --cbp-checkbox-color-halo-hover: var(--cbp-color-interactive-secondary-lighter);
+  --cbp-checkbox-color-halo-focus: var(--cbp-color-interactive-focus-light);
+  --cbp-checkbox-color-bg-checked: var(--cbp-color-interactive-selected-dark);
+  --cbp-checkbox-color-bg-checked-focus: var(--cbp-color-interactive-focus-dark);
+  --cbp-checkbox-color-border-checked: var(--cbp-color-interactive-selected-dark);
+  --cbp-checkbox-color-border-checked-hover: var(--cbp-color-interactive-selected-dark);
+  --cbp-checkbox-color-border-checked-focus: var(--cbp-color-white);
+  --cbp-checkbox-color-halo-checked-hover: var(--cbp-color-interactive-selected-light);
+  --cbp-checkbox-color-halo-checked-focus: var(--cbp-color-interactive-focus-light);
+  --cbp-checkbox-color-label: var(--cbp-color-text-darkest);
+
+
+  --cbp-checkbox-color-dark: var(--cbp-color-text-darkest);
+  --cbp-checkbox-color-bg-dark: var(--cbp-color-gray-cool-70);
+  --cbp-checkbox-color-border-dark: var(--cbp-color-interactive-secondary-light);
+  --cbp-checkbox-color-border-hover-dark: var(--cbp-color-interactive-secondary-lighter);
+  --cbp-checkbox-color-border-focus-dark: var(--cbp-color-interactive-focus-light);
+  --cbp-checkbox-color-halo-dark: transparent;
+  --cbp-checkbox-color-halo-hover-dark: var(--cbp-color-text-darker);
+  --cbp-checkbox-color-halo-focus-dark: var(--cbp-color-interactive-focus-dark);
+  --cbp-checkbox-color-bg-checked-dark: var(--cbp-color-interactive-selected-light);
+  --cbp-checkbox-color-bg-checked-focus-dark: var(--cbp-color-interactive-focus-light);
+  --cbp-checkbox-color-border-checked-dark: var(--cbp-color-interactive-selected-light);
+  --cbp-checkbox-color-border-checked-hover-dark: var(--cbp-color-interactive-selected-light);
+  --cbp-checkbox-color-border-checked-focus-dark: var(--cbp-color-black);
+  --cbp-checkbox-color-halo-checked-hover-dark: var(--cbp-color-interactive-selected-dark);
+  --cbp-checkbox-color-halo-checked-focus-dark: var(--cbp-color-interactive-focus-dark);
+  --cbp-checkbox-color-label-dark: var(--cbp-color-text-lightest);
+
+  --cbp-checkbox-margin: 0 0 var(--cbp-space-1x) 0;
+}
+
+// Displays dark design based on mode or context
+[data-cbp-theme=light] cbp-checkbox[context*=dark],
+[data-cbp-theme=dark] cbp-checkbox:not([context=dark-inverts]):not([context=light-always]) {
+  --cbp-checkbox-color: var(--cbp-checkbox-color-dark);
+  --cbp-checkbox-color-bg: var(--cbp-checkbox-color-bg-dark);
+  --cbp-checkbox-color-border: var(--cbp-checkbox-color-border-dark);
+  --cbp-checkbox-color-border-hover: var(--cbp-checkbox-color-border-hover-dark);
+  --cbp-checkbox-color-border-focus: var(--cbp-checkbox-color-border-focus-dark);
+  --cbp-checkbox-color-halo: var(--cbp-checkbox-color-halo-dark);
+  --cbp-checkbox-color-halo-hover: var(--cbp-checkbox-color-halo-hover-dark);
+  --cbp-checkbox-color-halo-focus: var(--cbp-checkbox-color-halo-focus-dark);
+
+  --cbp-checkbox-color-bg-checked: var(--cbp-checkbox-color-bg-checked-dark);
+  --cbp-checkbox-color-bg-checked-focus: var(--cbp-checkbox-color-bg-checked-focus-dark);
+  --cbp-checkbox-color-border-checked: var(--cbp-checkbox-color-border-checked-dark);
+  --cbp-checkbox-color-border-checked-hover: var(--cbp-checkbox-color-border-checked-hover-dark);
+  --cbp-checkbox-color-border-checked-focus: var(--cbp-checkbox-color-border-checked-focus-dark);
+  --cbp-checkbox-color-halo-checked-hover: var(--cbp-checkbox-color-halo-checked-hover-dark);
+  --cbp-checkbox-color-halo-checked-focus: var(--cbp-checkbox-color-halo-checked-focus-dark);
+
+  --cbp-checkbox-color-label: var(--cbp-checkbox-color-label-dark);
+}
+
+cbp-checkbox {
+  display: block;
+  margin: var(--cbp-checkbox-margin);
+  //min-height: var(--cbp-space-11x);
+
+  label {
+    display: flex;
+    align-items: center;
+    //gap: var(--cbp-space-2x);
+    min-height: var(--cbp-space-11x);
+    font-weight: var(--cbp-font-weight-bold);
+    color: var(--cbp-checkbox-color-label);
+  }
+
+  input[type=checkbox] {
+    position: relative;
+    flex-shrink: 0;
+    appearance: none; // checkboxes do not accept styling per design specs
+    color: var(--cbp-checkbox-color);
+    background-color: var(--cbp-checkbox-color-bg);
+    border-color: var(--cbp-checkbox-color-border);
+    border-style: solid;
+    border-width: var(--cbp-border-size-md);
+    border-radius: var(--cbp-border-radius-soft);
+    height: var(--cbp-space-6x);
+    width: var(--cbp-space-6x);
+    margin: 0;
+    margin-inline-end: var(--cbp-space-2x);
+    outline: 0;
+    box-shadow: 0 0 0 calc(var(--cbp-space-5x) / 2) var(--cbp-checkbox-color-halo);
+    clip-path: circle(80%);
+
+    // Check Mark
+    &::before {
+      content: '';
+      position: absolute;
+      margin: auto;
+      left: 0;
+      right: 0;
+      bottom: 0;
+      overflow: hidden;
+      top: 0;
+      border-right: solid 0px var(--cbp-checkbox-color);
+      border-bottom: solid 0px var(--cbp-checkbox-color);
+    }
+
+    // Verified: only need to set the base variables with higher level tokens that are swapped for dark mode
+    &:hover {
+      --cbp-checkbox-color-border: var(--cbp-checkbox-color-border-hover);
+      --cbp-checkbox-color-halo: var(--cbp-checkbox-color-halo-hover);
+    }
+
+    &:focus {
+      --cbp-checkbox-color-border: var(--cbp-checkbox-color-border-focus);
+      --cbp-checkbox-color-halo: var(--cbp-checkbox-color-halo-focus);
+    }
+
+    &:checked {
+      --cbp-checkbox-color-bg: var(--cbp-checkbox-color-bg-checked);
+      --cbp-checkbox-color-border: var(--cbp-checkbox-color-border-checked);
+
+      // Check Mark
+      &::before {
+        border-right-width: var(--cbp-border-size-lg);
+        border-bottom-width: var(--cbp-border-size-lg);
+        height: 70%;
+        width: 30%;
+        transform: rotate(45deg) translateY(-10%) translateX(-10%);
+      }
+
+      &:hover {
+        --cbp-checkbox-color-border: var(--cbp-checkbox-color-border-checked-hover);
+        --cbp-checkbox-color-halo: var(--cbp-checkbox-color-halo-checked-hover);
+      }
+
+      &:focus {
+        --cbp-checkbox-color-bg: var(--cbp-checkbox-color-bg-checked-focus);
+        --cbp-checkbox-color-border: var(--cbp-checkbox-color-border-checked-focus);
+        --cbp-checkbox-color-halo: var(--cbp-checkbox-color-halo-checked-focus);
+      }
+    }
+  }
+
+
+  &[disabled],
+  &:has(*:disabled) {
+    cursor: not-allowed;
+
+    label {
+      font-style: italic;
+    }
+  }
+
+  // These overrides need to be set at the component host level to work properly in dark mode
+  &[disabled],
+  &:has(*:disabled) {
+    // No focus for disabled form controls, hover state still exists so it must be invisible since this is a non-interactive element
+    --cbp-checkbox-color: var(--cbp-color-interactive-disabled-light);
+    --cbp-checkbox-color-bg: var(--cbp-color-interactive-disabled-light);
+    --cbp-checkbox-color-border: var(--cbp-color-interactive-disabled-dark);
+    --cbp-checkbox-color-border-hover: var(--cbp-color-interactive-disabled-dark);
+    --cbp-checkbox-color-bg-checked: var(--cbp-color-interactive-disabled-dark);
+    --cbp-checkbox-color-border-checked: var(--cbp-color-interactive-disabled-dark);
+    --cbp-checkbox-color-border-checked-hover: var(--cbp-color-interactive-disabled-dark);
+    --cbp-checkbox-color-halo-hover: transparent;
+    --cbp-checkbox-color-halo-checked-hover: transparent;
+    --cbp-checkbox-color-label: var(--cbp-color-interactive-disabled-dark);
+    
+    --cbp-checkbox-color-dark: var(--cbp-color-interactive-disabled-dark);
+    --cbp-checkbox-color-bg-dark: var(--cbp-color-interactive-disabled-dark);
+    --cbp-checkbox-color-border-dark: var(--cbp-color-interactive-disabled-light);
+    --cbp-checkbox-color-border-hover-dark: var(--cbp-color-interactive-disabled-light);
+    --cbp-checkbox-color-bg-checked-dark: var(--cbp-color-interactive-disabled-light);
+    --cbp-checkbox-color-border-checked-dark: var(--cbp-color-interactive-disabled-light);
+    --cbp-checkbox-color-border-checked-hover-dark: var(--cbp-color-interactive-disabled-light);
+    --cbp-checkbox-color-halo-hover-dark: transparent;
+    --cbp-checkbox-color-halo-checked-hover-dark: transparent;
+    --cbp-checkbox-color-label-dark: var(--cbp-color-interactive-disabled-light);
+  }
+}
+
+
+/*
+  &:has(input:hover) {
+    --cbp-checkbox-color-border: var(--cbp-checkbox-color-border-hover);
+    //--cbp-checkbox-color-border-dark: var(--cbp-checkbox-color-border-hover-dark);
+    --cbp-checkbox-color-halo: var(--cbp-checkbox-color-halo-hover);
+    //--cbp-checkbox-color-halo-dark: var(--cbp-checkbox-color-border-hover-dark);
+  }
+
+  &:has(input:focus) {
+    --cbp-checkbox-color-border: var(--cbp-checkbox-color-border-focus);
+    //--cbp-checkbox-color-border-dark: var(--cbp-checkbox-color-border-focus-dark);
+    --cbp-checkbox-color-halo: var(--cbp-checkbox-color-halo-focus);
+    //--cbp-checkbox-color-halo-dark: var(--cbp-checkbox-color-border-focus-dark);
+    //border-color: var(--cbp-color-interactive-focus-dark);
+    //box-shadow: 0 0 0 8px var(--cbp-color-interactive-focus-light);
+    //clip-path: circle(80%);
+    //outline: 0;
+  }
+*/
+
+/*
+    //vertical-align: middle;
+
+    &:checked {
+      border-color: var(--cbp-color-interactive-selected-dark);
+      background-color: var(--cbp-color-interactive-selected-dark);
+      color: var(--cbp-color-white);
+
+      // Check Mark
+      &::before {
+        border-right-color: var(--cbp-color-white);
+        border-right-style: solid;
+        border-right-width: var(--cbp-border-size-lg);
+        border-bottom-color: (--cbp-color-white);
+        border-bottom-style: solid;
+        border-bottom-width: var(--cbp-border-size-lg);
+        height: 70%;
+        width: 30%;
+        transform: rotate(45deg) translateY(-10%) translateX(-10%);
+      }
+
+      &:hover {
+        box-shadow: 0 0 0 8px var(--cbp-color-interactive-selected-light);
+        clip-path: circle(80%);
+      }
+
+      &:focus {
+        background-color: var(--cbp-color-interactive-focus-dark);
+        border-color: var(--cbp-color-white); // TODO: Discuss color change for this
+      }
+
+    }
+  }
+
+  &:hover {
+    box-shadow: 0 0 0 8px rgba(230, 230, 226, 0.5); // $cbp-ui-neutral-lighter
+    clip-path: circle(80%);
+  }
+  
+  &:focus {
+    border-color: var(--cbp-color-interactive-focus-dark);
+    box-shadow: 0 0 0 8px var(--cbp-color-interactive-focus-light);
+    clip-path: circle(80%);
+    outline: 0;
+
+    &:hover {
+      box-shadow: 0 0 0 8px var(--cbp-color-interactive-focus-light);
+      clip-path: circle(80%);
+    }
+	}
+}
+*/

--- a/packages/web-components/src/components/cbp-checkbox/cbp-checkbox.scss
+++ b/packages/web-components/src/components/cbp-checkbox/cbp-checkbox.scss
@@ -1,5 +1,39 @@
 /**
- *
+ * @prop --cbp-checkbox-color: var(--cbp-color-text-lightest);
+ * @prop --cbp-checkbox-color-bg: var(--cbp-color-white);
+ * @prop --cbp-checkbox-color-border: var(--cbp-color-interactive-secondary-dark);
+ * @prop --cbp-checkbox-color-border-hover: var(--cbp-color-interactive-secondary-darker);
+ * @prop --cbp-checkbox-color-border-focus: var(--cbp-color-interactive-focus-dark);
+ * @prop --cbp-checkbox-color-halo: transparent;
+ * @prop --cbp-checkbox-color-halo-hover: var(--cbp-color-interactive-secondary-lighter);
+ * @prop --cbp-checkbox-color-halo-focus: var(--cbp-color-interactive-focus-light);
+ * @prop --cbp-checkbox-color-bg-checked: var(--cbp-color-interactive-selected-dark);
+ * @prop --cbp-checkbox-color-bg-checked-focus: var(--cbp-color-interactive-focus-dark);
+ * @prop --cbp-checkbox-color-border-checked: var(--cbp-color-interactive-selected-dark);
+ * @prop --cbp-checkbox-color-border-checked-hover: var(--cbp-color-interactive-selected-dark);
+ * @prop --cbp-checkbox-color-border-checked-focus: var(--cbp-color-white);
+ * @prop --cbp-checkbox-color-halo-checked-hover: var(--cbp-color-interactive-selected-light);
+ * @prop --cbp-checkbox-color-halo-checked-focus: var(--cbp-color-interactive-focus-light);
+ * @prop --cbp-checkbox-color-label: var(--cbp-color-text-darkest);
+
+ * @prop --cbp-checkbox-color-dark: var(--cbp-color-text-darkest);
+ * @prop --cbp-checkbox-color-bg-dark: var(--cbp-color-gray-cool-70);
+ * @prop --cbp-checkbox-color-border-dark: var(--cbp-color-interactive-secondary-light);
+ * @prop --cbp-checkbox-color-border-hover-dark: var(--cbp-color-interactive-secondary-lighter);
+ * @prop --cbp-checkbox-color-border-focus-dark: var(--cbp-color-interactive-focus-light);
+ * @prop --cbp-checkbox-color-halo-dark: transparent;
+ * @prop --cbp-checkbox-color-halo-hover-dark: var(--cbp-color-text-darker);
+ * @prop --cbp-checkbox-color-halo-focus-dark: var(--cbp-color-interactive-focus-dark);
+ * @prop --cbp-checkbox-color-bg-checked-dark: var(--cbp-color-interactive-selected-light);
+ * @prop --cbp-checkbox-color-bg-checked-focus-dark: var(--cbp-color-interactive-focus-light);
+ * @prop --cbp-checkbox-color-border-checked-dark: var(--cbp-color-interactive-selected-light);
+ * @prop --cbp-checkbox-color-border-checked-hover-dark: var(--cbp-color-interactive-selected-light);
+ * @prop --cbp-checkbox-color-border-checked-focus-dark: var(--cbp-color-black);
+ * @prop --cbp-checkbox-color-halo-checked-hover-dark: var(--cbp-color-interactive-selected-dark);
+ * @prop --cbp-checkbox-color-halo-checked-focus-dark: var(--cbp-color-interactive-focus-dark);
+ * @prop --cbp-checkbox-color-label-dark: var(--cbp-color-text-lightest);
+
+ * @prop --cbp-checkbox-margin: 0 0 var(--cbp-space-1x) 0;
  */
 :root {
   --cbp-checkbox-color: var(--cbp-color-text-lightest);
@@ -18,7 +52,6 @@
   --cbp-checkbox-color-halo-checked-hover: var(--cbp-color-interactive-selected-light);
   --cbp-checkbox-color-halo-checked-focus: var(--cbp-color-interactive-focus-light);
   --cbp-checkbox-color-label: var(--cbp-color-text-darkest);
-
 
   --cbp-checkbox-color-dark: var(--cbp-color-text-darkest);
   --cbp-checkbox-color-bg-dark: var(--cbp-color-gray-cool-70);
@@ -66,12 +99,10 @@
 cbp-checkbox {
   display: block;
   margin: var(--cbp-checkbox-margin);
-  //min-height: var(--cbp-space-11x);
 
   label {
     display: flex;
     align-items: center;
-    //gap: var(--cbp-space-2x);
     min-height: var(--cbp-space-11x);
     font-weight: var(--cbp-font-weight-bold);
     color: var(--cbp-checkbox-color-label);
@@ -183,77 +214,3 @@ cbp-checkbox {
     --cbp-checkbox-color-label-dark: var(--cbp-color-interactive-disabled-light);
   }
 }
-
-
-/*
-  &:has(input:hover) {
-    --cbp-checkbox-color-border: var(--cbp-checkbox-color-border-hover);
-    //--cbp-checkbox-color-border-dark: var(--cbp-checkbox-color-border-hover-dark);
-    --cbp-checkbox-color-halo: var(--cbp-checkbox-color-halo-hover);
-    //--cbp-checkbox-color-halo-dark: var(--cbp-checkbox-color-border-hover-dark);
-  }
-
-  &:has(input:focus) {
-    --cbp-checkbox-color-border: var(--cbp-checkbox-color-border-focus);
-    //--cbp-checkbox-color-border-dark: var(--cbp-checkbox-color-border-focus-dark);
-    --cbp-checkbox-color-halo: var(--cbp-checkbox-color-halo-focus);
-    //--cbp-checkbox-color-halo-dark: var(--cbp-checkbox-color-border-focus-dark);
-    //border-color: var(--cbp-color-interactive-focus-dark);
-    //box-shadow: 0 0 0 8px var(--cbp-color-interactive-focus-light);
-    //clip-path: circle(80%);
-    //outline: 0;
-  }
-*/
-
-/*
-    //vertical-align: middle;
-
-    &:checked {
-      border-color: var(--cbp-color-interactive-selected-dark);
-      background-color: var(--cbp-color-interactive-selected-dark);
-      color: var(--cbp-color-white);
-
-      // Check Mark
-      &::before {
-        border-right-color: var(--cbp-color-white);
-        border-right-style: solid;
-        border-right-width: var(--cbp-border-size-lg);
-        border-bottom-color: (--cbp-color-white);
-        border-bottom-style: solid;
-        border-bottom-width: var(--cbp-border-size-lg);
-        height: 70%;
-        width: 30%;
-        transform: rotate(45deg) translateY(-10%) translateX(-10%);
-      }
-
-      &:hover {
-        box-shadow: 0 0 0 8px var(--cbp-color-interactive-selected-light);
-        clip-path: circle(80%);
-      }
-
-      &:focus {
-        background-color: var(--cbp-color-interactive-focus-dark);
-        border-color: var(--cbp-color-white); // TODO: Discuss color change for this
-      }
-
-    }
-  }
-
-  &:hover {
-    box-shadow: 0 0 0 8px rgba(230, 230, 226, 0.5); // $cbp-ui-neutral-lighter
-    clip-path: circle(80%);
-  }
-  
-  &:focus {
-    border-color: var(--cbp-color-interactive-focus-dark);
-    box-shadow: 0 0 0 8px var(--cbp-color-interactive-focus-light);
-    clip-path: circle(80%);
-    outline: 0;
-
-    &:hover {
-      box-shadow: 0 0 0 8px var(--cbp-color-interactive-focus-light);
-      clip-path: circle(80%);
-    }
-	}
-}
-*/

--- a/packages/web-components/src/components/cbp-checkbox/cbp-checkbox.specs.mdx
+++ b/packages/web-components/src/components/cbp-checkbox/cbp-checkbox.specs.mdx
@@ -1,0 +1,39 @@
+import { Meta } from '@storybook/addon-docs';
+
+<Meta title="Components/Checkbox/Specifications" />
+
+# cbp-checkbox
+
+## Purpose
+
+The Checkbox component wraps the slotted native form control (`input type="checkbox"`) and label text, providing cross-browser styling.
+
+## Functional Requirements
+
+* The Checkbox component accepts the native form control (`input type="checkbox"`) and its label as slotted content, wrapping them in an implicit label.
+* The Checkbox component provides cross-browser styling for the form control in its various states, including hover, focus, disabled, and checked states.
+
+## Technical Specifications
+
+### User Interactions
+
+* The user interactions are that of a native checkbox (`input type="checkbox"`) element:
+  * Clicking anywhere on the form control or label text will place focus on the control and toggle its state.
+  * Checkboxes are keyboard accessible by tabbing onto them in either direction, placing focus onto the native form control.
+  * Pressing the spacebar will toggle the focused checkbox state, also emitting a custom event.
+
+### Responsiveness
+
+* The checkbox label will wrap as needed.
+
+### Accessibility
+
+* The native checkbox (`input type="checkbox"`) element and label text are wrapped within a `label` tag, forming an implicit label association (no `id` needed).
+* Full keyboard navigation is supported, as detailed under "User Interactions" above.
+
+### Additional Notes and Considerations
+
+* This component may manage the checkbox's disabled state, but does its best to get out of the way if the application wants to manage those states directly on the slotted elements.
+* A checkbox's value is only included in the submitted form data if the checkbox is checked. If it is, then the value of the checkbox's value attribute is reported as the input's value, or "on" if no value is set.
+* Firefox (alone) persists the dynamic checked state of an `input` across page loads. Use the autocomplete attribute to control this feature.
+* Native checkbox elements may not be `readonly` - only `disabled`.

--- a/packages/web-components/src/components/cbp-checkbox/cbp-checkbox.stories.tsx
+++ b/packages/web-components/src/components/cbp-checkbox/cbp-checkbox.stories.tsx
@@ -1,0 +1,59 @@
+export default {
+  title: 'Components/Checkbox',
+  tags: ['autodocs'],
+  argTypes: {
+    label: {
+      name: 'label (slotted)',
+      description: 'Label text (slotted) for the checkbox.',
+      control: 'text',
+    },
+    name: {
+      description: 'Specifies the `name` attribute of the slotted checkbox.',
+      control: 'text',
+    },
+    value: {
+      description: 'Specifies the `value` attribute of the slotted checkbox.',
+      control: 'text',
+    },
+    checked: {
+      description: 'Specifies the `checked` attribute of the slotted checkbox, which represents its initial checked state only.',
+      control: 'boolean',
+    },
+    disabled: {
+      description: 'Renders the checkbox in a disabled state. A disabled form control does not pass a value on native submit.',
+      control: 'boolean',
+    },
+    context : {
+      control: 'select',
+      options: [ "light-inverts", "light-always", "dark-inverts", "dark-always"]
+    },
+    sx: {
+      description: 'Supports adding inline styles as an object of key-value pairs comprised of CSS properties and values. Values should reference design tokens when possible.',
+      control: 'object',
+    },
+  },
+};
+
+const Template = ({ label, name, value, checked, disabled, context, sx }) => {
+  return ` 
+      <cbp-checkbox
+        ${value ? `value=${value}` : ''}
+        ${disabled ? `disabled=${disabled}` : ''}
+        ${context && context != 'light-inverts' ? `context=${context}` : ''}
+        ${sx ? `sx=${JSON.stringify(sx)}` : ''}
+      >
+        <input 
+          type="checkbox" 
+          name="${name}"
+          value="${value}"
+          ${checked ? `checked=${checked}` : ''}
+        />
+        ${label}
+      </cbp-checkbox>
+    `;
+};
+
+export const Checkbox = Template.bind({});
+Checkbox.args = {
+  label: "Checkbox label"
+}

--- a/packages/web-components/src/components/cbp-checkbox/cbp-checkbox.tsx
+++ b/packages/web-components/src/components/cbp-checkbox/cbp-checkbox.tsx
@@ -64,7 +64,7 @@ export class CbpCheckbox {
     });
 
     // query the DOM for the slotted form field and wire it up for accessibility and attach an event listener to it
-    this.formField = this.host.querySelector('input,select,textarea');
+    this.formField = this.host.querySelector('input[type=checkbox]');
 
     if (this.formField) {
       this.formField.addEventListener('change', this.handleChange());

--- a/packages/web-components/src/components/cbp-checkbox/cbp-checkbox.tsx
+++ b/packages/web-components/src/components/cbp-checkbox/cbp-checkbox.tsx
@@ -1,0 +1,91 @@
+import { Component, Element, Prop, Event, EventEmitter, Watch, Host, h } from '@stencil/core';
+import { setCSSProps} from '../../utils/utils';
+
+
+/**
+ * @slot - the checkbox control and label text goes in the default slot, both of which are placed inside of the `label` element. The label should not include excessively long descriptive text.
+ */
+@Component({
+  tag: 'cbp-checkbox',
+  styleUrl: 'cbp-checkbox.scss'
+})
+export class CbpCheckbox {
+
+  //private checkbox: any; // HTMLButtonElement or HTMLAnchorElement
+  private formField: any;
+
+  @Element() host: HTMLElement;
+
+  /** The `name` attribute of the checkbox, which is passed as part of formData (as a key) only when the checkbox is checked. */
+  @Prop() name: string;
+
+  /** The `value` attribute of the checkbox, which is passed as part of formData (as a value) only when the checkbox is checked. */
+  @Prop() value: string;
+
+  /** Marks the checkbox as checked by default when specified. */
+  @Prop() checked: boolean;
+
+  /** Marks the checkbox in a disabled state when specified. */
+  @Prop() disabled: boolean;
+
+  /** Specifies the context of the component as it applies to the visual design and whether it inverts when light/dark mode is toggled. Default behavior is "light-inverts" and does not have to be specified. */
+  @Prop({ reflect: true }) context: 'light-inverts' | 'light-always' | 'dark-inverts' | 'dark-always';
+
+  /** Supports adding inline styles as an object */
+  @Prop() sx: any = {};
+
+
+  /** A custom event emitted when the click event occurs for either a rendered button or anchor/link. */
+  @Event() stateChanged: EventEmitter;
+  handleChange() {
+    this.stateChanged.emit({
+      host: this.host,
+      nativeElement: this.formField,
+      value: this.formField.value,
+      checked: this.formField.checked
+    });
+  }
+
+  @Watch('disabled')
+  watchDisabledHandler(newValue: boolean) {
+    if (this.formField) {
+      (newValue) 
+        ? this.formField.setAttribute('disabled', '')
+        : this.formField.removeAttribute('disabled');
+    }
+  }
+
+  componentWillLoad() {
+    if (typeof this.sx == 'string') {
+      this.sx = JSON.parse(this.sx) || {};
+    }
+    setCSSProps(this.host, {
+      ...this.sx,
+    });
+
+    // query the DOM for the slotted form field and wire it up for accessibility and attach an event listener to it
+    this.formField = this.host.querySelector('input,select,textarea');
+
+    if (this.formField) {
+      this.formField.addEventListener('change', this.handleChange());
+    }
+  }
+
+  componentDidLoad() {
+    // Set the disabled state on load only if true. (The Watch decorators only listen for changes, not initial state)
+    if (!!this.formField) {
+      if (this.disabled) this.formField.setAttribute('disabled', '');
+    }
+  }
+
+  render() {
+    return (
+      <Host>
+        <label>
+          <slot />
+        </label>
+      </Host>
+    );
+  }
+
+}


### PR DESCRIPTION
* First cut of cbp-checkbox component
* Basic story for single checkbox. Checklists are a different beast that I'll be addressing separately in a later push (requires updates to `cbp-form-field`)

The majority of this effort was getting the CSS working for all those states and checked combinations. Base component functionality works very similar to `cbp-form-field` but may be revisited for code sharing with radio buttons.