### PR TITLE
bugfix/combobo-accept-space

### DIFF
--- a/packages/web-components/src/components/cbp-dropdown/cbp-dropdown.tsx
+++ b/packages/web-components/src/components/cbp-dropdown/cbp-dropdown.tsx
@@ -459,9 +459,10 @@ export class CbpDropdown {
     const openKeys = ['ArrowDown', 'ArrowUp', 'Enter', ' ']; // all keys that will do the default open action
     const navKeys = ['ArrowDown', 'ArrowUp', 'Enter', 'Home', 'End']; // all keys that will do the default open action
 
-    // If the menu is already open, pressing enter or space triggers a click on the current item. 
+    // If the menu is already open, pressing enter or space triggers a click on the current item -
+    // with an exception for pressing space as part of a combobox searchString (not the first character).
     // Run this first, before the menu may be opened by later code.
-    if (this.open && selectKeys.includes(key)) {
+    if (this.open && selectKeys.includes(key) && !(key == ' ' && this.searchString !== '')) {
       //event.preventDefault();
       this.dropdownItems[this.focusIndex]?.click();
       return;
@@ -500,9 +501,15 @@ export class CbpDropdown {
     }
 
     
-    // handle typing characters when open or closed
-    if ( key === 'Backspace' || key === 'Clear' ||
-        (key.length === 1 && key !== ' ' && !altKey && !ctrlKey && !metaKey && !navKeys.includes(key))
+    // handle typing characters when open or closed, allowing for Space as part of the searchString (not first character)
+    if ( key === 'Backspace' || key === 'Clear' || (key == ' ' && this.searchString !== '') ||
+        (
+          key.length === 1 && 
+          !altKey && 
+          !ctrlKey && 
+          !metaKey && 
+          !navKeys.includes(key)
+        )
     ) {
       this.open=true;
       this.filter ? this.searchByString(key.toLowerCase()) : this.jumpToLetter(key.toLowerCase());


### PR DESCRIPTION
Update dropdown combobox to accept Space as a search string character (just not first). Testable in the last 3 stories for dropdown (may need to turn on the "filter" control in the second to last).
