### PR TITLE
update visited selector to not override other states

### DIFF
--- a/packages/web-components/src/components/cbp-link/cbp-link.scss
+++ b/packages/web-components/src/components/cbp-link/cbp-link.scss
@@ -61,7 +61,8 @@ cbp-link {
       text-decoration: underline;
     }
 
-    &:visited {
+    // &:visited { //TODO: original
+    &:visited:not(:hover):not(:active):not(:focus){
       color: var(--cbp-link-color-visited); //:visited restricts what properties can be set for security reasons , setting color directly to support visible change
     }
 


### PR DESCRIPTION
#### updating selector for visited links as to not override other states. Issue initially noticed on breadcrumbs lacking hover
