### PR TITLE
Bugfix/a11y fixes 20250721

### DIFF
--- a/packages/web-components/CHANGELOG.md
+++ b/packages/web-components/CHANGELOG.md
@@ -14,6 +14,13 @@ The React components are wrappers generated from this package and will share the
   * Story code was updated and may need to be copied fresh for: 
     * Segmented Button Group (only if Button "pressed" values were explicitly set as a boolean HTML attribute).
     * Button (only if `pressed` or `expanded` props were used).
+* Updated the `cbp-universal-header` with an explicit `role="banner"`.
+  * BREAKING (story code): removed the `header` tag from all template/archetype stories in accordance with the above change. Story code may need to be re-copied or update in application code.
+  * This change also fixes the issue of the `cbp-app-header` not being sticky to the viewport as intended.
+* Updated the `cbp-form-field` component with accessibility bug fixes:
+  * Supports `aria-invalid` on form field groups (e.g., checklist, radio lists, etc.), rendered on the `fieldset` tag.
+  * Fixes support for `aria-describedby` on the Dropdown control.
+* Updated `cbp-skip-nav` to send focus to the target element rather than perform in-page navigation, which may break in some frameworks (and Storybook), and updated scroll margin to account for sticky App Header.
 
 ## [0.0.1-develop.22] 07-02-2025
 

--- a/packages/web-components/src/components/cbp-app/core.scss
+++ b/packages/web-components/src/components/cbp-app/core.scss
@@ -50,7 +50,16 @@ html {
 body {
   color: var(--cbp-color-body-text);
   background-color: var(--cbp-color-body-background);
-  font: var(--cbp-font-size-body) / 1rem var(--cbp-font-family-roboto);
+  font: var(--cbp-font-size-body)/1rem var(--cbp-font-family-roboto);
+}
+
+// Give everything a scroll margin so that it's not hidden beneath the sticky app header.
+* {
+  scroll-margin-block: var(--cbp-space-15x);
+}
+
+h1,h2,h3,h4,h5,h6 {
+  line-height: normal;
 }
 
 p,
@@ -68,9 +77,9 @@ button {
   cursor: pointer;
 }
 
-[aria-disabled='true'],
+[aria-disabled=true],
 :disabled,
-input:read-only:not([type='checkbox'], [type='radio'], [type='file'], [type='range'], [type='color']),
+input:read-only:not([type=checkbox], [type=radio], [type=file], [type=range], [type=color]),
 textarea:read-only {
   cursor: not-allowed;
 }

--- a/packages/web-components/src/components/cbp-app/reset.scss
+++ b/packages/web-components/src/components/cbp-app/reset.scss
@@ -42,8 +42,8 @@ dd {
 }
 
 /* Remove list styles on ul, ol elements with a list role, which suggests default styling will be removed */
-ul[role="list"],
-ol[role="list"] {
+ul[role=list],
+ol[role=list] {
   list-style: none;
   margin: 0;
   padding: 0;

--- a/packages/web-components/src/components/cbp-form-field/cbp-form-field.tsx
+++ b/packages/web-components/src/components/cbp-form-field/cbp-form-field.tsx
@@ -215,6 +215,7 @@ export class CbpFormField {
         <Host>
           <fieldset 
             disabled={this.disabled}
+            aria-labelledby={`${this.fieldId}-grouplabel`}
             aria-describedby={`${this.fieldId}-description`}
             aria-invalid={this.error ? 'true' : false}
           >

--- a/packages/web-components/src/components/cbp-skip-nav/cbp-skip-nav.tsx
+++ b/packages/web-components/src/components/cbp-skip-nav/cbp-skip-nav.tsx
@@ -26,8 +26,19 @@ export class CbpSkipNav {
   /** Supports adding inline styles as an object */
   @Prop() sx: any = {};
 
+
+  handleClick(e) {
+    // Cancel navigation (because it can break in many contexts) and send focus to the target element.
+    e.preventDefault();
+    e.stopPropagation();
+    const target = document.querySelector(`#${this.targetId}`) as HTMLElement;
+    if (target) {
+      target.focus();
+    }
+  }
+  
   componentWillLoad() {
-    const target = document.querySelector(`#${this.targetId}`);
+    const target = document.querySelector(`#${this.targetId}`) as HTMLElement;
     if (!target) console.warn(`Configuration Error (cbp-skip-nav): The specified targetId of "${this.targetId}" cannot be found in the current page.`);
 
     if (typeof this.sx == 'string') {
@@ -45,6 +56,7 @@ export class CbpSkipNav {
           href={this.targetId ? `#${this.targetId}` : null}
           accessKey={this.shortcutKey}
           ref={(el) => this.link = el} 
+          onClick={ (e) => this.handleClick(e)}
         >
           <slot>Skip to main content</slot>
         </a>

--- a/packages/web-components/src/components/cbp-usa-banner/cbp-usa-banner.tsx
+++ b/packages/web-components/src/components/cbp-usa-banner/cbp-usa-banner.tsx
@@ -69,7 +69,7 @@ export class CbpUsaBanner {
               />
               <div>
                 <strong>Secure .gov websites use HTTPS</strong>
-                <p>A <strong>lock</strong> (<cbp-icon name="lock" size="var(--cbp-space-3x)" />) or <strong>https://</strong> means you&#39;ve safely connected to the .gov website. Share sensitive information only on official, secure websites.</p>
+                <p>A <strong>lock</strong> (<cbp-icon name="lock" size="var(--cbp-space-3x)" accessibilityText="lock icon"/>) or <strong>https://</strong> means you&#39;ve safely connected to the .gov website. Share sensitive information only on official, secure websites.</p>
               </div>
             </div>
           </div>


### PR DESCRIPTION
* Update skipnav to set focus rather than navigate.
* Fix HTML heading line-height and add scroll-margin to account for sticky app header.
* Added explicit aria-labelledby to form field groups.
* Added accessible text to the lock icon in USA Banner  for better reading.
* Updated changelog with latest fixes.