### PR TITLE
Bugfix/a11y fixes 20250718

### DIFF
--- a/packages/web-components/src/components/cbp-dropdown/cbp-dropdown.tsx
+++ b/packages/web-components/src/components/cbp-dropdown/cbp-dropdown.tsx
@@ -54,7 +54,7 @@ export class CbpDropdown {
   /* TODO */
   //@Prop() create: boolean;
 
-  /** Optionally specify the ID of the visible control here, which is used to generate related pattern node IDs and associate everything for accessibility */
+  /** Optionally specify the ID of the visible control here, which is used to generate related pattern node IDs and associate everything for accessibility. */
   @Prop() fieldId: string = createNamespaceKey('cbp-dropdown');
 
   /** Specifies the name of the (hidden) form field */

--- a/packages/web-components/src/components/cbp-footer/cbp-footer.tsx
+++ b/packages/web-components/src/components/cbp-footer/cbp-footer.tsx
@@ -36,11 +36,11 @@ export class CbpFooter {
           {
             this.host.querySelector('[slot=cbp-footer-nav]') && 
             <div class="cbp-footer-nav">
-              <slot name="cbp-footer-nav"></slot>
+              <slot name="cbp-footer-nav" />
             </div>
           }
           <div class="cbp-footer-content">
-            <slot/>
+            <slot />
           </div>
         </footer>
       </Host>

--- a/packages/web-components/src/components/cbp-form-field-wrapper/cbp-form-field-wrapper.tsx
+++ b/packages/web-components/src/components/cbp-form-field-wrapper/cbp-form-field-wrapper.tsx
@@ -6,10 +6,10 @@ import { setCSSProps } from '../../utils/utils';
  * and button controls to form inputs in accordance with design requirements.
  * 
  * @slot - The default slot holds the form control.
- * @slot cbp-form-field-overlay-start - Holds an overlay positioned on the left side of the form field.
- * @slot cbp-form-field-overlay-end - Holds an overlay positioned on the right side of the form field.
- * @slot cbp-form-field-attached-button
- * @slot cbp-form-field-unattached-buttons
+ * @slot cbp-form-field-overlay-start - Optionally slot an overlay positioned on the left side of the form field.
+ * @slot cbp-form-field-overlay-end - Optionally slot an overlay positioned on the right side of the form field.
+ * @slot cbp-form-field-attached-button - Optionally slot in any buttons that appear attached to the native form field.
+ * @slot cbp-form-field-unattached-buttons - Optionally slot in any buttons that appear horizontally after the native form field, but not attached to it.
  */
 @Component({
   tag: 'cbp-form-field-wrapper',

--- a/packages/web-components/src/components/cbp-form-field/api-docs.mdx
+++ b/packages/web-components/src/components/cbp-form-field/api-docs.mdx
@@ -1,6 +1,6 @@
 import { Meta, Markdown } from "@storybook/blocks";
 import Docs from './readme.md?raw';
 
-<Meta title="Components/Form Fields/API Docs" />
+<Meta title="Components/Form Field/API Docs" />
 
 <Markdown>{Docs}</Markdown>

--- a/packages/web-components/src/components/cbp-form-field/cbp-form-field.specs.mdx
+++ b/packages/web-components/src/components/cbp-form-field/cbp-form-field.specs.mdx
@@ -1,6 +1,6 @@
 import { Meta } from '@storybook/addon-docs';
 
-<Meta title="Components/Form Fields/Specifications" />
+<Meta title="Components/Form Field/Specifications" />
 
 # cbp-form-field
 
@@ -44,11 +44,14 @@ import { Meta } from '@storybook/addon-docs';
 * For single-input form fields:
   * The label is rendered within a semantic `label` tag referencing the slotted form control by `id`.
   * The (optional) description is associated to the form control as a description via the `aria-describedby` attribute.
+  * The `disabled` and `readonly` properties controls the same-named attributes on the native form control.
+  * The `error` property controls the `aria-invalid` attribute on the native form control.
 * For multi-input form fields, such as radio lists or checklists:
   * The entire patterns is wrapped within a `fieldset`, which provides an inherent "group" role.
   * The component label is rendered as a `legend`, which provides the group's label.
   * The (optional) description is associated to the `fieldset` via the `aria-describedby` attribute.
   * The `disabled` property controls the same-named attribute on the `fieldset`, using a little-known feature to toggle all fields within it disabled.
+  * The `error` property controls the `aria-invalid` attribute on the `fieldset`. This is the preferred way of marking a checklist or radio list as invalid. For groupings containing multiple discrete form entries, such as a Name or Address pattern, the `error` property should also be used on the individual fields within the group.
 * Disabled form controls and buttons are non-interactive and cannot be navigated to using the keyboard and should be used with caution (if at all).
 * Placeholder text should rarely, if ever, be used.
   * Especially in forms where the user is expected to enter data, placeholder text with sufficient contrast to the background color may be mistaken as entered input.

--- a/packages/web-components/src/components/cbp-form-field/cbp-form-field.stories.tsx
+++ b/packages/web-components/src/components/cbp-form-field/cbp-form-field.stories.tsx
@@ -1,5 +1,5 @@
 export default {
-  title: 'Components/Form Fields',
+  title: 'Components/Form Field',
   tags: ['beta'],
   argTypes: {
     label: {

--- a/packages/web-components/src/components/cbp-form-field/cbp-form-field.tsx
+++ b/packages/web-components/src/components/cbp-form-field/cbp-form-field.tsx
@@ -108,6 +108,7 @@ export class CbpFormField {
 
   @Watch('error')
   watchErrorHandler(newValue: boolean) {
+    // This is already filtered for non-groups
     if (this.formField) {
       (newValue) 
         ? this.formField.setAttribute('aria-invalid', 'true')
@@ -159,11 +160,11 @@ export class CbpFormField {
     // Moved this logic to componentDidLoad so that it works with buttons rendered by the component lifecycle (not just slotted), such as in file input.
     if (!this.group) {
       // query the DOM for the slotted form field and wire it up for accessibility and attach an event listener to it
-      this.formField = this.host.querySelector('input,select,textarea');
+      this.formField = this.host.querySelector('button[role=combobox],input,select,textarea');
       
       // Treat nested components separately, as it's hard to modify their rendered content directly
       this.formFieldComponent = this.host.querySelector('cbp-dropdown,cbp-slider');
-      
+
       this.buttons = this.host.querySelectorAll('cbp-button');
       this.attachedButtons = this.host.querySelectorAll('[slot=cbp-form-field-attached-button] cbp-button');
       this.hasDescription = !!this.description || !!this.host.querySelector('[slot=cbp-form-field-description]');
@@ -215,6 +216,7 @@ export class CbpFormField {
           <fieldset 
             disabled={this.disabled}
             aria-describedby={`${this.fieldId}-description`}
+            aria-invalid={this.error ? 'true' : false}
           >
             <legend
               id={`${this.fieldId}-grouplabel`}

--- a/packages/web-components/src/components/cbp-form-field/input-range.stories.tsx
+++ b/packages/web-components/src/components/cbp-form-field/input-range.stories.tsx
@@ -1,5 +1,5 @@
 export default {
-  title: 'Components/Form Fields',
+  title: 'Components/Form Field',
   tags: ['beta'],
   argTypes: {
     label: {

--- a/packages/web-components/src/components/cbp-universal-header/cbp-universal-header.tsx
+++ b/packages/web-components/src/components/cbp-universal-header/cbp-universal-header.tsx
@@ -20,7 +20,7 @@ export class CbpUniversalHeader {
   
   render() {
     return (
-      <Host>
+      <Host role="banner">
         <div class="cbp-universal-header__brand">
           <picture>
             <source srcSet={this.logoSrcSm} media="(max-width: 37.5rem)" type="image/svg+xml" height={44} width={44} />

--- a/packages/web-components/src/stories/Archetype_Passenger.stories.tsx
+++ b/packages/web-components/src/stories/Archetype_Passenger.stories.tsx
@@ -760,59 +760,57 @@ const InternalTemplate = ({ isLoggedIn, username, navItems, passengersArgs, mani
   return `
     <cbp-skip-nav></cbp-skip-nav>
 
-    <header>
-      <cbp-universal-header
-        logo-src-lg="./assets/images/cbp-header-logo.svg"
-        logo-src-sm="./assets/images/cbp-seal.svg"
-      >
-        <ul>
-        ${
-          isLoggedIn
-            ? `
-          <li>
-            <cbp-button color="secondary" fill="ghost" context="dark-always">
-              <cbp-icon name="book"></cbp-icon>
-              <cbp-hide visually-hide-at="max-width: 64em">
-                  App Directory
-                </cbp-hide>
-            </cbp-button>
-          </li>
-          <li>
-            <cbp-button color="secondary" fill="ghost" context="dark-always">
-              <cbp-icon name="comment"></cbp-icon>  
-              <cbp-hide visually-hide-at="max-width: 64em">
-                Feedback
+    <cbp-universal-header
+      logo-src-lg="./assets/images/cbp-header-logo.svg"
+      logo-src-sm="./assets/images/cbp-seal.svg"
+    >
+      <ul>
+      ${
+        isLoggedIn
+          ? `
+        <li>
+          <cbp-button color="secondary" fill="ghost" context="dark-always">
+            <cbp-icon name="book"></cbp-icon>
+            <cbp-hide visually-hide-at="max-width: 64em">
+                App Directory
               </cbp-hide>
-            </cbp-button>
-          </li>
-          <li>
-            <cbp-button color="secondary" fill="ghost" context="dark-always">
-              <cbp-icon name="user"></cbp-icon>
-              <cbp-hide visually-hide-at="max-width: 64em">
-                ${username}
-              </cbp-hide>
-            </cbp-button>
-          </li>
-          `
-            : `
-          <li>
-            <cbp-button tag="a" href="#" color="secondary" fill="ghost" context="dark-always">
-              <cbp-icon name="right-to-bracket"></cbp-icon>Login
-            </cbp-button>
-          </li>
-          `
-        }
-        </ul>
-      </cbp-universal-header>
+          </cbp-button>
+        </li>
+        <li>
+          <cbp-button color="secondary" fill="ghost" context="dark-always">
+            <cbp-icon name="comment"></cbp-icon>  
+            <cbp-hide visually-hide-at="max-width: 64em">
+              Feedback
+            </cbp-hide>
+          </cbp-button>
+        </li>
+        <li>
+          <cbp-button color="secondary" fill="ghost" context="dark-always">
+            <cbp-icon name="user"></cbp-icon>
+            <cbp-hide visually-hide-at="max-width: 64em">
+              ${username}
+            </cbp-hide>
+          </cbp-button>
+        </li>
+        `
+          : `
+        <li>
+          <cbp-button tag="a" href="#" color="secondary" fill="ghost" context="dark-always">
+            <cbp-icon name="right-to-bracket"></cbp-icon>Login
+          </cbp-button>
+        </li>
+        `
+      }
+      </ul>
+    </cbp-universal-header>
 
-      <cbp-app-header
-          subnav-drawer-id='appHeaderDrawer'
-        >
-        ${generateNavItems(navItems)}
-        </cbp-app-header>
+    <cbp-app-header
+      subnav-drawer-id="appHeaderDrawer"
+    >
+      ${generateNavItems(navItems)}
+    </cbp-app-header>
         
-      ${renderDrawer(navItems, 'appHeaderDrawer')}
-    </header>
+    ${renderDrawer(navItems, 'appHeaderDrawer')}
 
     <cbp-container sx='{"padding":"1rem var(--cbp-responsive-spacing-outer)"}'>
       <main id="main" tabindex="-1">

--- a/packages/web-components/src/stories/templates.stories.tsx
+++ b/packages/web-components/src/stories/templates.stories.tsx
@@ -58,53 +58,51 @@ const InternalTemplate = ({ isLoggedIn, username, navItems }) => {
       direction="column"
       sx='{"min-height":"100vh"}'
     >
-      <header>
-        <cbp-universal-header
-          logo-src-lg="./assets/images/cbp-header-logo.svg"
-          logo-src-sm="./assets/images/cbp-seal.svg"
-        >
-          <ul>
-          ${ isLoggedIn
-            ? `
-            <li>
-              <cbp-button color="secondary" fill="ghost" context="dark-always">
-                <cbp-icon name="book"></cbp-icon>
-                <cbp-hide visually-hide-at="max-width: 64em">App Directory</cbp-hide>
-              </cbp-button>
-            </li>
-            <li>
-              <cbp-button color="secondary" fill="ghost" context="dark-always">
-                <cbp-icon name="comment"></cbp-icon>  
-                <cbp-hide visually-hide-at="max-width: 64em">Feedback</cbp-hide>
-              </cbp-button>
-            </li>
-            <li>
-              <cbp-button color="secondary" fill="ghost" context="dark-always">
-                <cbp-icon name="user"></cbp-icon>
-                <cbp-hide visually-hide-at="max-width: 64em">${username}</cbp-hide>
-              </cbp-button>
-            </li>
-            `
-            : `
-            <li>
-              <cbp-button tag="a" href="#" color="secondary" fill="ghost" context="dark-always">
-              <cbp-icon name="right-to-bracket"></cbp-icon>
-              Login
-              </cbp-button>
-            </li>
-            `
-          }
-          </ul>
-        </cbp-universal-header>
+      <cbp-universal-header
+        logo-src-lg="./assets/images/cbp-header-logo.svg"
+        logo-src-sm="./assets/images/cbp-seal.svg"
+      >
+        <ul>
+        ${ isLoggedIn
+          ? `
+          <li>
+            <cbp-button color="secondary" fill="ghost" context="dark-always">
+              <cbp-icon name="book"></cbp-icon>
+              <cbp-hide visually-hide-at="max-width: 64em">App Directory</cbp-hide>
+            </cbp-button>
+          </li>
+          <li>
+            <cbp-button color="secondary" fill="ghost" context="dark-always">
+              <cbp-icon name="comment"></cbp-icon>  
+              <cbp-hide visually-hide-at="max-width: 64em">Feedback</cbp-hide>
+            </cbp-button>
+          </li>
+          <li>
+            <cbp-button color="secondary" fill="ghost" context="dark-always">
+              <cbp-icon name="user"></cbp-icon>
+              <cbp-hide visually-hide-at="max-width: 64em">${username}</cbp-hide>
+            </cbp-button>
+          </li>
+          `
+          : `
+          <li>
+            <cbp-button tag="a" href="#" color="secondary" fill="ghost" context="dark-always">
+            <cbp-icon name="right-to-bracket"></cbp-icon>
+            Login
+            </cbp-button>
+          </li>
+          `
+        }
+        </ul>
+      </cbp-universal-header>
 
-        <cbp-app-header
-          subnav-drawer-id='appHeaderDrawer'
-        >
+      <cbp-app-header
+        subnav-drawer-id="appHeaderDrawer"
+      >
         ${generateNavItems(navItems)}
-        </cbp-app-header>
+      </cbp-app-header>
         
      ${renderDrawer(navItems, 'appHeaderDrawer', false)}
-      </header>
 
       <cbp-container sx='{"flex-grow":"1","padding":"1rem var(--cbp-responsive-spacing-outer)"}'>
         <main id="main" tabindex="-1">
@@ -167,53 +165,51 @@ const Internal2ColumnTemplate = ({ isLoggedIn, username, navItems, contentGridSi
       direction="column"
       sx='{"min-height":"100vh"}'
     >
-      <header>
-        <cbp-universal-header
-          logo-src-lg="./assets/images/cbp-header-logo.svg"
-          logo-src-sm="./assets/images/cbp-seal.svg"
-        >
-          <ul>
-          ${ isLoggedIn
-            ? `
-            <li>
-              <cbp-button color="secondary" fill="ghost" context="dark-always">
-                <cbp-icon name="book"></cbp-icon>
-                <cbp-hide visually-hide-at="max-width:64em">App Directory</cbp-hide>
-              </cbp-button>
-            </li>
-            <li>
-              <cbp-button color="secondary" fill="ghost" context="dark-always">
-                <cbp-icon name="comment"></cbp-icon>  
-                <cbp-hide visually-hide-at="max-width:64em">Feedback</cbp-hide>
-              </cbp-button>
-            </li>
-            <li>
-              <cbp-button color="secondary" fill="ghost" context="dark-always">
-                <cbp-icon name="user"></cbp-icon>
-                <cbp-hide visually-hide-at="max-width:64em">${username}</cbp-hide>
-              </cbp-button>
-            </li>
-            `
-            : `
-            <li>
-              <cbp-button tag="a" href="#" color="secondary" fill="ghost" context="dark-always">
-              <cbp-icon name="right-to-bracket"></cbp-icon>
-              Login
-              </cbp-button>
-            </li>
-            `
-          }
-          </ul>
-        </cbp-universal-header>
+      <cbp-universal-header
+        logo-src-lg="./assets/images/cbp-header-logo.svg"
+        logo-src-sm="./assets/images/cbp-seal.svg"
+      >
+        <ul>
+        ${ isLoggedIn
+          ? `
+          <li>
+            <cbp-button color="secondary" fill="ghost" context="dark-always">
+              <cbp-icon name="book"></cbp-icon>
+              <cbp-hide visually-hide-at="max-width:64em">App Directory</cbp-hide>
+            </cbp-button>
+          </li>
+          <li>
+            <cbp-button color="secondary" fill="ghost" context="dark-always">
+              <cbp-icon name="comment"></cbp-icon>  
+              <cbp-hide visually-hide-at="max-width:64em">Feedback</cbp-hide>
+            </cbp-button>
+          </li>
+          <li>
+            <cbp-button color="secondary" fill="ghost" context="dark-always">
+              <cbp-icon name="user"></cbp-icon>
+              <cbp-hide visually-hide-at="max-width:64em">${username}</cbp-hide>
+            </cbp-button>
+          </li>
+          `
+          : `
+          <li>
+            <cbp-button tag="a" href="#" color="secondary" fill="ghost" context="dark-always">
+            <cbp-icon name="right-to-bracket"></cbp-icon>
+            Login
+            </cbp-button>
+          </li>
+          `
+        }
+        </ul>
+      </cbp-universal-header>
 
-        <cbp-app-header
-          subnav-drawer-id='appHeaderDrawer'
-        >
+      <cbp-app-header
+        subnav-drawer-id="appHeaderDrawer"
+      >
         ${generateNavItems(navItems)}
-        </cbp-app-header>
-        
-     ${renderDrawer(navItems, 'appHeaderDrawer', false)}
-      </header>
+      </cbp-app-header>
+      
+      ${renderDrawer(navItems, 'appHeaderDrawer', false)}
 
       <cbp-grid
         grid-template-columns="${contentGridSize} ${sidebarGridSize}"
@@ -447,53 +443,51 @@ const InternalCardsLayoutTemplate = ({ isLoggedIn, username, navItems, numberOfC
       direction="column"
       sx='{"min-height":"100vh"}'
     >
-      <header>
-        <cbp-universal-header
-          logo-src-lg="./assets/images/cbp-header-logo.svg"
-          logo-src-sm="./assets/images/cbp-seal.svg"
-        >
-          <ul>
-          ${ isLoggedIn
-            ? `
-            <li>
-              <cbp-button color="secondary" fill="ghost" context="dark-always">
-                <cbp-icon name="book"></cbp-icon>
-                <cbp-hide visually-hide-at="max-width:64em">App Directory</cbp-hide>
-              </cbp-button>
-            </li>
-            <li>
-              <cbp-button color="secondary" fill="ghost" context="dark-always">
-                <cbp-icon name="comment"></cbp-icon>  
-                <cbp-hide visually-hide-at="max-width:64em">Feedback</cbp-hide>
-              </cbp-button>
-            </li>
-            <li>
-              <cbp-button color="secondary" fill="ghost" context="dark-always">
-                <cbp-icon name="user"></cbp-icon>
-                <cbp-hide visually-hide-at="max-width:64em">${username}</cbp-hide>
-              </cbp-button>
-            </li>
-            `
-            : `
-            <li>
-              <cbp-button tag="a" href="#" color="secondary" fill="ghost" context="dark-always">
-              <cbp-icon name="right-to-bracket"></cbp-icon>
-              Login
-              </cbp-button>
-            </li>
-            `
-          }
-          </ul>
-        </cbp-universal-header>
+      <cbp-universal-header
+        logo-src-lg="./assets/images/cbp-header-logo.svg"
+        logo-src-sm="./assets/images/cbp-seal.svg"
+      >
+        <ul>
+        ${ isLoggedIn
+          ? `
+          <li>
+            <cbp-button color="secondary" fill="ghost" context="dark-always">
+              <cbp-icon name="book"></cbp-icon>
+              <cbp-hide visually-hide-at="max-width:64em">App Directory</cbp-hide>
+            </cbp-button>
+          </li>
+          <li>
+            <cbp-button color="secondary" fill="ghost" context="dark-always">
+              <cbp-icon name="comment"></cbp-icon>  
+              <cbp-hide visually-hide-at="max-width:64em">Feedback</cbp-hide>
+            </cbp-button>
+          </li>
+          <li>
+            <cbp-button color="secondary" fill="ghost" context="dark-always">
+              <cbp-icon name="user"></cbp-icon>
+              <cbp-hide visually-hide-at="max-width:64em">${username}</cbp-hide>
+            </cbp-button>
+          </li>
+          `
+          : `
+          <li>
+            <cbp-button tag="a" href="#" color="secondary" fill="ghost" context="dark-always">
+            <cbp-icon name="right-to-bracket"></cbp-icon>
+            Login
+            </cbp-button>
+          </li>
+          `
+        }
+        </ul>
+      </cbp-universal-header>
 
-        <cbp-app-header
-          subnav-drawer-id='appHeaderDrawer'
-        >
+      <cbp-app-header
+        subnav-drawer-id="appHeaderDrawer"
+      >
         ${generateNavItems(navItems)}
-        </cbp-app-header>
+      </cbp-app-header>
         
-     ${renderDrawer(navItems, 'appHeaderDrawer', false)}
-      </header>
+      ${renderDrawer(navItems, 'appHeaderDrawer', false)}
 
       <cbp-container sx='{"padding":"1rem var(--cbp-responsive-spacing-outer)","flex-grow":"2"}'>
         <main id="main" tabindex="-1">


### PR DESCRIPTION
* Gave the universal header an explicit role.
* Removed the `header` tags from the templates/archetype - App header is now sticky as intended.
* Added `aria-invalid` to form field groups (e.g., checklist, radiolists, etc.).
* Fixed aria attributes and added `aria-described` by to dropdown control.
* Other small docs and code tweaks with no functionality changes.