### PR TITLE
Bugfix/a11y fixes 20250630

### DIFF
--- a/packages/web-components/CHANGELOG.md
+++ b/packages/web-components/CHANGELOG.md
@@ -4,6 +4,17 @@ This CHANGELOG.md tracks the updates to the web components package of the CBP de
 
 The React components are wrappers generated from this package and will share the same changes. Projects using React 19 may use the native web components without React wrappers.
 
+## [unreleased] TBD
+
+* BREAKING: Updated the `cbp-button` properties of `expanded` and `pressed` to a string union of `"true" | "false"` rather than a true Boolean value.
+  * This is due to the fact that JSX does not render the `aria-expanded` or `aria-pressed` at all with a false value.
+  * When `aria-expanded="false"` is not rendered, the statefulness of the control is not conveyed to screen readers and updates to the state are only spoken when the value is true.
+  * These properties are primarily used internally and this change is unlikely to cause significant problems.
+  * Components updated to work with this change include: Accordion Item, Expand, Menu, Code Snippet, Subnav Item, and Segmented Button Group.
+  * Story code was updated and may need to be copied fresh for: 
+    * Segmented Button Group (only if Button "pressed" values were explicitly set as a boolean HTML attribute).
+    * Button (only if `pressed` or `expanded` props were used).
+
 ## [0.0.1-develop.22] 07-02-2025
 
 * First cut of the `cbp-resize-observer` component.

--- a/packages/web-components/src/components/cbp-accordion-item/cbp-accordion-item.tsx
+++ b/packages/web-components/src/components/cbp-accordion-item/cbp-accordion-item.tsx
@@ -27,7 +27,7 @@ export class CbpAccordionItem {
   @Prop() headingId: string = createNamespaceKey('cbp-accordion-item');
   
   /** Specifies whether the accordion is open. */
-  @Prop({ reflect: true }) open: boolean;
+  @Prop({ reflect: true }) open: boolean = false;
   
   /** The accordion control label. */
   @Prop() label: string;
@@ -79,9 +79,8 @@ export class CbpAccordionItem {
             fill="ghost"
             color="secondary"
             controls={`${this.headingId}-content`}
-            expanded={this.open}
-            accessibilityText="Toggle Accordion Item"
-            aria-describedby={this.headingId}
+            expanded={`${this.open}`}
+            aria-labelledby={this.headingId}
             ref={el => (this.control = el)}
           >
             <cbp-icon name="chevron-right"></cbp-icon>

--- a/packages/web-components/src/components/cbp-accordion/cbp-accordion.specs.mdx
+++ b/packages/web-components/src/components/cbp-accordion/cbp-accordion.specs.mdx
@@ -21,20 +21,21 @@ An Accordion is a common paradigm for progressive disclosure, organizing content
 
 ### User Interactions
 
-* Accordion Items are toggled via its heading.
+* Accordion Items are toggled via its heading and button control.
   * While the entire heading is not a button, clicking anywhere on it will toggle its content.
   * When using keyboard navigation, the actual chevron button will gain focus and activation will toggle the accordion item.
 
 ### Responsiveness
 
-* Accordion Item headings should remain brief enough to prevent wrapping into more than two lines on the smallest device profile.
+* Accordion Item headings will wrap as needed, but should remain brief enough to prevent wrapping into more than two lines on the smallest device profile.
 
 ### Accessibility
 
 * Accordion Item headings default to `h3` tags, but should use the appropriate heading level for the document structure.
-* When the Accordion Item heading is activated, whether content is expanded or collapsed, focus is sent to the actual button control.
-* The button control has the `aria-expanded` attribute applied to convey statefulness of the Accordion Item.
-* The button control also contains the `aria-controls` attribute, referencing the `id` of the Accordion Item content wrapper.
+* When the Accordion Item control is activated, whether content is expanded or collapsed, focus is sent to the actual button control.
+  * The button control has the `aria-labelledby` attribute referencing the text of the Accordion Item heading.
+  * The button control has the `aria-expanded` attribute applied to convey statefulness of the Accordion Item.
+  * The button control also contains the `aria-controls` attribute, referencing the `id` of the Accordion Item content wrapper.
 
 ### Additional Notes and Considerations
 

--- a/packages/web-components/src/components/cbp-button/cbp-button.stories.tsx
+++ b/packages/web-components/src/components/cbp-button/cbp-button.stories.tsx
@@ -124,8 +124,8 @@ const Template = ({ label, withIcon, tag, type, value, href, rel, target, downlo
         ${accessibilityText ? `accessibility-text=${accessibilityText}` : ''}
         ${controls ? `controls=${controls}` : ''}
         ${targetProp ? `target-prop=${targetProp}` : ''}
-        ${pressed ? `pressed=${pressed}` : ''}
-        ${expanded ? `expanded=${expanded}` : ''}
+        ${pressed!=undefined ? `pressed="${pressed}"` : ''}
+        ${expanded!=undefined ? `expanded="${expanded}"` : ''}
         ${disabled ? 'disabled' : ''}
         ${context && context != 'light-inverts' ? `context=${context}` : ''}
         ${sx ? `sx=${JSON.stringify(sx)}` : ''}

--- a/packages/web-components/src/components/cbp-button/cbp-button.tsx
+++ b/packages/web-components/src/components/cbp-button/cbp-button.tsx
@@ -56,15 +56,18 @@ export class CbpButton {
   /** Specifies the (min-)height of the button (in CSS units) when different from the default size. */
   @Prop() height: string;
 
-  /** Specifies if the button is pressed and results in `aria-pressed="true"` being placed on the button when true. Only valid on actual `button` elements. */
-  @Prop() pressed: boolean;
+  /** 
+   * Specifies if the button is pressed and results in `aria-pressed="true|false"` being placed on the 
+   * button when specified. Only valid on actual `button` elements. 
+   */
+  @Prop() pressed: "true" | "false";
   
   /** 
-   * Specifies if a controlled UI widget is expanded and results in `aria-pressed="true"` being placed on the button when true.
-   * This property is usually used for progressive disclosure patterns such as accordions, menus, expand/collapse, etc., where
-   * focus remains on the control after the user action.
+   * Specifies if a controlled UI widget is expanded and results in `aria-pressed="true|false"` being placed 
+   * on the button when specified. This property is usually used for progressive disclosure patterns such as 
+   * accordions, menus, expand/collapse, etc., where focus remains on the control after the user action.
    */
-  @Prop() expanded: boolean;
+  @Prop() expanded: "true" | "false";
 
   /** 
    * Specifies the DOM element that the button controls and results in the `aria-controls` attribute
@@ -75,10 +78,11 @@ export class CbpButton {
   /* ??? */
   //@Prop() controlProp: "pressed" | "expanded";
   
-  /** The property on the target element being toggled by the button/control. */
-  @Prop() targetProp: string; // A prop on the controlled element such as "open"
+  /** The property on the target element being toggled by the button/control (e.g., "open"). */
+  @Prop() targetProp: string;
 
-  /** Specifies an accessible label for the button/link as an `aria-label` when the button does not contain label text
+  /** 
+   * Specifies an accessible label for the button/link as an `aria-label` when the button does not contain label text
    * or a sufficiently unique label. This text overrides the default label and is not additive to it.
    */
   @Prop() accessibilityText: string;
@@ -104,17 +108,27 @@ export class CbpButton {
     // If this is a control for something, manage state through stencil store
     if (this.controls) {
       // If the controlled element wasn't found, try to find it again
-      if (!this.controlTarget) {
-        this.controlTarget = this.controls ? document.querySelector(`#${this.controls}`) : undefined;
-      }
+      if (!this.controlTarget) this.controlTarget = document.querySelector(`#${this.controls}`);
+
       // Toggle the prop it controls
       if (this.controlTarget) {
         this.controlTarget[this.targetProp] = !this.controlTarget[this.targetProp];
-        this.host.expanded = this.controlTarget[this.targetProp]
+        //this.host.expanded = this.controlTarget[this.targetProp]; // TechDebt: does it make sense to assume this? This could be the cause of some issues seen in testing.
       } 
       else {
         console.warn('cbp-button configuration error: the control target referenced by ID by the `control` property could not be found.');
       }
+
+      // Toggle the control's expanded/pressed props, if set
+      // Does this conflict with existing behavior where another component controls these? Very likely.
+      /*
+      if (this.expanded != undefined) {
+        this.expanded == "true" ? "false" : "true";
+      }
+      if (this.pressed != undefined) {
+        this.pressed == "true" ? false : true;
+      }
+      */
     }
 
     this.buttonClick?.emit({
@@ -189,7 +203,7 @@ export class CbpButton {
   }
 
   render() {
-    const { type, name, value, pressed, expanded, disabled, rel, target, href, download } = this;
+    const { type, name, value, disabled, rel, target, href, download } = this;
 
     const attrs =
       this.tag === 'button'
@@ -225,8 +239,8 @@ export class CbpButton {
             {...attrs}
             disabled={this.disabled}
             aria-label={this.accessibilityText}
-            aria-pressed={pressed ? 'true' : null}
-            aria-expanded={expanded ? 'true' : null}
+            aria-pressed={this.pressed}
+            aria-expanded={this.expanded}
             aria-controls={this.controls}
             ref={el => (this.button = el)}
           >
@@ -244,8 +258,8 @@ export class CbpButton {
             {...this.persistedAttrs}
             {...attrs}
             aria-label={this.accessibilityText}
-            aria-pressed={pressed ? 'true' : null}
-            aria-expanded={expanded ? 'true' : null}
+            aria-pressed={this.pressed}
+            aria-expanded={this.expanded}
             aria-controls={this.controls}
             role={disabled ? 'link' : null}
             aria-disabled={disabled ? 'true' : null}

--- a/packages/web-components/src/components/cbp-button/cbp-button.tsx
+++ b/packages/web-components/src/components/cbp-button/cbp-button.tsx
@@ -113,22 +113,11 @@ export class CbpButton {
       // Toggle the prop it controls
       if (this.controlTarget) {
         this.controlTarget[this.targetProp] = !this.controlTarget[this.targetProp];
-        //this.host.expanded = this.controlTarget[this.targetProp]; // TechDebt: does it make sense to assume this? This could be the cause of some issues seen in testing.
       } 
       else {
         console.warn('cbp-button configuration error: the control target referenced by ID by the `control` property could not be found.');
       }
-
-      // Toggle the control's expanded/pressed props, if set
-      // Does this conflict with existing behavior where another component controls these? Very likely.
-      /*
-      if (this.expanded != undefined) {
-        this.expanded == "true" ? "false" : "true";
-      }
-      if (this.pressed != undefined) {
-        this.pressed == "true" ? false : true;
-      }
-      */
+      // Toggling the control's expanded/pressed props is handled by parent components, so it cannot be done here.
     }
 
     this.buttonClick?.emit({
@@ -168,7 +157,8 @@ export class CbpButton {
   }
 
   componentDidLoad() {
-    // If the button was not defined by ref in the render lifecycle, query the DOM for one that may have been slotted and attach an event listener to it
+    // If the button was not defined by ref in the render lifecycle, query the DOM for one that may 
+    // have been slotted and attach an event listener to it.
     if (!this.button) {
       const slottedButton = (this.button = this.host.querySelector('button,a'));
       if (slottedButton) {

--- a/packages/web-components/src/components/cbp-chip/cbp-chip.specs.mdx
+++ b/packages/web-components/src/components/cbp-chip/cbp-chip.specs.mdx
@@ -32,6 +32,7 @@ The Chip component acts like an interactive version of the Tag and is typically 
 
 * Chips render a button that is fully mouse and keyboard accessible with the required visible focus indicator.
 * Chips should always contain a visible text label.
+* Chips use the "pressed" property (defaults to false) for statefulness, which renders `aria-pressed` on the native `button` element.
 
 ### Additional Notes and Considerations
 

--- a/packages/web-components/src/components/cbp-chip/cbp-chip.tsx
+++ b/packages/web-components/src/components/cbp-chip/cbp-chip.tsx
@@ -27,7 +27,7 @@ export class CbpChip {
   @Prop() value: string;
   
   /** Specifies the pressed state of the button and `aria-pressed` attribute of the rendered button */
-  @Prop() pressed: boolean;
+  @Prop() pressed: boolean = false;
 
   /** Specifies the context of the component as it applies to the visual design and whether it inverts when light/dark mode is toggled. Default behavior is "light-inverts" and does not have to be specified. */
   @Prop({ reflect: true }) context: "light-inverts" | "light-always" | "dark-inverts" | "dark-always";

--- a/packages/web-components/src/components/cbp-code-snippet/cbp-code-snippet.specs.mdx
+++ b/packages/web-components/src/components/cbp-code-snippet/cbp-code-snippet.specs.mdx
@@ -40,7 +40,8 @@ The Code Snippet component is used to display code in a readable format and faci
 
 * The "Copy" and "Show More/Less" buttons are usable via keyboard navigation.
 * The "Copy" button displays only an icon, but has an `aria-label` applied to provide an accessible name.
-* The "Show More/Less" button will have the `aria-expanded` attribute to indicate its functionality to progressively reveal more information.
+* The "Show More/Less" button will have `aria-expanded="false"` to indicate its functionality to progressively reveal more information.
+* Upon user interaction with the "Show More/Less" button, the `aria-expanded` value will be toggled.
 
 ### Additional Notes and Considerations
 

--- a/packages/web-components/src/components/cbp-code-snippet/cbp-code-snippet.tsx
+++ b/packages/web-components/src/components/cbp-code-snippet/cbp-code-snippet.tsx
@@ -31,7 +31,7 @@ export class CbpCodeSnippet {
 
 
   // There are issues with allowing the component to render expanded, so make this a state that defaults to no expanded.
-  @State() expanded: boolean;
+  @State() expanded: boolean = false;
   @State() codeContainerHeight: number;
   @State() codeBlockHeight: number;
 
@@ -116,7 +116,7 @@ export class CbpCodeSnippet {
           <cbp-button 
             fill="ghost" 
             color="secondary" 
-            expanded={this.expanded} 
+            expanded={`${this.expanded}`} 
             context={this.context}
             onClick={() => this.toggleShowAll()} 
           >

--- a/packages/web-components/src/components/cbp-expand/cbp-expand.specs.mdx
+++ b/packages/web-components/src/components/cbp-expand/cbp-expand.specs.mdx
@@ -31,8 +31,9 @@ The Expand component is a standalone component used for progressive disclosure, 
 
 * Expand component headings default to `h4` tags, but should use the appropriate heading level for the document structure.
 * When the component heading is activated, whether content is expanded or collapsed, focus is sent to the actual button control.
-* The button control has the `aria-expanded` attribute applied to convey statefulness of the control.
-* The button control also contains the `aria-controls` attribute, referencing the `id` of the content wrapper.
+  * The button control has the `aria-labelledby` attribute referencing the text of the Expand heading.
+  * The button control has the `aria-expanded` attribute applied to convey statefulness of the control.
+  * The button control also contains the `aria-controls` attribute, referencing the `id` of the content wrapper.
 
 ### Additional Notes and Considerations
 

--- a/packages/web-components/src/components/cbp-expand/cbp-expand.tsx
+++ b/packages/web-components/src/components/cbp-expand/cbp-expand.tsx
@@ -26,7 +26,7 @@ export class CbpExpand {
   @Prop() headingId: string = createNamespaceKey('cbp-expand');
   
   /** Specifies whether the content is expanded and visible. */
-  @Prop({ reflect: true }) open: boolean;
+  @Prop({ reflect: true }) open: boolean = false;
   
   /** The component control label. */
   @Prop() label: string;
@@ -84,9 +84,8 @@ export class CbpExpand {
               height="var(--cbp-space-6x)"
               context={this.context}
               controls={`${this.headingId}-content`}
-              expanded={this.open}
-              accessibilityText="Expand/collapse"
-              aria-describedby={this.headingId}
+              expanded={`${this.open}`}
+              aria-labelledby={this.headingId}
               ref={el => (this.control = el)}
             >
               <cbp-icon name="caret-down" size="var(--cbp-space-3x)"></cbp-icon>

--- a/packages/web-components/src/components/cbp-menu-item/cbp-menu-item.tsx
+++ b/packages/web-components/src/components/cbp-menu-item/cbp-menu-item.tsx
@@ -41,7 +41,7 @@ export class CbpMenuItem {
 
   render() {
     return (
-      <Host>
+      <Host role="presentation">
         <slot />
       </Host>
     );

--- a/packages/web-components/src/components/cbp-menu/cbp-menu.specs.mdx
+++ b/packages/web-components/src/components/cbp-menu/cbp-menu.specs.mdx
@@ -24,7 +24,7 @@ A Menu contains additional actions in the form of links or buttons, which can be
 ### User Interactions
 
 * Activating the menu control (button) will toggle the menu visibility and emit a custom `menuToggle` event in addition to the native button's `click` event.
-* When opened, focus will be sent to the first menu item.
+* When opened, focus will be sent to the first menu item (on a slight delay, so that it is read by screen readers).
 * Once open, the menu items can be navigated via keyboard using the arrow keys (rather than tab).
   * Pressing `Arrow Down` or `Arrow Right` will navigate to the next menu item.
   * Pressing `Arrow Up` or `Arrow Left` will navigate to the previous menu item.
@@ -42,11 +42,14 @@ A Menu contains additional actions in the form of links or buttons, which can be
 
 * The menu control shall always be a `button` tag with `type="button"`.
 * The menu control shall have `aria-haspopup="menu"` applied to it.
+* The menu control shall have `aria-expanded="false"` applied to it by default.
 * The menu control shall have a unique `id`, which is referenced by the semantic menu's (containing `role="menu"`) `aria-labelledby` attribute.
-* Buttons without accessible label text, such as icon buttons, should use the `aria-label` attribute to specify an accessible label that uniquely identifies the control.
-* Activating the menu control (button) will toggle `aria-expanded` attribute, which is managed by the component, and send focus to the first item in the menu.
+* Buttons controls accessible label text, such as icon buttons, should use the `accessibilityText` property (for the Button component) or `aria-label` attribute (for native buttons) to specify an accessible label that uniquely identifies the control.
 * Menu items should be represented by semantically valid links or buttons, depending on their functionality.
-* Keyboard navigation is supported according to the specifications in the User Interactions section, above.
+* Activating the menu control (button) will:
+  * Toggle `aria-expanded` attribute, which is managed by the component and
+  * Send focus to the first menu item (on a slight delay, so that it is read by screen readers).
+  * Keyboard navigation is supported according to the specifications in the User Interactions section, above.
 * If the menu is closed by pressing `ESC` or activating the close button, focus will be returned to the menu's control.
 
 ### Additional Notes and Considerations

--- a/packages/web-components/src/components/cbp-menu/cbp-menu.tsx
+++ b/packages/web-components/src/components/cbp-menu/cbp-menu.tsx
@@ -78,6 +78,9 @@ export class CbpMenu {
         100
       );
     }
+
+    // regardless of the new value, set the expanded value on the control
+    this.CBPButton.expanded=`${this.open}`;
   }
 
   // Clicking outside of the component closes the menu
@@ -110,7 +113,7 @@ export class CbpMenu {
   }
 
   setCurrentMenuItem(i = 0) {
-    this.menuItems[i]?.focus();
+    this.menuItems[i].focus();
   }
 
   // if tabbing out of the menu from the close button, close the menu
@@ -133,9 +136,11 @@ export class CbpMenu {
 
   componentDidLoad() {
     this.menuItems = Array.from(this.menu.querySelectorAll('button, a'));
+
     if (!this.control) this.control = this.host.querySelector('button');
     if (this.control) {
       this.CBPButton.controls=this.uid;
+      this.CBPButton.expanded=`${this.open}`;
       this.control.setAttribute('aria-controls',`${this.uid}-menu`);
       this.control.setAttribute("aria-haspopup","menu");
     }

--- a/packages/web-components/src/components/cbp-menu/cbp-menu.tsx
+++ b/packages/web-components/src/components/cbp-menu/cbp-menu.tsx
@@ -75,7 +75,7 @@ export class CbpMenu {
 
       setTimeout( () => 
         this.setCurrentMenuItem(),
-        100
+        500
       );
     }
 
@@ -135,7 +135,7 @@ export class CbpMenu {
   }
 
   componentDidLoad() {
-    this.menuItems = Array.from(this.menu.querySelectorAll('button, a'));
+    this.menuItems = Array.from(this.menu.querySelectorAll('button,a'));
 
     if (!this.control) this.control = this.host.querySelector('button');
     if (this.control) {

--- a/packages/web-components/src/components/cbp-segmented-button-group/cbp-segmented-button-group.scss
+++ b/packages/web-components/src/components/cbp-segmented-button-group/cbp-segmented-button-group.scss
@@ -28,7 +28,7 @@ cbp-segmented-button-group {
     --cbp-button-color-bg-dark: var(--cbp-color-gray-cool-80);
     --cbp-button-color-bg-hover-dark: var(--cbp-color-interactive-secondary-light);
     
-      // borders are unchanging in segmented button groups even in interactive states
+    // borders are unchanging in segmented button groups even in interactive states
     --cbp-button-color-border-dark: var(--cbp-color-interactive-secondary-lighter);
     --cbp-button-color-border-hover-dark: var(--cbp-button-color-border-dark);
     --cbp-button-color-border-focus-dark: var(--cbp-button-color-border-dark);
@@ -47,7 +47,7 @@ cbp-segmented-button-group {
       --cbp-button-border-width: var(--cbp-border-size-md) var(--cbp-border-size-md) var(--cbp-border-size-md) calc(var(--cbp-border-size-md) / 2);
     }
 
-    &:has([aria-pressed='true']) {
+    &:has([aria-pressed=true]) {
       --cbp-button-color: var(--cbp-color-white);
       --cbp-button-color-bg: var(--cbp-color-interactive-selected-dark);
       

--- a/packages/web-components/src/components/cbp-segmented-button-group/cbp-segmented-button-group.specs.mdx
+++ b/packages/web-components/src/components/cbp-segmented-button-group/cbp-segmented-button-group.specs.mdx
@@ -18,7 +18,10 @@ The Segmented Button Group component wraps multiple buttons and can be used as a
 ### User Interactions
 
 * Activating any of the buttons within the group toggles the `pressed` property and likewise `aria-pressed` value on the button element.
-* If the group allows only one button to be active, when pressing a button, all others will be programmatically "unpressed."
+* If the group allows only one button to be active:
+  * When pressing a button, all others will be programmatically "unpressed."
+  * Pressing a button again does not toggle it "unpressed"; it stays pressed, like a radio button.
+* If the group allows multiple selections, user interaction toggles the pressed state and does not affect the other buttons in the group.
 * When a button within the group is activated (either pressed state) by user interaction, both the Button and the Segmented Button Group components emit custom events that can be listened for.
 
 ### Responsiveness

--- a/packages/web-components/src/components/cbp-segmented-button-group/cbp-segmented-button-group.stories.tsx
+++ b/packages/web-components/src/components/cbp-segmented-button-group/cbp-segmented-button-group.stories.tsx
@@ -24,7 +24,17 @@ export default {
 
 function generateButtons(buttons) {
   const html = buttons.map(({ label, value, pressed, disabled, variant }) => {
-    return `<cbp-button type="button" value="${value}" ${pressed == true ? 'pressed' : ''} ${disabled == true ? 'disabled' : ''} ${variant ? `variant="${variant}"` : ''}>${label}</cbp-button>`;
+    return `
+      <cbp-button 
+        type="button" 
+        value="${value}" 
+        ${pressed != undefined ? `pressed="${pressed}"` : ''}
+        ${disabled == true ? 'disabled' : ''}
+        ${variant ? `variant="${variant}"` : ''}
+      >
+        ${label}
+      </cbp-button>
+    `;
   });
   return html.join('');
 }

--- a/packages/web-components/src/components/cbp-segmented-button-group/cbp-segmented-button-group.tsx
+++ b/packages/web-components/src/components/cbp-segmented-button-group/cbp-segmented-button-group.tsx
@@ -77,6 +77,16 @@ export class SegmentedButtonGroup {
     });
   }
 
+  componentDidLoad() {
+    // Set the pressed state of each button to "false" if it's not set to "true" already.
+    this.buttongroup.forEach( cbpButton => {
+      if(cbpButton.pressed !== "true"){
+        cbpButton.pressed="false";
+      }
+    });
+  }
+
+
   render() {
     return (
       <Host role="group" aria-label={this.accessibilityText}>

--- a/packages/web-components/src/components/cbp-segmented-button-group/cbp-segmented-button-group.tsx
+++ b/packages/web-components/src/components/cbp-segmented-button-group/cbp-segmented-button-group.tsx
@@ -43,14 +43,16 @@ export class SegmentedButtonGroup {
 
   @Listen('buttonClick')
   handleButtonClick({ detail: { nativeElement: element, host, value } }) {
-    // Toggle "pressed" prop on the button
-    host.pressed=!host.pressed;
+    // Toggle "pressed" prop on the button only when multiple selections are allowed; 
+    // otherwise, it acts like a radio list and a click selects it but doesn't deselect it.
+    if (this.multiple) host.pressed = (host.pressed == "true") ? "false" : "true";
+    else host.pressed = "true";
 
     // if a button was toggled to "pressed," toggle the rest unpressed for groups that only allow a single buttons pressed.
     if(!this.multiple && host.pressed) {
       this.buttongroup.forEach(el => {
         if(el != host){
-          el.pressed=false;
+          el.pressed="false";
         }
       });
     }

--- a/packages/web-components/src/components/cbp-subnav-item/cbp-subnav-item.tsx
+++ b/packages/web-components/src/components/cbp-subnav-item/cbp-subnav-item.tsx
@@ -1,5 +1,5 @@
 import { Component, Element, Event, EventEmitter, Prop, Host, h } from '@stencil/core';
-import { setCSSProps } from '../../utils/utils';
+import { setCSSProps, createNamespaceKey } from '../../utils/utils';
 
 
 /**
@@ -20,26 +20,33 @@ export class CbpSubnavItem {
 
   @Element() host: HTMLCbpSubnavItemElement;
 
-  /** Specifies the current Subnav Item */
-  @Prop ({ reflect: true}) current: boolean = false;
+  /** Specifies the text label for the subnav item. */
+  @Prop() label: string;
 
-  /** Specifies a name used to associated nav items with subnav items*/
-  @Prop({ reflect: true }) name: string;
-
-  /** Specifies the label for the subnav item */
-  @Prop () label: string;
-
-  /** Specifies the href passed to the button prop */
+  /** Specifies the href for the Subnav Item anchor. */
   @Prop() href: string;
 
-  /** used to style icon based on open/hide state */
-  @Prop({ reflect: true }) open: boolean 
+  /** Optionally specifies a unique `ID` for the menu, used to wire up the controls and accessibility features. */
+  @Prop() uid: string = createNamespaceKey('cbp-subnav-item');
+
+  /** Specifies a name used to associated Nav Items with Subnav Items. */
+  @Prop({ reflect: true }) name: string;
+
+  /** Specifies the current item within the collection of Subnav Items. */
+  @Prop ({ reflect: true}) current: boolean = false;
+
+  /** 
+   * Specifies whether a Subnav Item with nested children is expanded or collapsed. 
+   * Primarily used internally for user interactions.
+   */
+  @Prop({ reflect: true }) open: boolean = false;
   
   /** Specifies the context of the component as it applies to the visual design and whether it inverts when light/dark mode is toggled. Default behavior is "light-inverts" and does not have to be specified. */
   @Prop({ reflect: true }) context: "light-inverts" | "light-always" | "dark-inverts" | "dark-always";
 
   /** Supports adding inline styles as an object */
   @Prop() sx: any = {};
+
 
   @Event() toggleSubnavItem: EventEmitter;
   handleToggleSubnavItem(){
@@ -78,6 +85,7 @@ export class CbpSubnavItem {
       <Host>
         <div>
           <cbp-button
+            id={this.uid}
             tag="a"
             fill="outline"
             color="primary"
@@ -94,6 +102,8 @@ export class CbpSubnavItem {
             <cbp-button
               fill="outline"
               color="primary"
+              expanded={`${this.open}`}
+              aria-labelledby={this.uid}
               context={this.context}
               onClick={() => this.handleToggleSubnavItem()}
             >

--- a/packages/web-components/src/components/cbp-subnav/cbp-subnav.specs.mdx
+++ b/packages/web-components/src/components/cbp-subnav/cbp-subnav.specs.mdx
@@ -41,15 +41,17 @@ Sub-Navigation (Subnav) is meant to be used as a secondary, vertical navigation.
 
 ### Responsiveness
 
-* Subnav is designed to be inside of a Drawer component and as such will defer to the Responsiveness of the Drawer component
+* Subnav is primarily designed to be inside of a Drawer component, and as such will defer to the responsiveness of the Drawer.
 
 ### Accessibility
 
-* The "current" navigation control is denoted via `aria-current` as well as visual styling.
-* Keyboard tab navigation will be fore both anchor button and icon button seperately
-* Icon button will hide/expand on 'enter & space'
-* anchor buttons will launch to associated href on 'enter'
-* use of the navigation tag w/ a prop for accessibility text
+* The Sub-Navigation items are wrapped in a semantic `nav` landmark tag.
+  * Since this is likely not the first or only `nav` tag, it should be supplied with an accessible label.
+  * The Subnav component sets this accessible label (`aria-label`) to "Sub-Navigation" by default, but it should be overridden with something more contextual when applicable. For example, when used solely for the responsive navigation, perhaps "Mobile Navigation" would be a better description.
+* The "current" navigation control is denoted via `aria-current="page"` as well as visual styling.
+* Keyboard navigation allow tabbing to both the anchor and expand button separately.
+* The expand button is labelled by the Subnav Item's anchor text (via `aria-labelledby`).
+* The expand button renders an `aria-expanded` attribute to indicate the state of the expanded/collapsed content.
 
 ### Additional Notes and Considerations
 

--- a/packages/web-components/src/components/cbp-tab/cbp-tab.tsx
+++ b/packages/web-components/src/components/cbp-tab/cbp-tab.tsx
@@ -67,7 +67,7 @@ export class CbpTab {
 
   render() {
     return (
-      <Host>
+      <Host role="presentation">
         <button
           type="button"
           role="tab"

--- a/packages/web-components/src/components/cbp-table/cbp-table.tsx
+++ b/packages/web-components/src/components/cbp-table/cbp-table.tsx
@@ -68,14 +68,19 @@ export class CbpTable {
         
         // Update the icon for any initial sort
         const icon = control.querySelector('button cbp-icon') as HTMLCbpIconElement;
+        
         if (item.getAttribute('aria-sort') == "ascending") icon.rotate = 270;
         if (item.getAttribute('aria-sort') == "descending") icon.rotate = 90;
         // Set aria-sort to none last
         if (!item.getAttribute('aria-sort')) {
           item.setAttribute("aria-sort","none");
           icon.setAttribute('hidden','');
+          control.pressed="false";
         }
-        else icon.name="arrow-right";
+        else {
+          icon.name="arrow-right";
+          control.pressed="true";
+        }
 
         // ({detail: { host, nativeElement, value }})
         control.addEventListener( "buttonClick", () => {
@@ -115,12 +120,12 @@ export class CbpTable {
     else {
       // If a new header was pressed, reset the previous sort state
       this.sort.columnHeading.setAttribute('aria-sort','none');
-      this.sort.columnHeading.querySelector('cbp-button').pressed=false;
+      this.sort.columnHeading.querySelector('cbp-button').pressed="false";
       (this.sort.columnHeading.querySelector('button cbp-icon') as HTMLCbpIconElement).name=undefined;
       (this.sort.columnHeading.querySelector('button cbp-icon')).setAttribute('hidden','');
   
       // Set the new sort state
-      CbpButton.pressed=true;
+      CbpButton.pressed="true";
     }
     // Update the statefulness of the sorted header
     Icon.removeAttribute('hidden');

--- a/packages/web-components/src/components/cbp-usa-banner/cbp-usa-banner.tsx
+++ b/packages/web-components/src/components/cbp-usa-banner/cbp-usa-banner.tsx
@@ -13,7 +13,7 @@ export class CbpUsaBanner {
   @Element() host: HTMLElement;
 
   /** Specifies that the banner is open. Primarily used for internal component logic.  */
-  @Prop({ reflect: true }) open: boolean;
+  @Prop({ reflect: true }) open: boolean = false;
 
   // /** A custom event emitted when the banner link control is activated. */
   handleClick() {
@@ -38,7 +38,7 @@ export class CbpUsaBanner {
                 fill="ghost"
                 target-prop="open"
                 controls="gov-banner"
-                expanded={this.open}
+                expanded={`${this.open}`}
                 onClick={() => this.handleClick()}
               >
                 Here is how you know <cbp-icon name="chevron-right" size="var(--cbp-space-3x)" />


### PR DESCRIPTION
* The main issue is changing the `pressed` and `expanded` properties of `cbp-button` to a string union of `"true"|"false"` from a Boolean. This is due to the fact that JSX does not render the `aria-expanded` or `aria-pressed` at all with a false value. When `aria-expanded="false"` is not rendered, the statefulness of the control is not conveyed to screen readers and updates to the state are only spoken when the value is true.
* Resulting component updates impacted by this change:
  * Accordion - removed aria-label (verbose), updated aria-describedby to aria-labelledby, outputting expanded=false improves accessibility and feedback on state changes/user interaction.
  * Breadcrumb (responsive menu) - added expanded="false” to rendered menu button.
  * Chip - accepts a boolean, but converts to a string - fixed by defaulting to false, which improves accessibility and feedback on state changes/user interaction.
  * Expand - removed aria-label (verbose), updated aria-describedby to aria-labelledby, outputting expanded=false improves accessibility and feedback on state changes/user interaction.
  * Code Snippet - updated to output expanded as a string, defaulting to “false,” which improves accessibility and feedback on state changes/user interaction.
  * Menu - set button expanded="false” on load, toggle it in the @watch on the open prop - improves accessibility and feedback on state changes/user interaction. However, focus was not moving properly to the first menu item when opened, and wasn’t read by the screen reader until the delay was increased to 500ms.
  * Segmented Button Group - updated to work with updated Button pressed prop (“true”|”false” string union). Updated so single select groups toggle pressed=“true” on user interaction but cannot toggle them off (like a radio button). Groups with multiple=true can toggle pressed=true/false on each user interaction.
  * Subnav Item - set expanded as a string on the expand button. Also generate a UID to apply as an `id` on the main subnav item control (cbp-button), which associates a label for the expand button (when present) via aria-labelledby.
  * Table - pressed updated internally. Set pressed (both true and false) on initial load as part of makeSortable() function.
  * USA Banner - updated to set expanded as a string, open prop defaulted to false.

Dialog control, Drawer control, and Nav Item (Drawer Control) do not need `aria-expanded` and removing the auto-toggling of expanded (when there’s an aria-controls on the Button component) fixes the issue where these controls are left in aria-expanded=“true” state when a dialog or drawer is closed.