### PR TITLE
Feature/inline drawer

### DIFF
--- a/packages/web-components/src/components/cbp-dialog/cbp-dialog.stories.tsx
+++ b/packages/web-components/src/components/cbp-dialog/cbp-dialog.stories.tsx
@@ -77,7 +77,8 @@ const Template = ({ title, content, color, open, uid, accessibilityText, actions
     <cbp-button
       type="button"
       color="secondary"
-      accessibility-text="Open Drawer"
+      variant="square"
+      accessibility-text="Open Dialog"
       target-prop="open"
       controls=${uid}
     >

--- a/packages/web-components/src/components/cbp-drawer/cbp-drawer.scss
+++ b/packages/web-components/src/components/cbp-drawer/cbp-drawer.scss
@@ -12,7 +12,7 @@
 [data-cbp-theme=dark] cbp-drawer:not([context=dark-inverts]):not([context=light-always]) {
   --cbp-drawer-color-bg: var(--cbp-color-gray-cool-70);
 }
- 
+
 
 cbp-drawer {
   all: unset;
@@ -27,6 +27,10 @@ cbp-drawer {
   --cbp-panel-content-color-dark: var(--cbp-color-text-lightest);
   --cbp-panel-content-color-bg-dark: var(--cbp-color-gray-cool-70);
   --cbp-panel-content-color-border-dark: var(--cbp-color-gray-cool-60);
+
+  &.cbp-drawer--persistent {
+    display: block;
+  }
 
   .cbp-drawer__content {
     display: flex;
@@ -88,13 +92,15 @@ cbp-drawer[open] {
       }
     }
   }
+  
   .cbp-drawer__content {
     position: fixed;
+  }
 
-}
-
-@media (min-width: 37.5em) {
-  .cbp-drawer__content {
-    width: 25rem;
+  @media (min-width: 37.5em) {
+    .cbp-drawer__content {
+      width: 25rem;
+    }
   }
 }
+

--- a/packages/web-components/src/components/cbp-drawer/cbp-drawer.scss
+++ b/packages/web-components/src/components/cbp-drawer/cbp-drawer.scss
@@ -17,6 +17,7 @@
 cbp-drawer {
   all: unset;
   display: none;
+  position: relative;
   --cbp-panel-border-radius: 0;
   --cbp-panel-border-width: 0;
   // Use the panel CSS API to override the colors in dark mode for a specific drawer variant
@@ -26,23 +27,11 @@ cbp-drawer {
   --cbp-panel-content-color-dark: var(--cbp-color-text-lightest);
   --cbp-panel-content-color-bg-dark: var(--cbp-color-gray-cool-70);
   --cbp-panel-content-color-border-dark: var(--cbp-color-gray-cool-60);
-}
-
-cbp-drawer[open] {
-  display: block;
-  position: fixed;
-  top: 0;
-  right: 0;
-  bottom: 0;
-  left: 0;
-  z-index: calc(var(--cbp-z-index-level-top) - 1);
-  overflow-y: auto;
-  background-color: rgba(0, 0, 0, 0.3); // backdrop
 
   .cbp-drawer__content {
     display: flex;
     flex-direction: column;
-    position: fixed;
+    //position: fixed;
     top: 0;
     overflow-y: auto;
     z-index: var(--cbp-z-index-level-4);
@@ -65,6 +54,18 @@ cbp-drawer[open] {
       top: 1em;
     }
   }
+}
+
+cbp-drawer[open] {
+  display: block;
+  position: fixed;
+  top: 0;
+  right: 0;
+  bottom: 0;
+  left: 0;
+  z-index: calc(var(--cbp-z-index-level-top) - 1);
+  overflow-y: auto;
+  background-color: rgba(0, 0, 0, 0.3); // backdrop
   
   &[position='left'] {
     .cbp-drawer__content {
@@ -87,10 +88,13 @@ cbp-drawer[open] {
       }
     }
   }
+  .cbp-drawer__content {
+    position: fixed;
 
-  @media (min-width: 37.5em) {
-    .cbp-drawer__content {
-      width: 25rem;
-    }
+}
+
+@media (min-width: 37.5em) {
+  .cbp-drawer__content {
+    width: 25rem;
   }
 }

--- a/packages/web-components/src/components/cbp-drawer/cbp-drawer.scss
+++ b/packages/web-components/src/components/cbp-drawer/cbp-drawer.scss
@@ -42,7 +42,6 @@ cbp-drawer {
   .cbp-drawer__content {
     display: flex;
     flex-direction: column;
-    //position: fixed;
     top: 0;
     overflow-y: auto;
     z-index: var(--cbp-z-index-level-4);

--- a/packages/web-components/src/components/cbp-drawer/cbp-drawer.scss
+++ b/packages/web-components/src/components/cbp-drawer/cbp-drawer.scss
@@ -18,18 +18,25 @@ cbp-drawer {
   all: unset;
   display: none;
   position: relative;
-  --cbp-panel-border-radius: 0;
-  --cbp-panel-border-width: 0;
-  // Use the panel CSS API to override the colors in dark mode for a specific drawer variant
-  --cbp-panel-header-color-dark: var(--cbp-color-text-lighter);
-  --cbp-panel-header-color-bg-dark: var(--cbp-color-branding-dhs-blue);
-  --cbp-panel-header-color-bottom-border-dark: var(--cbp-color-gray-cool-50);
-  --cbp-panel-content-color-dark: var(--cbp-color-text-lightest);
-  --cbp-panel-content-color-bg-dark: var(--cbp-color-gray-cool-70);
-  --cbp-panel-content-color-border-dark: var(--cbp-color-gray-cool-60);
+
+  &:not(.cbp-drawer--persistent) {
+    --cbp-panel-border-radius: 0;
+    --cbp-panel-border-width: 0;
+    // Use the panel CSS API to override the colors in dark mode for a specific drawer variant
+    --cbp-panel-header-color-dark: var(--cbp-color-text-lighter);
+    --cbp-panel-header-color-bg-dark: var(--cbp-color-branding-dhs-blue);
+    --cbp-panel-header-color-bottom-border-dark: var(--cbp-color-gray-cool-50);
+    --cbp-panel-content-color-dark: var(--cbp-color-text-lightest);
+    --cbp-panel-content-color-bg-dark: var(--cbp-color-gray-cool-70);
+    --cbp-panel-content-color-border-dark: var(--cbp-color-gray-cool-60);
+  }
 
   &.cbp-drawer--persistent {
     display: block;
+
+    .cbp-drawer__content {
+      height: auto;
+    }
   }
 
   .cbp-drawer__content {

--- a/packages/web-components/src/components/cbp-drawer/cbp-drawer.specs.mdx
+++ b/packages/web-components/src/components/cbp-drawer/cbp-drawer.specs.mdx
@@ -16,6 +16,9 @@ The Drawer is a container that may be hidden and revealed, sliding in from eithe
 * The Drawer may slide in from either the left or right side of the viewport, taking up the full height of the viewport.
 * A backdrop covers the visible portion of the page behind the drawer.
 * Clicking the backdrop or the designated close button will close (hide) the drawer.
+* In some instances, it may be desirable for a panel to "mobilize" into a drawer at a certain smaller screen size. 
+  * In this case the drawer acts as a block element while persistent.
+  * While persistent, the Drawer cannot be closed.
 
 ## Technical Specifications
 
@@ -29,6 +32,10 @@ The Drawer is a container that may be hidden and revealed, sliding in from eithe
 
 * Under 600px (37.5rem), the Drawer takes 100% of the width of the viewport.
 * At larger viewport sizes, the Drawer renders at 25rem (400px at default font sizing) wide.
+* In some instances, it may be desirable for a panel to "mobilize" into a drawer at a certain smaller screen size.
+  * In this case, the drawer is considered "persistent" above a specified media query breakpoint and rendered as a block-level element..
+  * The media query breakpoint is set via the `persistAt` property.
+  * When this functionality is implemented, the drawer control should be hidden using the `cbp-hide` component with the same breakpoint as the `hideAt` value.
 
 ### Accessibility
 
@@ -39,6 +46,10 @@ The Drawer is a container that may be hidden and revealed, sliding in from eithe
 * When the drawer appears on the screen, keyboard focus should be moved to the default focusable control inside the drawer.
 * After the drawer is dismissed, keyboard focus should be moved back to where it was before it moved into the drawer. 
 * The expected behavior is that the drawer's tab order wraps.
+* When a drawer is persistent on-screen (not an overlay):
+  * Its `role` is changed to "region"
+  * The `aria-modal` attribute is removed.
+  * The "close" button is not rendered (and the drawer cannot be closed).
 
 ### Additional Notes and Considerations
 

--- a/packages/web-components/src/components/cbp-drawer/cbp-drawer.stories.tsx
+++ b/packages/web-components/src/components/cbp-drawer/cbp-drawer.stories.tsx
@@ -39,15 +39,19 @@ export default {
 
 const Template = ({ position, withIcon, open, persistAt, uid, accessibilityText, context, sx }) => {
   return `
-    <cbp-button
-      type="button"
-      color="secondary"
-      accessibility-text="Open Drawer"
-      target-prop="open"
-      controls=${uid}
+    <cbp-hide 
+      ${persistAt ? `hide-at=${persistAt}` : ''}
     >
-      <cbp-icon name="bars"></cbp-icon>
-    </cbp-button>
+      <cbp-button
+        type="button"
+        color="secondary"
+        accessibility-text="Open Drawer"
+        target-prop="open"
+        controls=${uid}
+      >
+        <cbp-icon name="bars"></cbp-icon>
+      </cbp-button>
+    </cbp-hide>
 
     <cbp-drawer
       ${position ? `position=${position}` : ''}
@@ -82,6 +86,7 @@ export const Drawer = Template.bind({});
 Drawer.args = {
   position: 'left',
   uid: 'drawer',
+  persistAt: 'min-width:50rem',
   context: 'light-always'
 };
 
@@ -101,7 +106,7 @@ const UserPreferencesTemplate = ({ position, open, persistAt, uid, accessibility
     <cbp-drawer
       ${position ? `position=${position}` : ''}
       ${open ? `open=${open}` : ''}
-      ${persistAt ? `persist-at=${persistAt}` : ''}
+      ${persistAt ? `persist-at="${persistAt}"` : ''}
       ${accessibilityText ? `accessibility-text=${accessibilityText}` : ''}
       ${context && context != 'light-inverts' ? `context=${context}` : ''}
       ${sx ? `sx=${JSON.stringify(sx)}` : ''}

--- a/packages/web-components/src/components/cbp-drawer/cbp-drawer.stories.tsx
+++ b/packages/web-components/src/components/cbp-drawer/cbp-drawer.stories.tsx
@@ -10,6 +10,9 @@ export default {
     open: {
       description: 'Specifies whether the drawer is open or closed.',
       control: 'boolean',
+    },    
+    persistAt: {
+      control: 'text',
     },
     uid: {
       description: 'A unique `id` applied to the drawer and referenced by the control.',
@@ -19,6 +22,7 @@ export default {
       description: 'Accessibility text is required to label the drawer (dialog) and is applied as an `aria-label`.',
       control: 'text',
     },
+
     withIcon: {
       control: 'boolean',
     },
@@ -33,7 +37,7 @@ export default {
   },
 };
 
-const Template = ({ position, withIcon, open, uid, accessibilityText, context, sx }) => {
+const Template = ({ position, withIcon, open, persistAt, uid, accessibilityText, context, sx }) => {
   return `
     <cbp-button
       type="button"
@@ -48,6 +52,7 @@ const Template = ({ position, withIcon, open, uid, accessibilityText, context, s
     <cbp-drawer
       ${position ? `position=${position}` : ''}
       ${open ? `open=${open}` : ''}
+      ${persistAt ? `persist-at=${persistAt}` : ''}
       ${accessibilityText ? `accessibility-text=${accessibilityText}` : ''}
       ${context && context != 'light-inverts' ? `context=${context}` : ''}
       ${sx ? `sx=${JSON.stringify(sx)}` : ''}
@@ -81,7 +86,7 @@ Drawer.args = {
 };
 
 
-const UserPreferencesTemplate = ({ position, open, uid, accessibilityText, withIcon, context, sx }) => {
+const UserPreferencesTemplate = ({ position, open, persistAt, uid, accessibilityText, withIcon, context, sx }) => {
   return `
     <cbp-button
       type="button"
@@ -96,6 +101,7 @@ const UserPreferencesTemplate = ({ position, open, uid, accessibilityText, withI
     <cbp-drawer
       ${position ? `position=${position}` : ''}
       ${open ? `open=${open}` : ''}
+      ${persistAt ? `persist-at=${persistAt}` : ''}
       ${accessibilityText ? `accessibility-text=${accessibilityText}` : ''}
       ${context && context != 'light-inverts' ? `context=${context}` : ''}
       ${sx ? `sx=${JSON.stringify(sx)}` : ''}

--- a/packages/web-components/src/components/cbp-drawer/cbp-drawer.stories.tsx
+++ b/packages/web-components/src/components/cbp-drawer/cbp-drawer.stories.tsx
@@ -45,6 +45,7 @@ const Template = ({ position, withIcon, open, persistAt, uid, accessibilityText,
       <cbp-button
         type="button"
         color="secondary"
+        variant="square"
         accessibility-text="Open Drawer"
         target-prop="open"
         controls=${uid}
@@ -86,7 +87,7 @@ export const Drawer = Template.bind({});
 Drawer.args = {
   position: 'left',
   uid: 'drawer',
-  persistAt: 'min-width:50rem',
+  //persistAt: 'min-width:64rem',
   context: 'light-always'
 };
 
@@ -96,6 +97,7 @@ const UserPreferencesTemplate = ({ position, open, persistAt, uid, accessibility
     <cbp-button
       type="button"
       color="secondary"
+      variant="square"
       accessibility-text="Open Drawer"
       target-prop="open"
       controls=${uid}

--- a/packages/web-components/src/components/cbp-drawer/cbp-drawer.tsx
+++ b/packages/web-components/src/components/cbp-drawer/cbp-drawer.tsx
@@ -88,7 +88,7 @@ export class CbpDrawer {
     if (mql.matches) {
       this.persistent = true;
     }
-    else {
+    else {  
       this.persistent = false;
     }
   }
@@ -131,7 +131,7 @@ export class CbpDrawer {
         <div
           ref={el => (this.drawer = el)}
           role={this.persistent ? "region" : "dialog"}
-          aria-modal={this.persistent ? false : "true"}
+          aria-modal={!this.persistent ? "true" : false}
           class="cbp-drawer__content"
           aria-label={this.accessibilityText}
           tabindex="-1"

--- a/packages/web-components/src/components/cbp-drawer/cbp-drawer.tsx
+++ b/packages/web-components/src/components/cbp-drawer/cbp-drawer.tsx
@@ -23,7 +23,7 @@ export class CbpDrawer {
   /** Creates an accessible label for the drawer (dialog). */
   @Prop() accessibilityText: string;
 
-  /** Specifies a valid CSS media query (preferably using relative units), when met will hide the wrapped content using display: none. E.g., `max-width: 64em` */
+  /** Specifies a valid CSS media query (preferably using relative units), when met will hide the wrapped content using display: none. E.g., `min-width:64em` */
   @Prop() persistAt: string;
 
   /** Specifies the context of the component as it applies to the visual design and whether it inverts when light/dark mode is toggled. Default behavior is "light-inverts" and does not have to be specified. */

--- a/packages/web-components/src/components/cbp-drawer/cbp-drawer.tsx
+++ b/packages/web-components/src/components/cbp-drawer/cbp-drawer.tsx
@@ -1,4 +1,4 @@
-import { Component, Prop, Element, Event, EventEmitter, Method, Watch, Host, h } from '@stencil/core';
+import { Component, Prop, Element, Event, EventEmitter, Method, Watch, Host, h, State } from '@stencil/core';
 import { setCSSProps, getFocusableElements } from '../../utils/utils';
 
 @Component({
@@ -32,10 +32,13 @@ export class CbpDrawer {
   /** Supports adding inline styles as an object */
   @Prop() sx: any = {};
 
+  @State() persistent: boolean = false;
+
   /** Custom event fired when the drawer is opened. */
   @Event() drawerOpen!: EventEmitter;
   /** Custom event fired when the drawer is closed. */
   @Event() drawerClose!: EventEmitter;
+
 
   @Watch('open')
   watchOpenHandler(newValue: boolean) {
@@ -84,10 +87,12 @@ export class CbpDrawer {
   // Callback functions for the media query event listeners
   doPersistAt(mql) {
     if (mql.matches) {
-      this.host.style.setProperty('display', 'block')
+      //this.host.style.setProperty('display', 'block');
+      this.persistent = true;
     }
     else {
-      this.host.style.setProperty('display', this.open ? 'fixed' : 'none');
+      //this.host.style.setProperty('display', this.open ? 'fixed' : 'none');
+      this.persistent = false;
     }
   }
 
@@ -121,16 +126,20 @@ export class CbpDrawer {
 
   render() {
     return (
-      <Host onClick={e => this.handleBackdropClick(e)} onKeyUp={e => this.handleKeyUp(e)} id={this.uid}>
+      <Host 
+        class={this.persistent ? "cbp-drawer--persistent" : ""}
+        onClick={e => this.handleBackdropClick(e)} 
+        onKeyUp={e => this.handleKeyUp(e)} id={this.uid}
+      >
         <div
           ref={el => (this.drawer = el)}
-          role="dialog"
-          aria-modal="true"
+          role={this.persistent ? "region" : "dialog"}
+          aria-modal={this.persistent ? false : "true"}
           class="cbp-drawer__content"
           aria-label={this.accessibilityText}
           tabindex="-1"
         >
-          <cbp-button
+          {!this.persistent && <cbp-button
             class="cbp-drawer__close-button"
             variant="square"
             type="button"
@@ -142,7 +151,7 @@ export class CbpDrawer {
             context="dark-always"
           >
             <cbp-icon name="circle-xmark" size="1rem"></cbp-icon>
-          </cbp-button>
+          </cbp-button>}
 
           <slot />
         </div>

--- a/packages/web-components/src/components/cbp-drawer/cbp-drawer.tsx
+++ b/packages/web-components/src/components/cbp-drawer/cbp-drawer.tsx
@@ -71,7 +71,6 @@ export class CbpDrawer {
         this.focusableElements = getFocusableElements(this.host);
       }
       this.focusableElements[0]?.focus();
-      //console.log(this.focusableElements,document.activeElement);
     }, 100);
   }
 
@@ -87,11 +86,9 @@ export class CbpDrawer {
   // Callback functions for the media query event listeners
   doPersistAt(mql) {
     if (mql.matches) {
-      //this.host.style.setProperty('display', 'block');
       this.persistent = true;
     }
     else {
-      //this.host.style.setProperty('display', this.open ? 'fixed' : 'none');
       this.persistent = false;
     }
   }

--- a/packages/web-components/src/components/cbp-drawer/cbp-drawer.tsx
+++ b/packages/web-components/src/components/cbp-drawer/cbp-drawer.tsx
@@ -23,6 +23,9 @@ export class CbpDrawer {
   /** Creates an accessible label for the drawer (dialog). */
   @Prop() accessibilityText: string;
 
+  /** Specifies a valid CSS media query (preferably using relative units), when met will hide the wrapped content using display: none. E.g., `max-width: 64em` */
+  @Prop() persistAt: string;
+
   /** Specifies the context of the component as it applies to the visual design and whether it inverts when light/dark mode is toggled. Default behavior is "light-inverts" and does not have to be specified. */
   @Prop({ reflect: true }) context: 'light-inverts' | 'light-always' | 'dark-inverts' | 'dark-always';
 
@@ -77,7 +80,27 @@ export class CbpDrawer {
     e.key == 'Escape' && this.closeDrawer();
   }
 
+
+  // Callback functions for the media query event listeners
+  doPersistAt(mql) {
+    if (mql.matches) {
+      this.host.style.setProperty('display', 'block')
+    }
+    else {
+      this.host.style.setProperty('display', this.open ? 'fixed' : 'none');
+    }
+  }
+
+
   componentDidLoad() {
+    if (this.persistAt) {
+      const MQ = window?.matchMedia(`(${this.persistAt})`);
+      if (MQ) {
+        MQ.addEventListener('change', mql => this.doPersistAt(mql)); // Add an event listener to the media query
+        this.doPersistAt(MQ); // Run the breakpoint change handler once on load
+      }
+    }
+
     if (typeof this.sx == 'string') {
       this.sx = JSON.parse(this.sx) || {};
     }
@@ -89,10 +112,12 @@ export class CbpDrawer {
   }
 
   componentDidRender() {
+    // Support animation by doing it this way
     setTimeout(() => {
       this.open ? this.drawer.classList.add('cbp-drawer--open') : this.drawer.classList.remove('cbp-drawer--open');
     }, 10);
   }
+
 
   render() {
     return (

--- a/packages/web-components/src/stories/Archetype_Passenger.stories.tsx
+++ b/packages/web-components/src/stories/Archetype_Passenger.stories.tsx
@@ -1,49 +1,48 @@
 export default {
-    title: 'Archetypes/Passenger List',
-    parameters: {
-      layout: 'fullscreen',
-      html: {
-        root: '#storybook-root',
-      },
+  title: 'Archetypes/Passenger List',
+  parameters: {
+    layout: 'fullscreen',
+    html: {
+      root: '#storybook-root',
     },
-    argTypes: {
-    },
-    args: {
-      username: 'HASHIDX',
-      isLoggedIn: true,
-    },
-  };
+  },
+  argTypes: {},
+  args: {
+    username: 'HASHIDX',
+    isLoggedIn: true,
+  },
+};
 
-    // const passengerArchetypeList = HTMLCbpStructuredListElement;
-    //TODO: needs default values (currently hard set to component defaults) below is 'ideal' but DOM not rendered at this point
-      let page = 1; //document.getElementsByTagName('cbp-pagination')[0].page;
-      let pageSize: number | "all" = 10; //document.getElementsByTagName('cbp-pagination')[0].pageSize;
+// const passengerArchetypeList = HTMLCbpStructuredListElement;
+//TODO: needs default values (currently hard set to component defaults) below is 'ideal' but DOM not rendered at this point
+let page = 1; //document.getElementsByTagName('cbp-pagination')[0].page;
+let pageSize: number | 'all' = 10; //document.getElementsByTagName('cbp-pagination')[0].pageSize;
 
-    function getTimeDiff(date1, date2){
-      const timeDiff = Math.abs(date1 - date2);
-      const seconds = Math.floor(timeDiff / 1000);
-      const minutes = Math.floor(seconds / 60);
-      const hours = Math.floor(minutes / 60);
-      const days = Math.floor(hours / 24);
+function getTimeDiff(date1, date2) {
+  const timeDiff = Math.abs(date1 - date2);
+  const seconds = Math.floor(timeDiff / 1000);
+  const minutes = Math.floor(seconds / 60);
+  const hours = Math.floor(minutes / 60);
+  const days = Math.floor(hours / 24);
 
-      return {days, hours: hours % 24, minutes: minutes % 60, seconds: seconds % 60}
-    }
+  return { days, hours: hours % 24, minutes: minutes % 60, seconds: seconds % 60 };
+}
 
-    function generatePassengers(passengerArgs, page, pageSize) {
-      //TODO: update api call for img to have some variation see doc: https://www.dicebear.com/styles/personas/
-      //TODO: math on the time to arrival format isn't great but not sure how to setup obj to not have diff for days
-      
-      const html = passengerArgs.map(({name, bio, arrival, error }, index) => {
-      const timeDiff = getTimeDiff(Date.now(), arrival) 
-      const formatedTime = arrival.toLocaleString('en-US', {
-        timeZone: 'America/New_York',
-        timeZoneName: "short"
-      });
+function generatePassengers(passengerArgs, page, pageSize) {
+  //TODO: update api call for img to have some variation see doc: https://www.dicebear.com/styles/personas/
+  //TODO: math on the time to arrival format isn't great but not sure how to setup obj to not have diff for days
 
-      if(index >= ((page-1) * pageSize) && index < (page * pageSize)){
-        return `
+  const html = passengerArgs.map(({ name, bio, arrival, error }, index) => {
+    const timeDiff = getTimeDiff(Date.now(), arrival);
+    const formatedTime = arrival.toLocaleString('en-US', {
+      timeZone: 'America/New_York',
+      timeZoneName: 'short',
+    });
+
+    if (index >= (page - 1) * pageSize && index < page * pageSize) {
+      return `
           <cbp-structured-list-item
-            ${error ? `color=danger`: ``} 
+            ${error ? `color=danger` : ``} 
           >
             <cbp-grid
               grid-template-columns="14rem 1fr 12rem"
@@ -59,9 +58,7 @@ export default {
                 <cbp-flex direction="column" gap="var(--cbp-space-1x)">
                   <cbp-typography tag="h3">${name}</cbp-typography>
                   <cbp-tag> Arriving In: ${timeDiff.hours}:${timeDiff.minutes}: ${timeDiff.hours} </cbp-tag>
-                  ${error ?
-                     `<cbp-tag color="danger"> T-list</cbp-tag>`
-                    : ``}
+                  ${error ? `<cbp-tag color="danger"> T-list</cbp-tag>` : ``}
                 </cbp-flex>
               </cbp-flex>
               <cbp-flex direction="column" gap="var(--cbp-space-1x)">
@@ -88,19 +85,19 @@ export default {
                 </cbp-button>
               </cbp-grid-item>
             </cbp-grid>
-          </cbp-structured-list-item>`
-        }
-    });
-    return html.join('');
+          </cbp-structured-list-item>`;
     }
+  });
+  return html.join('');
+}
 
-    function generateManifest(manifestArgs){
-      //TODO: tag icon for gate is not correct 
+function generateManifest(manifestArgs) {
+  //TODO: tag icon for gate is not correct
 
-      const html = manifestArgs.map(({flight, arrivalTerminal, arrivalLocation, arrivalGate, arrivalTime, departureTerminal, departureLocation, departureTime, people, hotlist}) => {
-      const timeDiff = getTimeDiff(Date.now(), arrivalTime);
-      
-        return `
+  const html = manifestArgs.map(({ flight, arrivalTerminal, arrivalLocation, arrivalGate, arrivalTime, departureTerminal, departureLocation, departureTime, people, hotlist }) => {
+    const timeDiff = getTimeDiff(Date.now(), arrivalTime);
+
+    return `
           <cbp-card
             variant="decision"
             class="hydrated"
@@ -167,384 +164,371 @@ export default {
               >
             </div>
           </cbp-card>
-          `
-      });
-      return html.join('');
-    }
+          `;
+  });
+  return html.join('');
+}
 
-    function passengerList(passengerArgs){
- 
-      document.addEventListener('paginationChange', function(e) {
-        const paginationComponent = e.target as HTMLCbpPaginationElement;
-        const structuredListComponent = document.querySelector("#passengerList > div[role='list']");
-        page = paginationComponent.page;
-        pageSize = paginationComponent.pageSize;
-  
-        structuredListComponent.innerHTML = generatePassengers(passengerArgs, page, pageSize);
-      });
+function passengerList(passengerArgs) {
+  document.addEventListener('paginationChange', function (e) {
+    const paginationComponent = e.target as HTMLCbpPaginationElement;
+    const structuredListComponent = document.querySelector("#passengerList > div[role='list']");
+    page = paginationComponent.page;
+    pageSize = paginationComponent.pageSize;
 
-      return `
-      <cbp-flex-item flex-grow="1">
-            <cbp-flex
-              gap="1rem"
-              wrap="wrap"
-            >
-              <cbp-flex-item
-                align-self="flex-end"
-                flex-basis="20rem"
-                flex-shrink="1"
-              >
-                <cbp-form-field
-                  label="Sort By"
-                  field-id="filterResults"
-                  sx='{"margin":"0"}'
-                >
-                  <cbp-dropdown field-id="filterResults">
-                    <cbp-dropdown-item value="1">
-                      Closest to Arrival
-                    </cbp-dropdown-item>
-                    <cbp-dropdown-item value="2">
-                      Furthest from Arrival
-                    </cbp-dropdown-item>
-                    <cbp-dropdown-item value="3">
-                      Alphabetically
-                    </cbp-dropdown-item>
-                  </cbp-dropdown>
-                </cbp-form-field>
-              </cbp-flex-item>
-              <cbp-flex-item 
-                align-self="flex-end"
-                sx='{"margin-left":"auto"}'
-              >
+    structuredListComponent.innerHTML = generatePassengers(passengerArgs, page, pageSize);
+  });
+
+  return `
+    <cbp-flex-item flex-grow="1">
+      <cbp-flex
+        gap="1rem"
+        wrap="wrap"
+      >
+        <cbp-flex-item
+          align-self="flex-end"
+          flex-basis="20rem"
+          flex-shrink="1"
+        >
+          <cbp-form-field
+            label="Sort By"
+            field-id="filterResults"
+            sx='{"margin":"0"}'
+          >
+            <cbp-dropdown field-id="filterResults">
+              <cbp-dropdown-item value="1">
+                Closest to Arrival
+              </cbp-dropdown-item>
+              <cbp-dropdown-item value="2">
+                Furthest from Arrival
+              </cbp-dropdown-item>
+              <cbp-dropdown-item value="3">
+                Alphabetically
+              </cbp-dropdown-item>
+            </cbp-dropdown>
+          </cbp-form-field>
+        </cbp-flex-item>
+        <cbp-flex-item 
+          align-self="flex-end"
+          sx='{"margin-left":"auto"}'
+        >
+          <cbp-button
+            type="button"
+            fill="outline"
+            color="secondary"
+            target-prop="open"
+            controls="manifestDrawer"
+          >
+            <cbp-icon 
+              name="book"
+              sx='{"margin-right":"var(--cbp-space-2x)"}'
+              ></cbp-icon>Manifests
+          </cbp-button>
+        </cbp-flex-item>
+        <cbp-flex-item 
+          align-self="flex-end"
+        >
+          <cbp-button
+            type="button"
+            fill="outline"
+            color="secondary"
+          >
+            <cbp-icon 
+              name="book"
+              sx='{"margin-right":"var(--cbp-space-2x)"}'
+            ></cbp-icon>Refresh
+          </cbp-button>
+        </cbp-flex-item>
+      </cbp-flex>
+      <cbp-structured-list id="passengerList" header-id="list-header" striped  sx='{"margin-top":"var(--cbp-space-4x)"}'>
+        <div slot="cbp-structured-list-header" id="list-header">
+            XX Results - X filters Applied - Updated : 11/01/2024 10:00 EST 
+        </div>
+        ${generatePassengers(passengerArgs, page, pageSize)}
+
+      </cbp-structured-list>
+        <cbp-pagination
+          records=${passengerArgs.length}
+        >
+          <cbp-form-field
+            slot="cbp-pagination-items-per-page"
+            label="Items Per Page"
+            field-id="pagination_size"
+          >
+            <cbp-dropdown field-id="pagination_size">
+              <cbp-dropdown-item value="10">10/Page</cbp-dropdown-item>
+              <cbp-dropdown-item value="25">25/Page</cbp-dropdown-item>
+              <cbp-dropdown-item value="50">50/Page</cbp-dropdown-item>
+              <cbp-dropdown-item value="100">100/Page</cbp-dropdown-item>
+              <cbp-dropdown-item value="all">All Results</cbp-dropdown-item>
+            </cbp-dropdown>
+          </cbp-form-field>
+
+          <cbp-form-field
+            slot="cbp-pagination-pages"
+            label="Page Displayed"
+            field-id="pagination_pages"
+          >
+            <cbp-dropdown field-id="pagination_pages">
+
+              <div slot="cbp-dropdown-attached-button-start">
                 <cbp-button
-                  type="button"
-                  fill="outline"
+                  fill="solid"
                   color="secondary"
-                  target-prop="open"
-                  controls="manifestDrawer"
+                  variant="square"
+                  value="previous page"
+                  accessibility-text="Previous page"
                 >
-                  <cbp-icon 
-                    name="book"
-                    sx='{"margin-right":"var(--cbp-space-2x)"}'
-                    ></cbp-icon>Manifests
+                  <cbp-icon name="chevron-right" rotate="180" />
                 </cbp-button>
-              </cbp-flex-item>
-              <cbp-flex-item 
-                align-self="flex-end"
-              >
-                <cbp-button
-                  type="button"
-                  fill="outline"
-                  color="secondary"
-                >
-                  <cbp-icon 
-                    name="book"
-                    sx='{"margin-right":"var(--cbp-space-2x)"}'
-                  ></cbp-icon>Refresh
-                </cbp-button>
-              </cbp-flex-item>
-            </cbp-flex>
-            <cbp-structured-list id="passengerList" header-id="list-header" striped  sx='{"margin-top":"var(--cbp-space-4x)"}'>
-              <div slot="cbp-structured-list-header" id="list-header">
-                 XX Results - X filters Applied - Updated : 11/01/2024 10:00 EST 
               </div>
-              ${
-                generatePassengers(passengerArgs, page, pageSize)
-              }
 
-            </cbp-structured-list>
-              <cbp-pagination
-                records=${passengerArgs.length}
+              <div slot="cbp-dropdown-attached-button-end">
+                <cbp-button
+                  fill="solid"
+                  color="secondary"
+                  variant="square"
+                  value="next page"
+                  accessibility-text="Next page"
+                >
+                  <cbp-icon name="chevron-right" />
+                </cbp-button>
+              </div>
+            </cbp-dropdown>
+          </cbp-form-field>
+        </cbp-pagination>
+
+    </cbp-flex-item>
+  `;
+}
+
+
+function filterPanel() {
+  return `
+    <cbp-drawer
+      position="left"
+      persist-at="min-width:37.5rem"
+    >
+      <cbp-panel
+        aria-labelledby="panelheader"
+        role="complementary"
+      >
+        <cbp-typography
+          slot="cbp-panel-header"
+          tag="h3"
+          variant="heading-lg"
+          id="panelheader"
+        >
+          Sidebar Header
+        </cbp-typography>
+          
+        <cbp-form-field
+          label="Search"
+          field-id="search"
+        >
+          <cbp-form-field-wrapper>
+            <input
+              type="search"
+              name="search"
+            />
+            <span slot="cbp-form-field-attached-button">
+              <cbp-button
+                type="submit"
+                fill="solid"
+                color="secondary"
+                variant="square"
+                accessibility-text="Search"
               >
-                <cbp-form-field
-                  slot="cbp-pagination-items-per-page"
-                  label="Items Per Page"
-                  field-id="pagination_size"
+                <cbp-icon
+                  name="magnifying-glass"
+                  size="1rem"
+                ></cbp-icon>
+              </cbp-button>
+            </span>
+          </cbp-form-field-wrapper>
+        </cbp-form-field>
+
+        <cbp-form-field group
+          label='Passenger Sex'
+          description='Required'
+        >
+          <cbp-flex
+            gap="var(--cbp-space-5x)"
+            breakpoint="28rem"
+            sx='{"width":"max-content"}'
+          >
+            <cbp-radio>
+              <input type="radio" name="sex" value="Male" /> Male
+            </cbp-radio>
+            <cbp-radio>
+              <input type="radio" name="sex" value="Female" /> Female
+            </cbp-radio>
+            <cbp-radio>
+              <input type="radio" name="sex" value="Other" /> Other
+            </cbp-radio>
+          </cbp-flex>
+        </cbp-form-field>
+
+        <cbp-form-field
+          label="Passenger Age Range"
+        >
+          <cbp-form-field-wrapper>
+            <input
+              type="range"
+              name="textinput"
+            />
+          </cbp-form-field-wrapper>
+        </cbp-form-field>
+
+        <cbp-form-field
+          label="Country that Issued Passport"
+          description="Required."
+        >
+          <select name="select">
+            <option value="">United States of America</option>
+            <option value="1">Option 1</option>
+            <option value="2">Option 2</option>
+            <option value="3">Option 3</option>
+            <option value="4">Option 4</option>
+            <option value="5">Option 5</option>
+          </select>
+        </cbp-form-field>
+
+        <cbp-form-field
+          label="Port of Departure"
+          description="Required."
+        >
+          <select name="select">
+            <option value="">Any</option>
+            <option value="1">Option 1</option>
+            <option value="2">Option 2</option>
+            <option value="3">Option 3</option>
+            <option value="4">Option 4</option>
+            <option value="5">Option 5</option>
+          </select>
+        </cbp-form-field>
+
+        <cbp-form-field
+          label="Port of Arrival"
+          description="Required."
+        >
+          <select name="select">
+            <option value="">JFK (XXXX/SM)</option>
+            <option value="1">Option 1</option>
+            <option value="2">Option 2</option>
+            <option value="3">Option 3</option>
+            <option value="4">Option 4</option>
+            <option value="5">Option 5</option>
+          </select>
+        </cbp-form-field>
+
+        <cbp-form-field
+          label="Arrival Date Range From:"
+          description="(MM/DD/YYYY) Format"
+        >
+          <cbp-form-field-wrapper>
+            <input
+              type="date"
+              name="textinput"
+            />
+          </cbp-form-field-wrapper>
+        </cbp-form-field>
+
+        <cbp-form-field
+          label="Arrival Time Range From:"
+          description="(HH:MM Format) UTC-6 America/New York."
+        >
+          <cbp-form-field-wrapper>
+            <input
+              type="time"
+            />
+            <span slot="cbp-form-field-overlay-start">
+            <cbp-icon name="book"></cbp-icon>
+            </span>
+
+            <cbp-segmented-button-group slot="cbp-form-field-attached-button">
+              <cbp-button
+                fill="outline"
+                color="secondary"
                 >
-                  <cbp-dropdown field-id="pagination_size">
-                    <cbp-dropdown-item value="10">10/Page</cbp-dropdown-item>
-                    <cbp-dropdown-item value="25">25/Page</cbp-dropdown-item>
-                    <cbp-dropdown-item value="50">50/Page</cbp-dropdown-item>
-                    <cbp-dropdown-item value="100">100/Page</cbp-dropdown-item>
-                    <cbp-dropdown-item value="all">All Results</cbp-dropdown-item>
-                  </cbp-dropdown>
-                </cbp-form-field>
+                AM
+              </cbp-button>
 
-                <cbp-form-field
-                  slot="cbp-pagination-pages"
-                  label="Page Displayed"
-                  field-id="pagination_pages"
+              <cbp-button
+                fill="outline"
+                color="secondary"
                 >
-                  <cbp-dropdown field-id="pagination_pages">
+                PM
+              </cbp-button>
 
-                    <div slot="cbp-dropdown-attached-button-start">
-                      <cbp-button
-                        fill="solid"
-                        color="secondary"
-                        variant="square"
-                        value="previous page"
-                        accessibility-text="Previous page"
-                      >
-                        <cbp-icon name="chevron-right" rotate="180" />
-                      </cbp-button>
-                    </div>
-
-                    <div slot="cbp-dropdown-attached-button-end">
-                      <cbp-button
-                        fill="solid"
-                        color="secondary"
-                        variant="square"
-                        value="next page"
-                        accessibility-text="Next page"
-                      >
-                        <cbp-icon name="chevron-right" />
-                      </cbp-button>
-                    </div>
-                  </cbp-dropdown>
-                </cbp-form-field>
-              </cbp-pagination>
-
-          </cbp-flex-item>
-      `;
-    }
-    
-    function filterPanel() {
-
-      return `
-      <cbp-flex-item>
-            <cbp-panel
-              aria-labelledby="panelheader"
-              role="complementary"
-            >
-              <cbp-typography
-                slot="cbp-panel-header"
-                tag="h3"
-                variant="heading-lg"
-                id="panelheader"
-              >
-                Sidebar Header
-              </cbp-typography>
-                <cbp-form-field
-                  label="Search"
-                  field-id="search"
+              <cbp-button
+                fill="outline"
+                color="secondary"
                 >
-                  <cbp-form-field-wrapper>
-                    <input
-                      type="search"
-                      name="search"
-                    />
+                24 HR
+              </cbp-button>
+            </cbp-segmented-button-group>
+          </cbp-form-field-wrapper>
+        </cbp-form-field>
 
-                    <span slot="cbp-form-field-attached-button">
-                      <cbp-button
-                        type="submit"
-                        fill="solid"
-                        color="secondary"
-                        variant="square"
-                        accessibility-text="Search"
-                      >
-                        <cbp-icon
-                          name="magnifying-glass"
-                          size="1rem"
-                        ></cbp-icon>
-                      </cbp-button>
-                    </span>
-                  </cbp-form-field-wrapper>
-                </cbp-form-field>
-                <cbp-form-field group
-                  label='Passenger Sex'
-                  description='Required'
+        <cbp-form-field
+          label="Arrival Date Range To:"
+          description="(MM/DD/YYYY) Format"
+        >
+          <cbp-form-field-wrapper>
+            <input
+              type="date"
+              name="textinput"
+            />
+          </cbp-form-field-wrapper>
+        </cbp-form-field>
+
+        <cbp-form-field
+          label="Arrival Date Range To:"
+          description="(HH:MM Format) UTC-6 America/New York."
+        >
+          <cbp-form-field-wrapper>
+            <input
+              type="time"
+            />
+            <span slot="cbp-form-field-overlay-start">
+            <cbp-icon name="book"></cbp-icon>
+            </span>
+
+            <cbp-segmented-button-group slot="cbp-form-field-attached-button">
+              <cbp-button
+                fill="outline"
+                color="secondary"
                 >
-                  <cbp-flex
-                    gap="var(--cbp-space-5x)"
-                    breakpoint="28rem"
-                    sx='{"width":"max-content"}'
-                  >
-                    <cbp-radio>
-                      <input 
-                        type="radio" 
-                        name="sex"
-                        value="Male"
-                      />
-                      Male
-                    </cbp-radio>
-                    <cbp-radio>
-                      <input 
-                        type="radio" 
-                        name="sex"
-                        value="Female"
-                      />
-                      Female
-                    </cbp-radio>
-                    <cbp-radio>
-                      <input 
-                        type="radio" 
-                        name="sex"
-                        value="Other"
-                      />
-                      Other
-                    </cbp-radio>
-                  </cbp-flex>
-                </cbp-form-field>
+                AM
+              </cbp-button>
 
-                <cbp-form-field
-                  label="Passenger Age Range"
+              <cbp-button
+                fill="outline"
+                color="secondary"
                 >
-                  <cbp-form-field-wrapper>
-                    <input
-                      type="range"
-                      name="textinput"
-                    />
-                  </cbp-form-field-wrapper>
-                </cbp-form-field>
+                PM
+              </cbp-button>
 
-                <cbp-form-field
-                  label="Country that Issued Passport"
-                  description="Required."
+              <cbp-button
+                fill="outline"
+                color="secondary"
                 >
-                  <select name="select">
-                    <option value="">United States of America</option>
-                    <option value="1">Option 1</option>
-                    <option value="2">Option 2</option>
-                    <option value="3">Option 3</option>
-                    <option value="4">Option 4</option>
-                    <option value="5">Option 5</option>
-                  </select>
-                </cbp-form-field>
+                24 HR
+              </cbp-button>
+            </cbp-segmented-button-group>
+          </cbp-form-field-wrapper>
+        </cbp-form-field>
 
-                <cbp-form-field
-                  label="Port of Departure"
-                  description="Required."
-                >
-                  <select name="select">
-                    <option value="">Any</option>
-                    <option value="1">Option 1</option>
-                    <option value="2">Option 2</option>
-                    <option value="3">Option 3</option>
-                    <option value="4">Option 4</option>
-                    <option value="5">Option 5</option>
-                  </select>
-                </cbp-form-field>
+      </cbp-panel>
+    </cbp-drawer>
+    `;
+}
 
-                <cbp-form-field
-                  label="Port of Arrival"
-                  description="Required."
-                >
-                  <select name="select">
-                    <option value="">JFK (XXXX/SM)</option>
-                    <option value="1">Option 1</option>
-                    <option value="2">Option 2</option>
-                    <option value="3">Option 3</option>
-                    <option value="4">Option 4</option>
-                    <option value="5">Option 5</option>
-                  </select>
-                </cbp-form-field>
+function manifestPane(manifestArgs) {
+  //TODO: segmented button slotted/embedded in the tab header is 'working' but pretty sure this is bad implementation
 
-                <cbp-form-field
-                  label="Arrival Date Range From:"
-                  description="(MM/DD/YYYY) Format"
-                >
-                  <cbp-form-field-wrapper>
-                    <input
-                      type="date"
-                      name="textinput"
-                    />
-                  </cbp-form-field-wrapper>
-                </cbp-form-field>
-
-                <cbp-form-field
-                  label="Arrival Time Range From:"
-                  description="(HH:MM Format) UTC-6 America/New York."
-                >
-                  <cbp-form-field-wrapper>
-                    <input
-                      type="time"
-                    />
-                    <span slot="cbp-form-field-overlay-start">
-                    <cbp-icon name="book"></cbp-icon>
-                    </span>
-   
-                    <cbp-segmented-button-group slot="cbp-form-field-attached-button">
-                      <cbp-button
-                        fill="outline"
-                        color="secondary"
-                        >
-                        AM
-                      </cbp-button>
-
-                      <cbp-button
-                        fill="outline"
-                        color="secondary"
-                        >
-                        PM
-                      </cbp-button>
-
-                      <cbp-button
-                        fill="outline"
-                        color="secondary"
-                        >
-                        24 HR
-                      </cbp-button>
-                    </cbp-segmented-button-group>
-                  </cbp-form-field-wrapper>
-                </cbp-form-field>
-
-                <cbp-form-field
-                  label="Arrival Date Range To:"
-                  description="(MM/DD/YYYY) Format"
-                >
-                  <cbp-form-field-wrapper>
-                    <input
-                      type="date"
-                      name="textinput"
-                    />
-                  </cbp-form-field-wrapper>
-                </cbp-form-field>
-
-                <cbp-form-field
-                  label="Arrival Date Range To:"
-                  description="(HH:MM Format) UTC-6 America/New York."
-                >
-                  <cbp-form-field-wrapper>
-                    <input
-                      type="time"
-                    />
-                    <span slot="cbp-form-field-overlay-start">
-                    <cbp-icon name="book"></cbp-icon>
-                    </span>
-   
-                    <cbp-segmented-button-group slot="cbp-form-field-attached-button">
-                      <cbp-button
-                        fill="outline"
-                        color="secondary"
-                        >
-                        AM
-                      </cbp-button>
-
-                      <cbp-button
-                        fill="outline"
-                        color="secondary"
-                        >
-                        PM
-                      </cbp-button>
-
-                      <cbp-button
-                        fill="outline"
-                        color="secondary"
-                        >
-                        24 HR
-                      </cbp-button>
-                    </cbp-segmented-button-group>
-                  </cbp-form-field-wrapper>
-                </cbp-form-field>
-            </cbp-panel>
-          </cbp-flex-item>
-      `;
-    }
-
-    function manifestPane(manifestArgs){
-      //TODO: segmented button slotted/embedded in the tab header is 'working' but pretty sure this is bad implementation
-      
-      return `
+  return `
         <cbp-drawer
           position= "right"
           accessibility-text= "Manifest Drawer"
@@ -632,19 +616,19 @@ export default {
           </cbp-panel>
         </cbp-drawer>
       `;
-    }
-  const InternalTemplate = ({ isLoggedIn, username, passengersArgs, manifestArgs}) => {
-    /** Techdebt for iteration on filter & manifest pane: 
-     * Icon for the app directory button is incorrect, verify all icons in buttons, most of these are initial stubs
-     * Buttons in the universal header need spacing between icon & text
-     * username value displaying twice, looks like issue with setting up the cbp-hide (is that needed here?)
-     * App header is stubbed in, need to reevaluate, hrefs pointing to wrong place
-     * Filter panel should have a fixed max width probably
-     * Footer missing InfoSec section (right side of footer)
-     * 
-    */       
+}
+const InternalTemplate = ({ isLoggedIn, username, passengersArgs, manifestArgs }) => {
+  /** Techdebt for iteration on filter & manifest pane:
+   * Icon for the app directory button is incorrect, verify all icons in buttons, most of these are initial stubs
+   * Buttons in the universal header need spacing between icon & text
+   * username value displaying twice, looks like issue with setting up the cbp-hide (is that needed here?)
+   * App header is stubbed in, need to reevaluate, hrefs pointing to wrong place
+   * Filter panel should have a fixed max width probably
+   * Footer missing InfoSec section (right side of footer)
+   *
+   */
 
-    return `
+  return `
     <cbp-skip-nav></cbp-skip-nav>
 
     <header>
@@ -653,8 +637,9 @@ export default {
         logo-src-sm="./assets/images/cbp-seal.svg"
       >
         <ul>
-        ${ isLoggedIn
-          ? `
+        ${
+          isLoggedIn
+            ? `
           <li>
             <cbp-button color="secondary" fill="ghost" context="dark-always">
               <cbp-icon name="book"></cbp-icon>
@@ -683,7 +668,7 @@ export default {
             </cbp-button>
           </li>
           `
-          : `
+            : `
           <li>
             <cbp-button tag="a" href="#" color="secondary" fill="ghost" context="dark-always">
             <cbp-icon name="right-to-bracket" sx='{"margin-right":"var(--cbp-space-2x)"}'></cbp-icon>
@@ -728,22 +713,22 @@ export default {
     </header>
 
     <cbp-container sx='{"padding":"1rem var(--cbp-responsive-spacing-outer)"}'>
-         <main id="main" tabindex="-1">
-           <cbp-typography tag="h1" divider="underline" sx='{"margin-bottom":"var(--cbp-space-5x)"}'>
-             Passenger Vetting
-           </cbp-typography>
-  
-           <cbp-grid
-            grid-template-columns="20rem 1fr "
-            gap="1rem"
-           >
-             ${filterPanel()}
-             ${passengerList(passengersArgs)}
-             ${manifestPane(manifestArgs)}
-           </cbp-grid>
-  
-           </main>
-       </cbp-container>
+      <main id="main" tabindex="-1">
+        <cbp-typography tag="h1" divider="underline" sx='{"margin-bottom":"var(--cbp-space-5x)"}'>
+          Passenger Vetting
+        </cbp-typography>
+
+        <cbp-grid
+          grid-template-columns="20rem 1fr "
+          gap="1rem"
+        >
+          ${filterPanel()}
+          ${passengerList(passengersArgs)}
+          ${manifestPane(manifestArgs)}
+        </cbp-grid>
+
+        </main>
+    </cbp-container>
 
     <cbp-footer>
       <nav slot="cbp-footer-nav">
@@ -774,129 +759,126 @@ export default {
       </section>
     </cbp-footer>
     `;
+};
 
-  };
-    
-  
 export const Internal = InternalTemplate.bind({});
 
 //TODO: randomize or update for different displays
 Internal.args = {
   passengersArgs: [
     {
-      name: "Smithington, Johnathan",
+      name: 'Smithington, Johnathan',
       bio: 'Male - Age 46 - USA',
-      arrival: new Date("2025-03-11T12:48:00")
+      arrival: new Date('2025-03-11T12:48:00'),
     },
     {
-      name: "Smithington, Johnathan",
+      name: 'Smithington, Johnathan',
       bio: 'Male - Age 46 - USA',
-      arrival: new Date("2025-03-10T09:48:00")
+      arrival: new Date('2025-03-10T09:48:00'),
     },
     {
-      name: "Smithington, Johnathan",
+      name: 'Smithington, Johnathan',
       bio: 'Male - Age 46 - USA',
-      arrival: new Date("2025-11-22T09:48:00"),
-      error: true
+      arrival: new Date('2025-11-22T09:48:00'),
+      error: true,
     },
     {
-      name: "Smithington, Johnathan",
+      name: 'Smithington, Johnathan',
       bio: 'Male - Age 46 - USA',
-      arrival: new Date("2025-11-22T09:48:00")
+      arrival: new Date('2025-11-22T09:48:00'),
     },
     {
-      name: "Smithington, Johnathan",
+      name: 'Smithington, Johnathan',
       bio: 'Male - Age 46 - USA',
-      arrival: new Date("2025-11-22T09:48:00")
+      arrival: new Date('2025-11-22T09:48:00'),
     },
     {
-      name: "Smithington, Johnathan",
+      name: 'Smithington, Johnathan',
       bio: 'Male - Age 46 - USA',
-      arrival: new Date("2025-11-22T09:48:00")
+      arrival: new Date('2025-11-22T09:48:00'),
     },
     {
-      name: "Smithington, Johnathan",
+      name: 'Smithington, Johnathan',
       bio: 'Male - Age 46 - USA',
-      arrival: new Date("2025-11-22T09:48:00")
+      arrival: new Date('2025-11-22T09:48:00'),
     },
     {
-      name: "Smithington, Johnathan",
+      name: 'Smithington, Johnathan',
       bio: 'Male - Age 46 - USA',
-      arrival: new Date("2025-11-22T09:48:00")
+      arrival: new Date('2025-11-22T09:48:00'),
     },
     {
-      name: "Smithington, Johnathan",
+      name: 'Smithington, Johnathan',
       bio: 'Male - Age 46 - USA',
-      arrival: new Date("2025-11-22T09:48:00")
+      arrival: new Date('2025-11-22T09:48:00'),
     },
     {
-      name: "Smithington, Johnathan",
+      name: 'Smithington, Johnathan',
       bio: 'Male - Age 46 - USA',
-      arrival: new Date("2025-11-22T09:48:00")
+      arrival: new Date('2025-11-22T09:48:00'),
     },
     {
-      name: "Smithington, Johnathan",
+      name: 'Smithington, Johnathan',
       bio: 'Male - Age 46 - USA',
-      arrival: new Date("2025-11-22T09:48:00")
+      arrival: new Date('2025-11-22T09:48:00'),
     },
     {
-      name: "Smithington, Johnathan",
+      name: 'Smithington, Johnathan',
       bio: 'Male - Age 46 - USA',
-      arrival: new Date("2025-11-22T09:48:00")
+      arrival: new Date('2025-11-22T09:48:00'),
     },
     {
-      name: "Smithington, Johnathan",
+      name: 'Smithington, Johnathan',
       bio: 'Male - Age 46 - USA',
-      arrival: new Date("2025-11-22T09:48:00")
+      arrival: new Date('2025-11-22T09:48:00'),
     },
     {
-      name: "Smithington, Johnathan",
+      name: 'Smithington, Johnathan',
       bio: 'Male - Age 46 - USA',
-      arrival: new Date("2025-11-22T09:48:00")
+      arrival: new Date('2025-11-22T09:48:00'),
     },
     {
-      name: "Smithington, Johnathan",
+      name: 'Smithington, Johnathan',
       bio: 'Male - Age 99 - USA',
-      arrival: new Date("2025-11-22T09:48:00")
+      arrival: new Date('2025-11-22T09:48:00'),
     },
-    
   ],
   manifestArgs: [
     {
-      flight:'DL 250',
+      flight: 'DL 250',
       arrivalTerminal: 'JFK',
       arrivalLocation: 'New York, NY',
       arrivalGate: 'Gate 34B',
-      arrivalTime: new Date("2025-03-10T10:44:00"),
+      arrivalTime: new Date('2025-03-10T10:44:00'),
       departureTerminal: 'LHR',
       departureLocation: 'London, UK',
-      departureTime: new Date("2025-03-11T15:48:00"),
+      departureTime: new Date('2025-03-11T15:48:00'),
       people: 86,
-      hotlist: 4
+      hotlist: 4,
     },
     {
-      flight:'UA 775',
+      flight: 'UA 775',
       arrivalTerminal: 'JFK',
       arrivalLocation: 'New York, NY',
       arrivalGate: 'Gate 34B',
-      arrivalTime: new Date("2025-03-10T10:44:00"),
+      arrivalTime: new Date('2025-03-10T10:44:00'),
       departureTerminal: 'BER',
       departureLocation: 'Berlin, Germany',
-      departureTime: new Date("2025-03-11T15:48:00"),
+      departureTime: new Date('2025-03-11T15:48:00'),
       people: 86,
-      hotlist: 4
+      hotlist: 4,
     },
     {
-      flight:'AA 8754',
+      flight: 'AA 8754',
       arrivalTerminal: 'JFK',
       arrivalLocation: 'New York, NY',
       arrivalGate: 'Gate 34B',
-      arrivalTime: new Date("2025-03-10T10:44:00"),
+      arrivalTime: new Date('2025-03-10T10:44:00'),
       departureTerminal: 'MAD',
       departureLocation: 'Madrid, Spain',
-      departureTime: new Date("2025-03-11T15:48:00"),
+      departureTime: new Date('2025-03-11T15:48:00'),
       people: 86,
-      hotlist: 4
+      hotlist: 4,
     },
-  ]
-}
+  ],
+};

--- a/packages/web-components/src/stories/Archetype_Passenger.stories.tsx
+++ b/packages/web-components/src/stories/Archetype_Passenger.stories.tsx
@@ -47,7 +47,7 @@ function generatePassengers(passengerArgs, page, pageSize) {
             <cbp-grid
               grid-template-columns="14rem 1fr 12rem"
               gap="var(--cbp-space-9x)"
-              breakpoint="70rem"
+              breakpoint="48rem"
             >
               <cbp-flex>
                   <img
@@ -208,6 +208,27 @@ function passengerList(passengerArgs) {
             </cbp-dropdown>
           </cbp-form-field>
         </cbp-flex-item>
+
+        <cbp-hide
+          hide-at="min-width:64rem"
+          sx='{"align-self":"flex-end"}'
+        >
+          <cbp-button
+            type="button"
+            color="secondary"
+            accessibility-text="Open Drawer"
+            target-prop="open"
+            controls="filterDrawer"
+            fill="outline"
+            class="hydrated"
+            >
+              <cbp-icon
+                name="filter"
+                sx='{"margin-right":"var(--cbp-space-2x)"}'
+              ></cbp-icon> Filter
+          </cbp-button>
+        </cbp-hide>
+
         <cbp-flex-item 
           align-self="flex-end"
           sx='{"margin-left":"auto"}'
@@ -306,8 +327,10 @@ function passengerList(passengerArgs) {
 function filterPanel() {
   return `
     <cbp-drawer
+      uid= "filterDrawer"
       position="left"
-      persist-at="min-width:37.5rem"
+      persist-at="min-width:64rem"
+      sx='{"flex-basis":"20rem"}'
     >
       <cbp-panel
         aria-labelledby="panelheader"
@@ -372,12 +395,12 @@ function filterPanel() {
         <cbp-form-field
           label="Passenger Age Range"
         >
-          <cbp-form-field-wrapper>
+          <cbp-slider hide-minmax>
             <input
               type="range"
-              name="textinput"
+              name="age"
             />
-          </cbp-form-field-wrapper>
+          </cbp-slider>
         </cbp-form-field>
 
         <cbp-form-field
@@ -426,12 +449,7 @@ function filterPanel() {
           label="Arrival Date Range From:"
           description="(MM/DD/YYYY) Format"
         >
-          <cbp-form-field-wrapper>
-            <input
-              type="date"
-              name="textinput"
-            />
-          </cbp-form-field-wrapper>
+          <input type="date" name="arrivaldatestart" />
         </cbp-form-field>
 
         <cbp-form-field
@@ -439,32 +457,21 @@ function filterPanel() {
           description="(HH:MM Format) UTC-6 America/New York."
         >
           <cbp-form-field-wrapper>
-            <input
-              type="time"
-            />
+            <input type="time" name="arrivaltimestart" />
             <span slot="cbp-form-field-overlay-start">
-            <cbp-icon name="book"></cbp-icon>
+              <cbp-icon name="book"></cbp-icon>
             </span>
 
             <cbp-segmented-button-group slot="cbp-form-field-attached-button">
-              <cbp-button
-                fill="outline"
-                color="secondary"
-                >
+              <cbp-button fill="outline" color="secondary">
                 AM
               </cbp-button>
 
-              <cbp-button
-                fill="outline"
-                color="secondary"
-                >
+              <cbp-button fill="outline" color="secondary">
                 PM
               </cbp-button>
 
-              <cbp-button
-                fill="outline"
-                color="secondary"
-                >
+              <cbp-button fill="outline" color="secondary">
                 24 HR
               </cbp-button>
             </cbp-segmented-button-group>
@@ -475,45 +482,29 @@ function filterPanel() {
           label="Arrival Date Range To:"
           description="(MM/DD/YYYY) Format"
         >
-          <cbp-form-field-wrapper>
-            <input
-              type="date"
-              name="textinput"
-            />
-          </cbp-form-field-wrapper>
+          <input type="date" name="arrivaldateend" />
         </cbp-form-field>
 
         <cbp-form-field
-          label="Arrival Date Range To:"
+          label="Arrival Time Range To:"
           description="(HH:MM Format) UTC-6 America/New York."
         >
           <cbp-form-field-wrapper>
-            <input
-              type="time"
-            />
+            <input type="time" name="arrivaltimeend" />
             <span slot="cbp-form-field-overlay-start">
-            <cbp-icon name="book"></cbp-icon>
+              <cbp-icon name="book"></cbp-icon>
             </span>
 
             <cbp-segmented-button-group slot="cbp-form-field-attached-button">
-              <cbp-button
-                fill="outline"
-                color="secondary"
-                >
+              <cbp-button fill="outline" color="secondary">
                 AM
               </cbp-button>
 
-              <cbp-button
-                fill="outline"
-                color="secondary"
-                >
+              <cbp-button fill="outline" color="secondary">
                 PM
               </cbp-button>
 
-              <cbp-button
-                fill="outline"
-                color="secondary"
-                >
+              <cbp-button fill="outline" color="secondary">
                 24 HR
               </cbp-button>
             </cbp-segmented-button-group>
@@ -718,17 +709,17 @@ const InternalTemplate = ({ isLoggedIn, username, passengersArgs, manifestArgs }
           Passenger Vetting
         </cbp-typography>
 
-        <cbp-grid
-          grid-template-columns="20rem 1fr "
+        <cbp-flex
           gap="1rem"
         >
           ${filterPanel()}
           ${passengerList(passengersArgs)}
-          ${manifestPane(manifestArgs)}
-        </cbp-grid>
-
+        </cbp-flex>
         </main>
+
     </cbp-container>
+
+    ${manifestPane(manifestArgs)}
 
     <cbp-footer>
       <nav slot="cbp-footer-nav">

--- a/packages/web-components/src/stories/Archetype_Passenger.stories.tsx
+++ b/packages/web-components/src/stories/Archetype_Passenger.stories.tsx
@@ -181,13 +181,16 @@ function passengerList(passengerArgs) {
 
   return `
     <cbp-flex-item flex-grow="1">
+
       <cbp-flex
         gap="1rem"
         wrap="wrap"
+        breakpoint="30rem"
+        align-items="flex-end"
       >
         <cbp-flex-item
-          align-self="flex-end"
-          flex-basis="20rem"
+          flex-basis="12rem"
+          flex-grow="1"
           flex-shrink="1"
         >
           <cbp-form-field
@@ -209,10 +212,7 @@ function passengerList(passengerArgs) {
           </cbp-form-field>
         </cbp-flex-item>
 
-        <cbp-hide
-          hide-at="min-width:64rem"
-          sx='{"align-self":"flex-end"}'
-        >
+        <cbp-hide hide-at="min-width:64rem">
           <cbp-button
             type="button"
             color="secondary"
@@ -229,10 +229,10 @@ function passengerList(passengerArgs) {
           </cbp-button>
         </cbp-hide>
 
-        <cbp-flex-item 
-          align-self="flex-end"
-          sx='{"margin-left":"auto"}'
-        >
+        <cbp-flex-item flex-grow="3">
+        </cbp-flex-item>
+      
+        <cbp-flex-item>
           <cbp-button
             type="button"
             fill="outline"
@@ -246,9 +246,8 @@ function passengerList(passengerArgs) {
               ></cbp-icon>Manifests
           </cbp-button>
         </cbp-flex-item>
-        <cbp-flex-item 
-          align-self="flex-end"
-        >
+        
+        <cbp-flex-item>
           <cbp-button
             type="button"
             fill="outline"
@@ -261,63 +260,65 @@ function passengerList(passengerArgs) {
           </cbp-button>
         </cbp-flex-item>
       </cbp-flex>
+
+
       <cbp-structured-list id="passengerList" header-id="list-header" striped  sx='{"margin-top":"var(--cbp-space-4x)"}'>
         <div slot="cbp-structured-list-header" id="list-header">
             XX Results - X filters Applied - Updated : 11/01/2024 10:00 EST 
         </div>
         ${generatePassengers(passengerArgs, page, pageSize)}
-
       </cbp-structured-list>
-        <cbp-pagination
-          records=${passengerArgs.length}
+
+      <cbp-pagination
+        records=${passengerArgs.length}
+      >
+        <cbp-form-field
+          slot="cbp-pagination-items-per-page"
+          label="Items Per Page"
+          field-id="pagination_size"
         >
-          <cbp-form-field
-            slot="cbp-pagination-items-per-page"
-            label="Items Per Page"
-            field-id="pagination_size"
-          >
-            <cbp-dropdown field-id="pagination_size">
-              <cbp-dropdown-item value="10">10/Page</cbp-dropdown-item>
-              <cbp-dropdown-item value="25">25/Page</cbp-dropdown-item>
-              <cbp-dropdown-item value="50">50/Page</cbp-dropdown-item>
-              <cbp-dropdown-item value="100">100/Page</cbp-dropdown-item>
-              <cbp-dropdown-item value="all">All Results</cbp-dropdown-item>
-            </cbp-dropdown>
-          </cbp-form-field>
+          <cbp-dropdown field-id="pagination_size">
+            <cbp-dropdown-item value="10">10/Page</cbp-dropdown-item>
+            <cbp-dropdown-item value="25">25/Page</cbp-dropdown-item>
+            <cbp-dropdown-item value="50">50/Page</cbp-dropdown-item>
+            <cbp-dropdown-item value="100">100/Page</cbp-dropdown-item>
+            <cbp-dropdown-item value="all">All Results</cbp-dropdown-item>
+          </cbp-dropdown>
+        </cbp-form-field>
 
-          <cbp-form-field
-            slot="cbp-pagination-pages"
-            label="Page Displayed"
-            field-id="pagination_pages"
-          >
-            <cbp-dropdown field-id="pagination_pages">
+        <cbp-form-field
+          slot="cbp-pagination-pages"
+          label="Page Displayed"
+          field-id="pagination_pages"
+        >
+          <cbp-dropdown field-id="pagination_pages">
 
-              <div slot="cbp-dropdown-attached-button-start">
-                <cbp-button
-                  fill="solid"
-                  color="secondary"
-                  variant="square"
-                  value="previous page"
-                  accessibility-text="Previous page"
-                >
-                  <cbp-icon name="chevron-right" rotate="180" />
-                </cbp-button>
-              </div>
+            <div slot="cbp-dropdown-attached-button-start">
+              <cbp-button
+                fill="solid"
+                color="secondary"
+                variant="square"
+                value="previous page"
+                accessibility-text="Previous page"
+              >
+                <cbp-icon name="chevron-right" rotate="180" />
+              </cbp-button>
+            </div>
 
-              <div slot="cbp-dropdown-attached-button-end">
-                <cbp-button
-                  fill="solid"
-                  color="secondary"
-                  variant="square"
-                  value="next page"
-                  accessibility-text="Next page"
-                >
-                  <cbp-icon name="chevron-right" />
-                </cbp-button>
-              </div>
-            </cbp-dropdown>
-          </cbp-form-field>
-        </cbp-pagination>
+            <div slot="cbp-dropdown-attached-button-end">
+              <cbp-button
+                fill="solid"
+                color="secondary"
+                variant="square"
+                value="next page"
+                accessibility-text="Next page"
+              >
+                <cbp-icon name="chevron-right" />
+              </cbp-button>
+            </div>
+          </cbp-dropdown>
+        </cbp-form-field>
+      </cbp-pagination>
 
     </cbp-flex-item>
   `;


### PR DESCRIPTION
* Updated the drawer to be able to persist in the flow of the document at a certain breakpoint.
* Updated the Passenger list story to use a persistent drawer.
* Fixed drawer and dialog controls to be square using `variant=square`.

I'm deferring the dark mode update to the backdrop, because I think that should be tokenized rather than 1-offs in 2 different places. That can be a separate PR with any dark mode updates Jeremy has planned.
