### PR TITLE
Add indeterminate state to checkbox, other tweaks.

### DIFF
--- a/packages/web-components/src/components/cbp-checkbox/cbp-checkbox.scss
+++ b/packages/web-components/src/components/cbp-checkbox/cbp-checkbox.scss
@@ -126,7 +126,7 @@ cbp-checkbox {
     box-shadow: 0 0 0 calc(var(--cbp-space-5x) / 2) var(--cbp-checkbox-color-halo);
     clip-path: circle(80%);
 
-    // Check Mark
+    // Check Mark/Dash
     &::before {
       content: '';
       position: absolute;
@@ -136,8 +136,6 @@ cbp-checkbox {
       bottom: 0;
       overflow: hidden;
       top: 0;
-      border-right: solid 0px var(--cbp-checkbox-color);
-      border-bottom: solid 0px var(--cbp-checkbox-color);
     }
 
     // Verified: only need to set the base variables with higher level tokens that are swapped for dark mode
@@ -151,18 +149,11 @@ cbp-checkbox {
       --cbp-checkbox-color-halo: var(--cbp-checkbox-color-halo-focus);
     }
 
-    &:checked {
+    
+    &:checked,
+    &:indeterminate {
       --cbp-checkbox-color-bg: var(--cbp-checkbox-color-bg-checked);
       --cbp-checkbox-color-border: var(--cbp-checkbox-color-border-checked);
-
-      // Check Mark
-      &::before {
-        border-right-width: var(--cbp-border-size-lg);
-        border-bottom-width: var(--cbp-border-size-lg);
-        height: 70%;
-        width: 30%;
-        transform: rotate(45deg) translateY(-10%) translateX(-10%);
-      }
 
       &:hover {
         --cbp-checkbox-color-border: var(--cbp-checkbox-color-border-checked-hover);
@@ -175,6 +166,27 @@ cbp-checkbox {
         --cbp-checkbox-color-halo: var(--cbp-checkbox-color-halo-checked-focus);
       }
     }
+
+    &:checked {
+      // Check Mark
+      &::before {
+        border-right: solid var(--cbp-border-size-lg) var(--cbp-checkbox-color);
+        border-bottom: solid var(--cbp-border-size-lg) var(--cbp-checkbox-color);
+        height: 70%;
+        width: 30%;
+        transform: rotate(45deg) translateY(-10%) translateX(-10%);
+      }
+    }
+    
+    &:indeterminate {
+      // Indeterminate dash
+      &::before {
+        border: solid var(--cbp-border-size-sm) var(--cbp-checkbox-color);
+        height: 0;
+        width: 60%;
+      }
+    }
+
   }
 
 

--- a/packages/web-components/src/components/cbp-checkbox/cbp-checkbox.stories.tsx
+++ b/packages/web-components/src/components/cbp-checkbox/cbp-checkbox.stories.tsx
@@ -19,6 +19,10 @@ export default {
       description: 'Specifies the `checked` attribute of the slotted checkbox, which represents its initial checked state only.',
       control: 'boolean',
     },
+    indeterminate: {
+      description: 'Sets the checkbox to indeterminate, which is only relevant to checkbox groupings.',
+      control: 'boolean',
+    },
     disabled: {
       description: 'Renders the checkbox in a disabled state. A disabled form control does not pass a value on native submit.',
       control: 'boolean',
@@ -34,11 +38,13 @@ export default {
   },
 };
 
-const Template = ({ label, name, value, checked, disabled, context, sx }) => {
+const Template = ({ label, name, value, checked, indeterminate, disabled, context, sx }) => {
   return ` 
       <cbp-checkbox
         ${value ? `value=${value}` : ''}
         ${disabled ? `disabled=${disabled}` : ''}
+        ${checked ? `checked=${checked}` : ''}
+        ${indeterminate ? `indeterminate=${indeterminate}` : ''}
         ${context && context != 'light-inverts' ? `context=${context}` : ''}
         ${sx ? `sx=${JSON.stringify(sx)}` : ''}
       >
@@ -55,5 +61,7 @@ const Template = ({ label, name, value, checked, disabled, context, sx }) => {
 
 export const Checkbox = Template.bind({});
 Checkbox.args = {
-  label: "Checkbox label"
+  label: "Checkbox label",
+  name: "checkbox",
+  value: "1",
 }

--- a/packages/web-components/src/components/cbp-checkbox/cbp-checkbox.tsx
+++ b/packages/web-components/src/components/cbp-checkbox/cbp-checkbox.tsx
@@ -12,7 +12,7 @@ import { setCSSProps} from '../../utils/utils';
 export class CbpCheckbox {
 
   //private checkbox: any; // HTMLButtonElement or HTMLAnchorElement
-  private formField: any;
+  private formField: HTMLInputElement;
 
   @Element() host: HTMLElement;
 
@@ -25,6 +25,9 @@ export class CbpCheckbox {
   /** Marks the checkbox as checked by default when specified. */
   @Prop() checked: boolean;
 
+  /** Marks the checkbox as checked by default when specified. */
+  @Prop() indeterminate: boolean;
+
   /** Marks the checkbox in a disabled state when specified. */
   @Prop() disabled: boolean;
 
@@ -35,9 +38,12 @@ export class CbpCheckbox {
   @Prop() sx: any = {};
 
 
+  //this.formField.indeterminate=true;
+
   /** A custom event emitted when the click event occurs for either a rendered button or anchor/link. */
   @Event() stateChanged: EventEmitter;
   handleChange() {
+    this.checked=this.formField.checked;
     this.stateChanged.emit({
       host: this.host,
       nativeElement: this.formField,
@@ -55,6 +61,11 @@ export class CbpCheckbox {
     }
   }
 
+  @Watch('indeterminate')
+  watchIndeterminateHandler(newValue: boolean) {
+    if (this.formField) this.formField.indeterminate=newValue;
+  }
+
   componentWillLoad() {
     if (typeof this.sx == 'string') {
       this.sx = JSON.parse(this.sx) || {};
@@ -67,13 +78,14 @@ export class CbpCheckbox {
     this.formField = this.host.querySelector('input[type=checkbox]');
 
     if (this.formField) {
-      this.formField.addEventListener('change', this.handleChange());
+      this.formField.addEventListener('change', () => this.handleChange());
     }
   }
 
   componentDidLoad() {
-    // Set the disabled state on load only if true. (The Watch decorators only listen for changes, not initial state)
+    // Set the disabled/indeterminate states on load only if true. (The Watch decorators only listen for changes, not initial state)
     if (!!this.formField) {
+      if (this.indeterminate) this.formField.indeterminate=this.indeterminate;
       if (this.disabled) this.formField.setAttribute('disabled', '');
     }
   }


### PR DESCRIPTION
* Add indeterminate state to checkbox and story.
* Fix `checked` property so that it stays in sync with the checked state and is part of the emitted event.
