### PR TITLE
Feature/responsive breadcrumbs

### DIFF
--- a/packages/web-components/CHANGELOG.md
+++ b/packages/web-components/CHANGELOG.md
@@ -4,6 +4,14 @@ This CHANGELOG.md tracks the updates to the web components package of the CBP de
 
 The React components are wrappers generated from this package and will share the same changes. Projects using React 19 may use the native web components without React wrappers.
 
+## [unreleased] TBA
+
+* First cut of the `cbp-resize-observer` component.
+* Updated `cbp-breadcrumb` with responsive functionality using the Resize Observer and Menu components.
+* Minor bugfixes/updates to `cbp-menu`.
+* Add a vscode output target to Stencil config.
+
+
 ## [0.0.1-develop.21] 06-05-2025
 
 * A number of visually breaking changes were introduced in this release. These changes were undertaken with much consideration. However, we felt that the changes streamline using the Button, Link, and Icon components - some of the most-used components in the design system - enough to warrant the changes at this early stage in the design system development.
@@ -13,16 +21,17 @@ The React components are wrappers generated from this package and will share the
   * Updated the default `cbp-icon` size from "1em" to "1rem". This is because most icons alongside plain text (14px) are designed to be 16px (1rem). Any other sized icon should be explicitly specified via the `size` property using relative units or design tokens. Also updated the `cbp-icon` component to more easily allow overriding its size via its CSS API (`--cbp-icon-size`).
 * BREAKING: renamed the `cbp-nav-item` `selected` property to `current` for consistency and clarity.
 * BREAKING: renamed the `cbp-subnav` `accessibilitytext` property to `accessibilityText` for consistency.
-* BREAKING: updated the `cbp-nav-item` component to style any slotted links and buttons (not just cbp-button), including component-based routers. The "home" (application name) link must now be slotted into the `slot="cbp-home"` named slot to inherit the proper styling.
+* Updated the Application Header to support Navigation Items that have children:
+  * Navigation Items with children are represented by a button control that opens a drawer containing sub-navigation.
+  * The Application Header and Sub-navigation now contain a shared state, allowing user interaction with either component to update the state of the other.
+  * Updated the `cbp-nav-item` component to style any slotted links and buttons (not just `cbp-button`), including component-based routers.
+  * BREAKING: The "home" (application name) link must now be slotted into the `slot="cbp-home"` named slot to inherit the proper styling. This is less opinionated/more flexible than always styling the first nav-item in a special way.
 * First cut of the `cbp-menu` component.
 * Updated `cbp-drawer` to add the ability to persist its contents in the flow of the page at a certain breakpoint, mobilizing to an overlay below that breakpoint.
   * With the addition of a persistent drawer, the drawer component should match the user's preferences for light or dark mode rather than using "light-always" and "dark-always" contexts.
   * Implemented an official dark mode for the Drawer component.
   * Updated the "User Preferences" story to work with the new dark theme and component implementation. This pattern still uses `context="dark-always"`, but represents a custom pattern rather than the default dark mode.
   * Updated the Passenger List archetype to demonstrate the persistent drawer functionality.
-* Updated the Application Header to support Navigation Items that have children:
-  * Navigation Items with children are represented by a button control that opens a drawer containing sub-navigation.
-  * The Application Header and Sub-navigation now contain a shared state, allowing user interaction with either component to update the state of the other.
 * Updated the `cbp-dropdown` to fix a number of issues:
   * Now works as a multi-select when its dropdown items are passed in via JSON.
   * Fixed the issue of setting a value property on multi-selects to populate the initial state.

--- a/packages/web-components/readme.md
+++ b/packages/web-components/readme.md
@@ -16,8 +16,7 @@ In modern JavaScript frameworks, you can use the native web components, which ar
 - Call `defineCustomElements()` to initialize the loader and register the web components (to be lazy loaded when used).
 
 ```
-import { defineCustomElements } from '@cbpds/web-components/dist/esm/loader.js';
-
+import { defineCustomElements } from '@cbpds/web-components/dist/loader';
 defineCustomElements();
 ```
 

--- a/packages/web-components/src/components/cbp-app-header/cbp-app-header.specs.mdx
+++ b/packages/web-components/src/components/cbp-app-header/cbp-app-header.specs.mdx
@@ -19,15 +19,15 @@ The Application Header component is meant to contain the primary navigation acco
 ### User Interactions
 
 * The Application Header component contains an application-defined number of "nav items":
-  * A Nav Item representing navigation shall render an anchor.
+  * A Nav Item representing navigation shall contain a slotted anchor.
   * Navigation Items with children are represented by a button control that opens a drawer containing sub-navigation options.
-   for navigation or button control linking to the drawer that holds.
 * When a Nav Item anchor is activated, it is marked visually and accessibly as the "current" item.
 * A Nav Item representing a drawer control is only marked current if the item or one of its children are activated within the Sub-Navigation.
 
 ### Responsiveness
 
-* TBD
+* The application name (home link) is rendered at a smaller font size on mobile devices.
+* More TBD.
 
 ### Accessibility
 
@@ -39,7 +39,7 @@ The Application Header component is meant to contain the primary navigation acco
   * Specify the `controls` property, referencing the `id` of the Drawer it controls to render `aria-controls` on the native button.
   * Specify `target-prop="open"`.
   * Include the `expanded` property to render `aria-expanded` on the native button.
-* The "current" navigation control is denoted via `aria-current` as well as visual styling.
+* The "current" navigation control is denoted via `aria-current="page"` as well as visual styling.
 
 ### Additional Notes and Considerations
 

--- a/packages/web-components/src/components/cbp-app-header/cbp-app-header.stories.tsx
+++ b/packages/web-components/src/components/cbp-app-header/cbp-app-header.stories.tsx
@@ -59,7 +59,6 @@ function generateNavItems(items, drawerid=undefined){
   return html.join('');
 }
 
-
 function generateSubnav(items){
   const html = items.map(({ icon, label, name, href, children, current }) => {
       return `<cbp-subnav-item label="${label}" name="${name}" href=${href} ${current? 'current' : ''}  >${icon ? `<span slot="cbp-subnav-item-label">${icon} ${label}</span>` : ``} ${children? generateSubnav(children) : ``}</cbp-subnav-item>`;
@@ -86,6 +85,27 @@ const Template = ({ items, sx }) => {
     </cbp-app-header>
   `;
 };
+
+/* 
+    Test case for using flex to float additional content off to the right.
+
+      <cbp-flex 
+        align-items="center"
+        justify-content="space-between"
+        sx='{"width":"100%"}'
+      >
+        <div>
+          ${generateNavItems(items)}
+        </div>
+
+        <div>
+          <cbp-button>
+            Right-aligned button
+          </cbp-button>
+        </div>
+      </cbp-flex>
+*/
+
 
 
 export const ApplicationHeader = Template.bind({});

--- a/packages/web-components/src/components/cbp-app-header/cbp-app-header.tsx
+++ b/packages/web-components/src/components/cbp-app-header/cbp-app-header.tsx
@@ -1,6 +1,10 @@
 import { Component, Element, Listen, Host, h } from '@stencil/core';
 import state from '../cbp-app-header/store';
 
+/**
+ * @slot - The default slot usually contains only `cbp-nav-item` tags, but other content may also be included.
+ * @slot - cbp-home - The link to the home page containing the Application Name as link text should be placed within this named slot for the intended visual treatment. 
+ */
 @Component({
   tag: 'cbp-app-header',
   styleUrl: 'cbp-app-header.scss'

--- a/packages/web-components/src/components/cbp-breadcrumb/cbp-breadcrumb.scss
+++ b/packages/web-components/src/components/cbp-breadcrumb/cbp-breadcrumb.scss
@@ -2,11 +2,13 @@
  * @prop --cbp-breadcrumb-color: var(--cbp-color-text-darkest);
  * @prop --cbp-breadcrumb-color-dark: var(--cbp-color-text-lightest);
  * @prop --cbp-breadcrumb-gap: var(--cbp-space-2x);
+ * @prop --cbp-breadcrumb-divider: "/";
  */
  :root{
   --cbp-breadcrumb-color: var(--cbp-color-text-darkest);
   --cbp-breadcrumb-color-dark: var(--cbp-color-text-lightest);
   --cbp-breadcrumb-gap: var(--cbp-space-2x);
+  --cbp-breadcrumb-divider: "/";
 }
 
 [data-cbp-theme=light] cbp-breadcrumb[context*=dark]:not([context=light-always]),
@@ -16,11 +18,36 @@
 
 cbp-breadcrumb {
   color: var(--cbp-breadcrumb-color);
+  display: block;
  
   nav {
     display: flex;
-    flex-wrap: wrap;
     align-items: center;
     gap: var(--cbp-breadcrumb-gap);
+    width: max-content;
+    overflow: visible;
+  
+    // Setting the divider as ::before on each element after the home button
+    > *:not(:first-child)::before {
+      content: var(--cbp-breadcrumb-divider);
+      margin-inline-end: var(--cbp-breadcrumb-gap);
+      white-space: nowrap;
+    }
+
+    a {
+      white-space: nowrap;
+    }
+
+    // The home button appears too far away due to button size, so apply the gap as a negative margin.
+    > :first-child {
+      margin-inline-end: calc(var(--cbp-breadcrumb-gap) * -1);
+    }
+
+    // Fix for the ::before vertical alignment issue
+    cbp-menu:not([hidden]) {
+      display: flex;
+      align-items: center;
+      order: 1; // the flex order should be after the default items (0), but be before the last item (set to its index)
+    }
   }
 }

--- a/packages/web-components/src/components/cbp-breadcrumb/cbp-breadcrumb.specs.mdx
+++ b/packages/web-components/src/components/cbp-breadcrumb/cbp-breadcrumb.specs.mdx
@@ -6,24 +6,24 @@ import { Meta } from '@storybook/addon-docs';
 
 ## Purpose
 
-* The Breadcrumb component gives users a key indicator of where they are within a site/application, especially helpful when deeper within the site’s architecture. 
+* The Breadcrumb component gives users an indicator of where they are within a site/application hierarchy, especially helpful when deeper within the site’s architecture.
 
 ## Functional Requirements
 
 * The Breadcrumb component acts as a wrapper for navigation links.
-* The Breadcrumb is primarily made up of slotted `cbp-link` components.
-* TODO: On smaller screens, the breadcrumb links mobilize into a menu.
+* The Breadcrumb is primarily made up of slotted anchors.
+* On smaller screens, the breadcrumb links will be collapsed into a Menu component.
 
 ## Technical Specifications
 
 ### User Interactions
 
 * The Breadcrumb component itself is a container an has no user interactions.
-* The links within the breadcrumb component should be simple navigation links (incuding router links) in accordance with the `cbp-link` component behavior. 
+* The links within the breadcrumb component should be simple navigation links (including router links) in accordance with the `cbp-link` component behavior. 
 
 ### Responsiveness
 
-* TODO: update to come for overflow button responsiveness.
+* On small screens, the breadcrumbs will be collapsed into a Menu component.
 
 ### Accessibility
 

--- a/packages/web-components/src/components/cbp-breadcrumb/cbp-breadcrumb.stories.tsx
+++ b/packages/web-components/src/components/cbp-breadcrumb/cbp-breadcrumb.stories.tsx
@@ -1,64 +1,88 @@
 export default {
-    title: 'Components/Breadcrumb',
-    tags: ['beta'],
-    argTypes: {
-      context : {
-        control: 'select',
-        options: [ "light-inverts", "light-always", "dark-inverts", "dark-always"]
-      },
-      sx: {
-        description: 'Supports adding inline styles as an object of key-value pairs comprised of CSS properties and values. Values should reference design tokens when possible.',
-        control: 'object',
-      },
+  title: 'Components/Breadcrumb',
+  tags: ['beta'],
+  argTypes: {
+    divider: {
+      control: 'text',
     },
-      args: {
-      },
-    };
-  
-    function generateBreadcrumbs(breadcrumbs, context){
-      const html =  breadcrumbs.map(({text, href}) => {
-          return ` / <cbp-link href=${href}  context=${context}> ${text}</cbp-link> `
-        }
-      );
-      return html.join('');
-    }
+    context: {
+      control: 'select',
+      options: ["light-inverts", "light-always", "dark-inverts", "dark-always"]
+    },
+    sx: {
+      description: 'Supports adding inline styles as an object of key-value pairs comprised of CSS properties and values. Values should reference design tokens when possible.',
+      control: 'object',
+    },
+  },
+  args: {
+  },
+};
 
-    const Template = ({ breadcrumbs, home, context, sx}) => {
-        return ` 
-            <cbp-breadcrumb
-              ${context && context != 'light-inverts' ? `context=${context}` : ''}
-              ${sx ? `sx=${JSON.stringify(sx)}` : ''}
-            >
-              <cbp-button
-                tag="a"
-                fill="ghost"
-                color="primary"
-                variant="square"
-                context=${context}
-                href=${home}
-                accessibility-text="Home"
-              >
-                <cbp-icon
-                  name="home"
-                >
-                </cbp-icon>
-              </cbp-button>
-              ${generateBreadcrumbs(breadcrumbs, context)}
-            </cbp-breadcrumb>
-          `;
-      };
-    
-      export const Breadcrumb = Template.bind({});
-        Breadcrumb.args = {
-            breadcrumbs: [
-              {
-                text: 'Test',
-                href: '#'
-              },
-              {
-                text: 'Test 2',
-                href: '#'
-              },
-            ], 
-            home: '#'
-        };
+function generateBreadcrumbs(breadcrumbs, context) {
+  const html = breadcrumbs.map(({ text, href }) => {
+    return `<cbp-link href=${generateUnvisitedLink(href)} ${context && context != 'light-inverts' ? `context=${context}` : ''}>${text}</cbp-link>`
+  }
+  );
+  return html.join('');
+}
+
+// Replace placeholder href="#" with unique URLs that do not show as "visited" (a common problem when using # or self-referencing URLs);
+// Should also use preventDefault() to avoid navigation to a broken link.
+function generateUnvisitedLink(href) {
+  if(href == '#') return '?' + (Math.random() + 1).toString(26).slice(2, 7);
+  else return href;
+}
+
+const Template = ({ breadcrumbs, home, divider, context, sx }) => {
+  // preventDefault on all links in the breadcrumbs
+  setTimeout(() => {
+    let anchors = document.querySelectorAll('cbp-breadcrumb a');
+    anchors.forEach(anchor => {
+      anchor.addEventListener('click', function (e) { e.preventDefault(); })
+    });
+  }, 1000);
+
+  return ` 
+    <cbp-breadcrumb
+      ${divider ? `divider="${divider}"` : ''}
+      ${context && context != 'light-inverts' ? `context="${context}"` : ''}
+      ${sx ? `sx=${JSON.stringify(sx)}` : ''}
+    >
+      <cbp-button
+        tag="a"
+        fill="ghost"
+        color="primary"
+        variant="square"
+        ${context && context != 'light-inverts' ? `context="${context}"` : ''}
+        href="${home}"
+        accessibility-text="Home"
+      >
+        <cbp-icon name="home"></cbp-icon>
+      </cbp-button>
+      ${generateBreadcrumbs(breadcrumbs, context)}
+    </cbp-breadcrumb>
+  `;
+};
+
+export const Breadcrumb = Template.bind({});
+Breadcrumb.args = {
+  breadcrumbs: [
+    {
+      text: 'Page Title Level A',
+      href: '#'
+    },
+    {
+      text: 'Page Title Level B',
+      href: '#'
+    },
+    {
+      text: 'Page Title Level C',
+      href: '#'
+    },
+    {
+      text: 'Page Title Level D',
+      href: '#'
+    },
+  ],
+  home: '#'
+};

--- a/packages/web-components/src/components/cbp-breadcrumb/cbp-breadcrumb.tsx
+++ b/packages/web-components/src/components/cbp-breadcrumb/cbp-breadcrumb.tsx
@@ -1,7 +1,10 @@
-import { Component, Prop, Element, Host, h } from '@stencil/core';
-import { setCSSProps } from '../../utils/utils';
+import { Component, Prop, State, Element, Host, h } from '@stencil/core';
+import { setCSSProps, debounce } from '../../utils/utils';
 
 /**
+ * The Breadcrumb component gives users an indicator of where they are within a site/application hierarchy, 
+ * especially helpful when deeper within the site’s architecture.
+ * 
  * @slot - The individual links making up the breadcrumbs are placed in the default slot.
  */
 @Component({
@@ -10,7 +13,30 @@ import { setCSSProps } from '../../utils/utils';
 })
 export class CbpBreadcrumb {
 
+  private nav: HTMLElement;
+  private menu: HTMLCbpMenuElement;
+  private ro: HTMLElement;
+  private breadcrumbs: HTMLAnchorElement[] = []; // array of the actual anchors for building the responsive menu
+  private children: HTMLElement[] = []; // array of immediate children for toggling hidden
+  private sizeMap: object[] = [
+    {
+      size: "compact",
+      width: undefined
+    },
+    {
+      size: "medium",
+      width: undefined
+    },
+    {
+      size: "full",
+      width: undefined
+    }
+  ];
+
   @Element() host: HTMLElement;
+
+  /** Specifies a character as a divider between breadcrumb links. Defaults to "/". */
+  @Prop() divider: string;
 
   /** Specifies the context of the component as it applies to the visual design and whether it inverts when light/dark mode is toggled. Default behavior is "light-inverts" and does not have to be specified. */
   @Prop({ reflect: true }) context: "light-inverts" | "light-always" | "dark-inverts" | "dark-always";
@@ -18,21 +44,152 @@ export class CbpBreadcrumb {
   /** Supports adding inline styles as an object */
   @Prop() sx: any = {};
 
+  @State() menuItems: HTMLCbpMenuItemElement[] = [];
+  @State() sizeIndex = 2; // Default to full-width
+
+
+  handleResize( width ) {
+    // Get the width of the content (and update the sizeMap) before doing responsive adjustments.
+    this.sizeMap[this.sizeIndex]['width'] = this.nav.getBoundingClientRect().width;
+
+    // If the emitted size is less than the current mode's width, step down to the next responsive size
+    if (this.sizeIndex > 0 && width <= this.sizeMap[this.sizeIndex]['width']) {
+      this.resizeResponsive(this.sizeIndex - 1);
+    }
+
+    // If the emitted size is greater than than the next larger mode's width, move up to the next responsive size
+    if (this.sizeIndex < 2 && width > this.sizeMap[this.sizeIndex+1]['width']) {
+      this.resizeResponsive(this.sizeIndex + 1);
+    }
+  }
+
+  resizeResponsive(mode){
+    // switch to the specified mode
+    switch (this.sizeMap[mode]['size']) {
+
+      case "compact":
+        this.children.forEach( (item, index) => {
+          if (index > 0) {
+            item.setAttribute('hidden','');
+          }
+        });
+        this.menu.removeAttribute('hidden');
+        break;
+
+      case "medium":
+        this.children.forEach( (item, index) => {
+          if (index > 0 && index < (this.children.length - 2)) item.setAttribute('hidden','');
+          else item.removeAttribute('hidden');
+          // Set the flex order on the last breadcrumb so it's after the menu - does not need to be updated for other cases
+          if (index == (this.children.length - 2)) item.style.setProperty('order', `${index}`);
+        });
+        this.menu.removeAttribute('hidden');
+        break;
+
+      case "full": 
+        this.children.forEach( (item, index) => {
+          if (index > 0) item.removeAttribute('hidden');
+        });
+        this.menu.setAttribute('hidden','');
+        break;
+
+      default:
+        console.log(`cbp-breadcrumb - We should never see the default case... ${this.sizeMap[mode]['size']}.`);
+    }
+    
+    this.sizeIndex=mode;
+    
+    // After changing modes, update the width for the current mode (just in case anything has changed)
+    setTimeout(() => {
+      this.sizeMap[mode]['width'] = this.nav.getBoundingClientRect().width;
+      // from the middle state, make sure it doesn't need to go to the smallest mode if there's still overflow
+      if (mode == 1 && this.ro.getBoundingClientRect().width <= this.nav.getBoundingClientRect().width) {
+        this.resizeResponsive(this.sizeIndex - 1);
+      }
+    }, 200);
+  }
+
+
+  // TechDebt: this menu may or may not work with routing, depending on the implementation. Needs testing.
+  createMenu(breadcrumbs) {
+    let menuItems: HTMLCbpMenuItemElement[] = [];
+    // Loop over the breadcrumb anchors to generate the menu items
+    breadcrumbs.forEach( (item, index) => {
+      let newItem: HTMLCbpMenuItemElement =
+        <cbp-menu-item indentLevel={index}>
+          <a href={`${item.href}`}>
+            {index == 0 
+              ? <cbp-flex gap="var(--cbp-space-1x)"><cbp-icon name="home"></cbp-icon>Home</cbp-flex>
+              : item.textContent
+            }
+          </a>
+        </cbp-menu-item>;
+      menuItems = [...menuItems, newItem];
+    });
+    // Set them to the State to re-render
+    this.menuItems = [...menuItems];
+  }
+
   componentWillLoad() {
     if (typeof this.sx == 'string') {
       this.sx = JSON.parse(this.sx) || {};
     }
     setCSSProps(this.host, {
+      "--cbp-breadcrumb-divider": this.divider ? `"${this.divider}"` : undefined,
       ...this.sx,
     });
   }
+  
+  componentDidLoad() {
+    // Get the immediate children to toggle hidden
+    this.children=Array.from(this.nav.querySelectorAll(':scope > *'));
+    // Get the actual anchors for generating the responsive menu items
+    this.breadcrumbs=Array.from(this.host.querySelectorAll('a[href]'));
+    // Create responsive menu items from the breadcrumb links
+    this.createMenu(this.breadcrumbs);
+  }
+
 
   render() {
     return (
       <Host>
-        <nav aria-label="Breadcrumb">
-          <slot />
-        </nav>      
+        <cbp-resize-observer 
+          debounce={50}
+          ref={el => this.ro = el}
+          //onResized={(e) => this.handleResize(e.detail.width)}
+          onResized={ debounce((e) => {
+            this.handleResize(e.detail.width);
+          }, 10)}
+        >
+          <nav 
+            aria-label="Breadcrumb" 
+            ref={el => this.nav = el}
+          >
+            <slot />
+            
+            <cbp-menu 
+              hidden
+              uid="cbp-breadcrumbs-menu"
+              ref={el => this.menu = el}
+            >
+              <cbp-button
+                fill="outline"
+                color="secondary"
+                target-prop="open"
+                controls="cbp-breadcrumbs-menu"
+                accessibilityText="Breadcrumbs Menu"
+              >
+                <cbp-icon
+                  name="ellipsis-vertical"
+                  rotate={90}
+                />
+              </cbp-button>
+
+              {[...this.menuItems]}
+            </cbp-menu>
+
+          </nav>
+        </cbp-resize-observer>
       </Host>
     );
   }

--- a/packages/web-components/src/components/cbp-link/cbp-link.tsx
+++ b/packages/web-components/src/components/cbp-link/cbp-link.tsx
@@ -35,10 +35,10 @@ export class CbpLink {
   /** Defines an `accesskey` attribute of the rendered anchor. */
   @Prop() shortcutKey: string;
   
-  /** Specifies the `rel` attribute of the rendered anchor. */
+  /** Specifies an accessible label for the rendered anchor via `aria-label`. */
   @Prop() accessibilityText: string;
 
-  /** Specifies whether the anchor is "disabled". Creating disabled anchors may introduce accessibility concerns - use with caution. */
+  /** Specifies whether the the rendered anchor is "disabled". Creating disabled anchors may introduce accessibility concerns - use with caution. */
   @Prop({ reflect: true }) disabled: boolean;
   
   /** Specifies the context of the component as it applies to the visual design and whether it inverts when light/dark mode is toggled. Default behavior is "light-inverts" and does not have to be specified. */

--- a/packages/web-components/src/components/cbp-menu/cbp-menu.scss
+++ b/packages/web-components/src/components/cbp-menu/cbp-menu.scss
@@ -24,13 +24,11 @@ cbp-menu {
 
   /* The actual menu, positioned for mobile-first */
   .cbp-menu__menu {
-    position: fixed;
-    display: block;
-    bottom: 0;
+    position: absolute;
+    top: 0;
     left: 0;
-    width: 90%;
-    max-width: 100%;
-    margin: 0 5% var(--cbp-space-6x);
+    display: block;
+    width: max-content;
     padding: 0;
     background: var(--cbp-menu-color-bg);
     border-radius: var(--cbp-border-radius-softer);
@@ -42,10 +40,8 @@ cbp-menu {
   /* Menu Positioning for the larger breakpoints */
   @media (min-width: 37.5em) {
     .cbp-menu__menu {
-      position: absolute;
       width: max-content;
       max-width: max-content;
-      bottom: unset;
       margin: 0;
     }
 

--- a/packages/web-components/src/components/cbp-resize-observer/api-docs.mdx
+++ b/packages/web-components/src/components/cbp-resize-observer/api-docs.mdx
@@ -1,0 +1,6 @@
+import { Meta, Markdown } from "@storybook/blocks";
+import Docs from './readme.md?raw';
+
+<Meta title="Components/Resize Observer/API Docs" />
+
+<Markdown>{Docs}</Markdown>

--- a/packages/web-components/src/components/cbp-resize-observer/cbp-resize-observer.scss
+++ b/packages/web-components/src/components/cbp-resize-observer/cbp-resize-observer.scss
@@ -1,5 +1,11 @@
+/*
+ * The resize observer is a block-level component with a max-width of 100% that grows and shrinks with its parent container, 
+ * so that it can report changes in both directions.
+ * It allows for overflow, so that its children may still report their full dimensions based on their content and overflow may
+ * therefore be detected for responsive behavior.
+ */
 cbp-resize-observer {
   max-width: 100%;
-  display: inline-block;
+  display: block;
   overflow: visible;
 }

--- a/packages/web-components/src/components/cbp-resize-observer/cbp-resize-observer.specs.mdx
+++ b/packages/web-components/src/components/cbp-resize-observer/cbp-resize-observer.specs.mdx
@@ -1,0 +1,36 @@
+import { Meta } from '@storybook/addon-docs';
+
+<Meta title="Components/Resize Observer/Specifications" />
+
+# cbp-resize-observer
+
+## Purpose
+
+* The Resize Observer component is a wrapper that implements a resizeObserver to detect changes to its size, typically to compare to an immediate child that is wrapping a collection of variable-sized elements (e.g., links, tabs, etc.), in order to implement responsive functionality that cannot be accomplished with a media query or container query.
+
+## Functional Requirements
+
+* The Resize Observer component acts as a wrapper that takes up 100% of the width of its parent, so that it may report changes in size in both directions.
+* The Resize Observer component allows for overflow so that its children may still report their full dimensions based on their content and overflow may therefore be detected for responsive behavior.
+* The Resize Observer component emits a custom event, which may be listened for and used for comparisons in components and application logic.
+
+## Technical Specifications
+
+### User Interactions
+
+* n/a
+
+### Responsiveness
+
+* The resize observer acts as a wrapper with a max-width of 100% but allowing overflow of its children.
+* By comparing the size of the resize observer element to the a child wrapper, overflow can be detected and Responsiveness implemented by component or application logic.
+
+### Accessibility
+
+* As an invisible wrapper tag, there are no accessibility concerns for the Resize Observer component.
+* The resize observer can be used to make UIs more robust and functional at all screen sizes where media and container queries are not able to.
+
+### Additional Notes and Considerations
+
+* The native resizeObserver is a performant way of measuring changes to a DOM node's size or positioning.
+* However, care must be taken that application logic and calculations based on the resize event are not too complex as to impact performance of the UI.

--- a/packages/web-components/src/components/cbp-resize-observer/cbp-resize-observer.tsx
+++ b/packages/web-components/src/components/cbp-resize-observer/cbp-resize-observer.tsx
@@ -1,6 +1,12 @@
 import { Component, Element, Prop, Event, EventEmitter, Host, h } from '@stencil/core';
+//import { debounce } from '../../utils/utils';
 
 /**
+ * The Resize Observer component is a wrapper that implements a resizeObserver to detect changes to its size,
+ * typically to compare to an immediate child that is wrapping a collection of variable-sized elements 
+ * (e.g., links, tabs, etc.), in order to implement responsive functionality that cannot be accomplished 
+ * with a media query or container query.
+ * 
  * @slot - any markup or content may be placed in the default slot. 
  */
 @Component({
@@ -11,16 +17,11 @@ export class CbpResizeObserver {
 
   private observer: ResizeObserver;
   private observedEl: Element
-  //private parentEl: HTMLElement;
-  //private childEl: HTMLElement;
-
+ 
   @Element() host: HTMLElement;
 
-  /** Optionally specify a selector with which to query the closest matching parent of the host tag to observe. */
-  @Prop() parent: string;
-
-  /** Optionally specify a selector with which to query the a child of the host tag to observe. */
-  @Prop() child: string;
+  /** The number of milliseconds to debounce the event emitter. (not currently working) */
+  @Prop() debounce: number = 0;
 
   /** A custom event emitted when the click event occurs for either a rendered button or anchor/link. */
   @Event() resized!: EventEmitter;
@@ -35,9 +36,8 @@ export class CbpResizeObserver {
 
 
   componentDidLoad() {
-    // TODO: still need to figure out what comparisons are useful at this level - parent or children
-    const children = this.host.children;
-    this.observedEl = this.host; //this.host.querySelector(child) or this.host.closest(parent); ?
+    // Initialize the resizeObserver on the host element
+    this.observedEl = this.host;
     /*
       ResizeObserver object structure:
         Entries[]: 
@@ -56,24 +56,12 @@ export class CbpResizeObserver {
             devicePixelContentBoxSize[]: ResizeObserverSize
             target
     */
-    this.observer = new ResizeObserver(([{ contentRect }]) => {
+    this.observer = new ResizeObserver( ([{ contentRect }]) => {
       const {width, height, top, bottom, left, right, x, y} = contentRect;
-      console.log('Resize Observer: ', width, height, children, children[0].getBoundingClientRect());
+      //console.log('Resize Observer: ', width, height, top, bottom, left, right, x, y);
 
-      // TODO: do comparisons, such as to check for overflow (against child? this depends what we're observing)
-      // When using browser zoom, the numbers reported back are sometimes sub-pixel and trigger a flickering of the controls; adding +1 fixes this.
-      /*
-      if (width+1 > this.wrapper.scrollWidth) {
-        //
-      }
-      else {
-        //
-      }
-      */
-
-
-      // TechDebt: should this be debounced?
-      this.resized.emit({
+      const customEvent = {
+        host: this.host,
         width: width,
         height: height,
         top: top,
@@ -82,14 +70,27 @@ export class CbpResizeObserver {
         right: right,
         x: x,
         y: y
-      });
+      }
+
+      // TechDebt: should this be debounced?
+      /* not working
+      debounce( () => {
+        this.resized.emit( customEvent);
+       }, this.debounce);
+      */
+      this.resized.emit(customEvent);
 
     });
+
+    // Observe the element
     this.observer.observe(this.observedEl);
   }
 
   disconnectedCallback(){
-    this.observer.disconnect()
+    // remove the ResizeObserver if the component is removed from the DOM
+    if (this.observer) {
+      this.observer.unobserve(this.observedEl);
+    }
   }
 
   render() {
@@ -99,5 +100,4 @@ export class CbpResizeObserver {
       </Host>
     );
   }
-
 }

--- a/packages/web-components/src/components/cbp-tabs/cbp-tabs.tsx
+++ b/packages/web-components/src/components/cbp-tabs/cbp-tabs.tsx
@@ -119,9 +119,10 @@ export class CbpTabs {
   componentDidLoad() {
     this.initTabset();
 
-    // Only set up a ResizeObserver if the checklist is specified as a horizontal mode (inline or series)
+    // Set up a resize observer to compare the host (cbp-tabs) to its child wrapper (div.cbp-tabs-wrapper), looking for overflow.
     this.observer = new ResizeObserver(([{ contentRect: { width } }]) => {
-      // When using browser zoom, the numbers reported back are sometimes sub-pixel and trigger a flickering of the controls; adding +1 fixes this.
+      // When using browser zoom, the numbers reported back are sometimes sub-pixel and trigger a flickering 
+      // of the controls; adding +1 fixes this.
       if (width+1 > this.wrapper.scrollWidth) {
         this.previousControl.setAttribute('hidden','');
         this.nextControl.setAttribute('hidden','');
@@ -131,7 +132,7 @@ export class CbpTabs {
         this.nextControl.removeAttribute('hidden');
       }
     });
-      this.observedEl = this.host; //this.host.querySelector('uef-checklist>uef-input-styles');
+      this.observedEl = this.host;
       this.observer.observe(this.observedEl);
   }
 

--- a/packages/web-components/src/components/cbp-usa-banner/cbp-usa-banner.scss
+++ b/packages/web-components/src/components/cbp-usa-banner/cbp-usa-banner.scss
@@ -56,17 +56,13 @@ cbp-usa-banner {
     --cbp-button-color-border-hover: transparent;
     --cbp-button-color-border-focus: transparent;
     --cbp-button-color-border-active: transparent;
-
     --cbp-button-border-radius: 0;
-
     --cbp-button-color-outline-focus: var(--cbp-color-interactive-focus-light);
 
     --cbp-button-color-bg: transparent;
     --cbp-button-color-bg-hover: transparent;
     --cbp-button-color-bg-focus: transparent;
     --cbp-button-color-bg-active: transparent;
-
-    margin-left: var(--cbp-space-1x);
 
     > button {
       letter-spacing: unset;

--- a/packages/web-components/src/components/cbp-usa-banner/cbp-usa-banner.tsx
+++ b/packages/web-components/src/components/cbp-usa-banner/cbp-usa-banner.tsx
@@ -8,7 +8,7 @@ export class CbpUsaBanner {
 
   @Element() host: HTMLElement;
 
-  /** When set, specifies that the banner is open */
+  /** Specifies that the banner is open. Primarily used for internal component logic.  */
   @Prop({ reflect: true }) open: boolean;
 
   // /** A custom event emitted when the banner link control is activated. */
@@ -19,55 +19,56 @@ export class CbpUsaBanner {
   render() {
     return (
       <Host>
-         <section aria-label="Official website of the United States government">
-           <div class="cbp-banner__title">
-              <img src="data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAABAAAAALCAMAAABBPP0LAAAAG1BMVEUdM7EeNLIeM7HgQCDaPh/bPh/bPx/////bPyBEby41AAAAUElEQVQI123MNw4CABDEwD3jC/9/MQ1BQrgeOSkIqYe2o2FZtthXgQLgbHVMZdlsfUQFQnHtjP1+8BUhBDKOqtmfot6ojqPzR7TjdU+f6vkED+IDPhTBcMAAAAAASUVORK5CYII="
-                height="11"
-                width="16"
-                alt="usa logo" 
-              />
-              <span>
-                <span>Official website of the United States government.</span>
-                <cbp-button
-                  class='cbp-usa-banner-expand'
-                  fill='ghost'
-                  target-prop="open"
-                  controls='gov-banner'
-                  expanded={this.open}
-                  onClick={() => this.handleClick()}
-                >
-                  Here is how you know <cbp-icon name="chevron-right" size="var(--cbp-space-3x)" />
-                </cbp-button>
-              </span>
-            </div>
-            
-            <div class="cbp-usa-banner-content" id="gov-banner">
-              <div>
-                  <cbp-icon 
-                    class='cbp-banner-content-icon'
-                    color="var(--cbp-color-info-light)"
-                    name='landmark'
-                    size="1.25rem" 
-                  />  
-                <div>
-                  <strong>Official websites use .gov</strong>
-                  <p>A <strong>.gov</strong> website belongs to an official government organization in the United States.</p>
-                </div>
-              </div>
+        <section aria-label="Official website of the United States government">
+          <div class="cbp-banner__title">
+            <img src="data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAABAAAAALCAMAAABBPP0LAAAAG1BMVEUdM7EeNLIeM7HgQCDaPh/bPh/bPx/////bPyBEby41AAAAUElEQVQI123MNw4CABDEwD3jC/9/MQ1BQrgeOSkIqYe2o2FZtthXgQLgbHVMZdlsfUQFQnHtjP1+8BUhBDKOqtmfot6ojqPzR7TjdU+f6vkED+IDPhTBcMAAAAAASUVORK5CYII="
+              height="11"
+              width="16"
+              aria-hidden="true"
+              alt=""
+            />
+            <span>
+              <span>Official website of the United States government.</span>
+              <cbp-button
+                class="cbp-usa-banner-expand"
+                fill="ghost"
+                target-prop="open"
+                controls="gov-banner"
+                expanded={this.open}
+                onClick={() => this.handleClick()}
+              >
+                Here is how you know <cbp-icon name="chevron-right" size="var(--cbp-space-3x)" />
+              </cbp-button>
+            </span>
+          </div>
 
+          <div class="cbp-usa-banner-content" id="gov-banner">
+            <div>
+              <cbp-icon
+                class="cbp-banner-content-icon"
+                color="var(--cbp-color-info-light)"
+                name="landmark"
+                size="1.25rem"
+              />
               <div>
-                <cbp-icon 
-                  class='cbp-banner-content-icon'
-                  color="var(--cbp-color-info-light)"
-                  name='lock'
-                  size="1.25rem" 
-                />
-                <div>
-                  <strong>Secure .gov websites use HTTPS</strong>
-                  <p>A <strong>lock</strong> (<cbp-icon name='lock' />) or <strong>https://</strong> means you&#39;ve safely connected to the .gov website. Share sensitive information only on official, secure websites.</p>
-                </div>
+                <strong>Official websites use .gov</strong>
+                <p>A <strong>.gov</strong> website belongs to an official government organization in the United States.</p>
               </div>
             </div>
+
+            <div>
+              <cbp-icon
+                class="cbp-banner-content-icon"
+                color="var(--cbp-color-info-light)"
+                name="lock"
+                size="1.25rem"
+              />
+              <div>
+                <strong>Secure .gov websites use HTTPS</strong>
+                <p>A <strong>lock</strong> (<cbp-icon name="lock" size="var(--cbp-space-3x)" />) or <strong>https://</strong> means you&#39;ve safely connected to the .gov website. Share sensitive information only on official, secure websites.</p>
+              </div>
+            </div>
+          </div>
         </section>
       </Host>
     );

--- a/packages/web-components/src/utils/utils.tsx
+++ b/packages/web-components/src/utils/utils.tsx
@@ -59,9 +59,8 @@ export const getFocusableElements = (scope: HTMLElement) => {
   //return Array.from(scope.querySelectorAll('[tabindex="0"],a[href],button,input,textarea,select'));
 };
 
-
-export const debounce = <T extends { [key: string]: any }>({ callback, ms, prevent }: T) => {
-  let timer: ReturnType<typeof setTimeout>;
+export const debounce = (callback, wait, prevent=false) => {
+  let timer: ReturnType<typeof setTimeout> = null;;
   return (...args) => {
     if (prevent) {
       const e = args[0];
@@ -69,10 +68,11 @@ export const debounce = <T extends { [key: string]: any }>({ callback, ms, preve
       e.stopPropagation();
     }
     clearTimeout(timer);
-    timer = setTimeout(callback, ms, ...args);
+    timer = setTimeout(() => {
+      callback.apply(null, args);
+    }, wait);
   };
 };
-
 
 export const getElementAttrs = (el: HTMLElement): { [key: string]: any } => {
   let attrs = {};

--- a/packages/web-components/stencil.config.ts
+++ b/packages/web-components/stencil.config.ts
@@ -46,6 +46,10 @@ export const config: Config = {
       type: 'docs-readme',
       footer: '  ',
     },
+    { 
+      type: 'docs-vscode',
+      file: 'dist/vscode/cbpds-vscode-data.json',
+    },
     {
       type: 'www',
       copy: [


### PR DESCRIPTION
* Updated resize observer for actual use and added docs.
* Added responsive behavior to breadcrumbs using resize observer and menu.
* Fixed debounce function.
* Added vscode output target to Stencil config.
* Cleanup and tweaks to USA Banner.
* Updated other package and component docs.

I wanted to get debounce working at the resize observer component level (exposed to the end user), but had trouble. I left some comments in related to that so I can revisit it. It works for this case and I wanted to get this out the door.