### PR TITLE
Bugfix/size calculations hidden

### DIFF
--- a/packages/design-tokens/README.md
+++ b/packages/design-tokens/README.md
@@ -1,4 +1,4 @@
-# @cbpds/vdesign-tokens
+# @cbpds/design-tokens
 
 [![License: CC0-1.0](https://img.shields.io/badge/License-CC0_1.0-lightgrey.svg)](/LICENSE)
 
@@ -33,3 +33,11 @@ The compiled and minified CSS is located in:
 ```
 /packages/design-tokens/dist/sass/
 ```
+
+## Updating the Design Tokens
+
+Updates to the Design Tokens should be rare, but in such a case the web components package needs to be updated as well:
+
+* Update the desired JSON files representing the design tokens.
+* Build a new distribution of the design tokens by running `npm run build-tokens`.
+* Copy the CSS from `dist/css/cbp-design-tokens.css` into `/packages/web-components/src/components/cbp-app/css-variables.css`

--- a/packages/web-components/CHANGELOG.md
+++ b/packages/web-components/CHANGELOG.md
@@ -6,7 +6,7 @@ The React components are wrappers generated from this package and will share the
 
 ## [unpublished] TBD
 
-* Added a `color.highlight` token and styles to the `mark` tag and `::highlight` pseudo-element.
+* Added a `color.highlight` token and styles to the `mark` tag and `::highlight` selectors.
 
 ## [0.0.1-develop.26] 09-26-2025
 

--- a/packages/web-components/src/components/cbp-accordion-item/cbp-accordion-item.scss
+++ b/packages/web-components/src/components/cbp-accordion-item/cbp-accordion-item.scss
@@ -197,7 +197,7 @@ cbp-accordion-item {
     animation-timing-function: cubic-bezier(0.4, 0, 0.2, 10);
     animation-iteration-count: revert;
     animation-fill-mode: forwards;
-    overflow: hidden;
+    //overflow: hidden;
   }
 
   &:not([open]) {

--- a/packages/web-components/src/components/cbp-app-header/cbp-app-header.tsx
+++ b/packages/web-components/src/components/cbp-app-header/cbp-app-header.tsx
@@ -24,7 +24,7 @@ export class CbpAppHeader {
   private searchControl:HTMLCbpButtonElement;
   private searchField:HTMLInputElement;
 
-
+  
   /** Specifies the id of the drawer to be launched*/
   @Prop() subnavDrawerId: string;
 
@@ -137,6 +137,7 @@ export class CbpAppHeader {
     }, 101); // Note: Time 101 is set due to cbp-drawer setting @ 100
   }
 
+  // Called by the resize observer; also fires on initial render.
   handleResize(width) {
     // Get the width of the content (and update the this.navWidth) before doing responsive adjustments.
     if (this.navWidth == undefined) {
@@ -151,24 +152,24 @@ export class CbpAppHeader {
     }
   }
 
+  // If nav items can't fit, hide all nav items and show the hamburger control
   doResponsive() {
     this.children.forEach((item, index) => {
       if (index > 0 && item.id != 'global-search-toggle') {
         item.setAttribute('hidden', '');
       }
     });
-
     this.drawerButton?.parentElement?.classList.add('cbp-app-header-responsive');
     this.drawerButton?.removeAttribute('hidden');
   }
 
+  // If nav items fit, reveal them and hide the hamburger control
   doFullSize() {
     this.children.forEach((item, index) => {
       if (index > 0) {
         item.removeAttribute('hidden');
       }
     });
-
     this.drawerButton?.parentElement?.classList.remove('cbp-app-header-responsive');
     this.drawerButton?.setAttribute('hidden', '');
   }

--- a/packages/web-components/src/components/cbp-dropdown/cbp-dropdown.tsx
+++ b/packages/web-components/src/components/cbp-dropdown/cbp-dropdown.tsx
@@ -763,7 +763,6 @@ export class CbpDropdown {
 
   getSizeInfo() {
     this.visible = !!this.host.offsetWidth;
-    //console.log('Visible: ', this.host.offsetWidth, this.visible);
 
     if (this.visible) {
       // remove the resize observer if one was created
@@ -779,7 +778,6 @@ export class CbpDropdown {
     }
     else if(!this.observer) {
       // Set up a resize observer to check for when the host becomes visible and gets a size.
-      //console.log(this.host, ' is not visible, setting resize observer.');
       this.observer = new ResizeObserver(() => {
         this.getSizeInfo();
       });

--- a/packages/web-components/src/components/cbp-dropdown/cbp-dropdown.tsx
+++ b/packages/web-components/src/components/cbp-dropdown/cbp-dropdown.tsx
@@ -33,6 +33,9 @@ export class CbpDropdown {
   private attachedButtonStartWidth;
   private attachedButtonEndWidth;
 
+  private visible: boolean = false; // tracked for size calculations
+  private observer: ResizeObserver;
+
   private typingMode: boolean = false; // track typing mode for combobox mode (only when filter=true)
 
   @Element() host: HTMLCbpDropdownElement;
@@ -757,15 +760,38 @@ export class CbpDropdown {
     });
   }
 
+
+  getSizeInfo() {
+    this.visible = !!this.host.offsetWidth;
+    //console.log('Visible: ', this.host.offsetWidth, this.visible);
+
+    if (this.visible) {
+      // remove the resize observer if one was created
+      if (this.observer) this.observer.disconnect();
+
+      // Allocate space for attached buttons in overall sizing
+      this.attachedButtonStartWidth = this.attachedButtonStart ? this.attachedButtonStart.offsetWidth : 0;
+      this.attachedButtonEndWidth = this.attachedButtonEnd ? this.attachedButtonEnd.offsetWidth : 0;
+      setCSSProps(this.host, {
+        "--cbp-dropdown-attached-button-start-width": `${this.attachedButtonStartWidth}px`,
+        "--cbp-dropdown-attached-button-end-width": `${this.attachedButtonEndWidth}px`,
+      });
+    }
+    else if(!this.observer) {
+      // Set up a resize observer to check for when the host becomes visible and gets a size.
+      //console.log(this.host, ' is not visible, setting resize observer.');
+      this.observer = new ResizeObserver(() => {
+        this.getSizeInfo();
+      });
+      this.observer.observe(this.host);
+    }
+  }
+
+  
+
   componentDidLoad() {
-    // Update this with the buttons size
-    this.attachedButtonStartWidth = this.attachedButtonStart ? this.attachedButtonStart.offsetWidth : 0;
-    this.attachedButtonEndWidth = this.attachedButtonEnd ? this.attachedButtonEnd.offsetWidth : 0;
-    
-    setCSSProps(this.host, {
-      "--cbp-dropdown-attached-button-start-width": `${this.attachedButtonStartWidth}px`,
-      "--cbp-dropdown-attached-button-end-width": `${this.attachedButtonEndWidth}px`,
-    });
+    // Allocate space for attached buttons in overall sizing
+    this.getSizeInfo();
 
     // Get the value and label for single-select (this doesn't work for items specified as JSON)
     this.dropdownItems = Array.from(this.host.querySelectorAll('cbp-dropdown-item'));

--- a/packages/web-components/src/components/cbp-form-field-wrapper/cbp-form-field-wrapper.tsx
+++ b/packages/web-components/src/components/cbp-form-field-wrapper/cbp-form-field-wrapper.tsx
@@ -28,8 +28,46 @@ export class CbpFormFieldWrapper {
   private overlayStartWidth;
   private overlayEndWidth;
   private attachedButtonWidth;
+
+  private visible: boolean = false; // tracked for size calculations
+  private observer: ResizeObserver;
+
   
   @Element() host: HTMLElement;
+
+
+  getSizeInfo() {
+    this.visible = !!this.host.offsetWidth;
+
+    if (this.visible) {
+      // remove the resize observer if one was created
+      if (this.observer) this.observer.disconnect();
+
+      // Calculate the size of the overlays to set the input padding accordingly
+      // TechDebt: as a first cut, this is not reactive. How reactive does it need to be?
+      this.overlayStartWidth = this.overlayStart ? this.overlayStart.offsetWidth + 8 : 0;
+      this.overlayEndWidth = this.overlayEnd ? this.overlayEnd.offsetWidth + 8 : 0;
+      this.attachedButtonWidth = this.attachedButton ? this.attachedButton.offsetWidth : 0;
+
+      // Update this with the buttons size
+      this.overlayEndWidth = this.overlayEndWidth +  this.attachedButtonWidth
+
+      setCSSProps(this.host, {
+        "--cbp-form-field-overlay-start-width": `${this.overlayStartWidth}px`,
+        "--cbp-form-field-overlay-end-width": `${this.overlayEndWidth}px`,
+        "--cbp-form-field-attached-button-width": `${this.attachedButtonWidth}px`,
+      });
+    }
+    else if(!this.observer) {
+      // Set up a resize observer to check for when the host becomes visible and gets a size.
+      //console.log(this.host, ' is not visible, setting resize observer.');
+      this.observer = new ResizeObserver(() => {
+        this.getSizeInfo();
+      });
+      this.observer.observe(this.host);
+    }
+  }
+
 
   componentWillLoad() {
     // query the DOM for the slotted form field and wire it up for accessibility and attach an event listener to it
@@ -42,19 +80,7 @@ export class CbpFormFieldWrapper {
 
   componentDidLoad() {
     // Calculate the size of the overlays to set the input padding accordingly
-    // TechDebt: as a first cut, this is not reactive. How reactive does it need to be?
-    this.overlayStartWidth = this.overlayStart ? this.overlayStart.offsetWidth + 8 : 0;
-    this.overlayEndWidth = this.overlayEnd ? this.overlayEnd.offsetWidth + 8 : 0;
-    this.attachedButtonWidth = this.attachedButton ? this.attachedButton.offsetWidth : 0;
-
-    // Update this with the buttons size
-    this.overlayEndWidth = this.overlayEndWidth +  this.attachedButtonWidth
-
-    setCSSProps(this.host, {
-      "--cbp-form-field-overlay-start-width": `${this.overlayStartWidth}px`,
-      "--cbp-form-field-overlay-end-width": `${this.overlayEndWidth}px`,
-      "--cbp-form-field-attached-button-width": `${this.attachedButtonWidth}px`,
-    });
+    this.getSizeInfo();
 
     // Set the IDs on the slotted overlays (if needed) and assign them to the native input's `aria-describedby` attribute.
     let overlayids = '';

--- a/packages/web-components/src/components/cbp-resize-observer/cbp-resize-observer.scss
+++ b/packages/web-components/src/components/cbp-resize-observer/cbp-resize-observer.scss
@@ -1,6 +1,7 @@
 /*
  * The resize observer is a block-level component with a max-width of 100% that grows and shrinks with its parent container, 
  * so that it can report changes in both directions.
+ *
  * It allows for overflow, so that its children may still report their full dimensions based on their content and overflow may
  * therefore be detected for responsive behavior.
  */

--- a/packages/web-components/src/components/cbp-resize-observer/cbp-resize-observer.specs.mdx
+++ b/packages/web-components/src/components/cbp-resize-observer/cbp-resize-observer.specs.mdx
@@ -34,3 +34,4 @@ import { Meta, Markdown } from "@storybook/addon-docs/blocks";
 
 * The native resizeObserver is a performant way of measuring changes to a DOM node's size or positioning.
 * However, care must be taken that application logic and calculations based on the resize event are not too complex as to impact performance of the UI.
+* The immediate child should be sized according to its contents; Setting width to 100% will not allow the calculations to work correctly for switching between layouts.

--- a/packages/web-components/src/stories/hidden-size-calculations.stories.tsx
+++ b/packages/web-components/src/stories/hidden-size-calculations.stories.tsx
@@ -11,6 +11,16 @@ const Template = () => {
           
       <cbp-accordion-item label="Accordion Item 1">
         
+         
+        <cbp-breadcrumb>
+          <cbp-button tag="a" fill="ghost" color="primary" variant="square" href="#" accessibility-text="Home">
+            <cbp-icon name="home"></cbp-icon>
+          </cbp-button>
+          <cbp-link href="?o95gn">Page Title Level A</cbp-link>
+          <cbp-link href="?8iehg">Page Title Level B</cbp-link>
+          <cbp-link href="?f8ia0">Page Title Level C</cbp-link>
+          <cbp-link href="?2kepd">Page Title Level D</cbp-link>
+        </cbp-breadcrumb>
  
         <cbp-tabs accessibility-text="Tabs Example">
           <cbp-tab name="tab1">Tab 1</cbp-tab>

--- a/packages/web-components/src/stories/hidden-size-calculations.stories.tsx
+++ b/packages/web-components/src/stories/hidden-size-calculations.stories.tsx
@@ -1,0 +1,126 @@
+export default {
+  title: "Test/Size Calculations",
+};
+
+
+// Combobox using Countries data as an asynchronous call: 
+const Template = () => {
+
+  return ` 
+    <cbp-accordion>
+          
+      <cbp-accordion-item label="Accordion Item 1">
+        
+ 
+        <cbp-tabs accessibility-text="Tabs Example">
+          <cbp-tab name="tab1">Tab 1</cbp-tab>
+          <cbp-tab name="tab2">Tab 2</cbp-tab>
+          <cbp-tab name="tab3">Tab 3 is longer</cbp-tab>
+          <cbp-tab name="tab4">Tab 4</cbp-tab>
+          <cbp-tab name="tab5">Tab 5</cbp-tab>
+          <cbp-tab name="tab6">Tab 6</cbp-tab>
+          <cbp-tab name="tab7">Tab 7</cbp-tab>
+        </cbp-tabs>
+
+        <cbp-tab-panel name="tab1">
+          Tab panel 1 content.
+        </cbp-tab-panel>
+        <cbp-tab-panel name="tab2">
+          Tab panel 2 content.
+        </cbp-tab-panel>
+        <cbp-tab-panel name="tab3">
+          Tab panel 3 content.
+        </cbp-tab-panel>
+        <cbp-tab-panel name="tab4">
+          Tab panel 4 content.
+        </cbp-tab-panel>
+        <cbp-tab-panel name="tab5">
+          Tab panel 5 content.
+        </cbp-tab-panel>
+        <cbp-tab-panel name="tab6">
+          Tab panel 6 content.
+        </cbp-tab-panel>
+        <cbp-tab-panel name="tab7">
+          Tab panel 7 content.
+        </cbp-tab-panel>
+
+        <br /><br /><br /><br />
+        
+        <cbp-form-field label="Field Label" description="Field description.">
+          <cbp-form-field-wrapper>
+            <input type="file" name="fileinput">
+            <span slot="cbp-form-field-attached-button">
+              <cbp-button fill="solid" color="secondary" aria-describedby="undefined-label" onclick="event.target.closest('cbp-form-field').querySelector('input').click()">
+                Browse
+              </cbp-button>
+            </span>
+          </cbp-form-field-wrapper>
+        </cbp-form-field>
+
+                
+        <cbp-form-field label="Field Title" description="(HH:MM Format) UTC-6 America/New York">
+          <cbp-form-field-wrapper>  
+            <input placeholder="HH:MM" maxlength="5" name="time">
+            <cbp-icon slot="cbp-form-field-overlay-start" name="clock"></cbp-icon>
+
+            <span slot="cbp-form-field-attached-button">
+              <cbp-segmented-button-group name="time-ampm">
+                <cbp-button type="button" value="AM" pressed="true">
+                  AM
+                </cbp-button>
+
+                <cbp-button type="button" value="PM">
+                  PM
+                </cbp-button>
+
+                <cbp-button type="button" value="24H">
+                  24 hr
+                </cbp-button>
+              </cbp-segmented-button-group>
+            </span>
+
+          </cbp-form-field-wrapper>
+        </cbp-form-field>
+
+
+        <cbp-pagination records="538">
+          <cbp-form-field slot="cbp-pagination-items-per-page" label="Items Per Page" field-id="pagination_size">
+            <cbp-dropdown field-id="pagination_size">
+              <cbp-dropdown-item value="10">10/Page</cbp-dropdown-item>
+              <cbp-dropdown-item value="25">25/Page</cbp-dropdown-item>
+              <cbp-dropdown-item value="50">50/Page</cbp-dropdown-item>
+              <cbp-dropdown-item value="100">100/Page</cbp-dropdown-item>
+              <cbp-dropdown-item value="all">All Results</cbp-dropdown-item>
+            </cbp-dropdown>
+          </cbp-form-field>
+
+          <cbp-form-field slot="cbp-pagination-pages" label="Page Displayed" field-id="pagination_pages">
+            <cbp-dropdown field-id="pagination_pages">
+              <div slot="cbp-dropdown-attached-button-start">
+                <cbp-button fill="solid" color="secondary" variant="square" value="previous page" accessibility-text="Previous page">
+                  <cbp-icon name="chevron-right" rotate="180">
+                </cbp-icon></cbp-button>
+              </div>
+
+              <div slot="cbp-dropdown-attached-button-end">
+                <cbp-button fill="solid" color="secondary" variant="square" value="next page" accessibility-text="Next page">
+                  <cbp-icon name="chevron-right">
+                </cbp-icon></cbp-button>
+              </div>
+            </cbp-dropdown>
+          </cbp-form-field>
+
+        </cbp-pagination>
+
+      </cbp-accordion-item>
+
+      <cbp-accordion-item label="Accordion Item 2">
+        Accordion item 2 content.
+      </cbp-accordion-item>
+
+      </cbp-accordion>
+  `;
+};
+
+export const SizeCalculations = Template.bind({});
+

--- a/packages/web-components/src/stories/web-component-apis.mdx
+++ b/packages/web-components/src/stories/web-component-apis.mdx
@@ -1,0 +1,124 @@
+import { Meta, Markdown } from "@storybook/addon-docs/blocks";
+
+<Meta title="Web Components and APIs" />
+
+# Web Components and APIs
+
+## What are Web Components?
+
+Web components are a set of web platform APIs that allow you to create new custom, reusable, encapsulated HTML tags to use in web pages and web applications.
+
+* Custom elements
+* Shadow DOM
+* HTML Templates
+
+### Why web components?
+
+* Web components are framework-agnostic.
+* Ability to ship most bug fixes internally, with no code updates from consuming applications (just a package update).
+* Web components can be lazy-loaded and only those used are downloaded by the end user.
+
+### Some notes about our implementation
+
+* Since the Shadow DOM creates accessibility barriers, it is seldomly used within the CBP Design System web components. As such, most of the web components are technically custom elements. “Web components” and “custom elements” are often used interchangeably; the 
+custom elements API is the foundation for web components.
+* In TypeScript, custom elements have their own types in the form of "HTMLCbpTagnameElement". When typed properly, all web component properties and methods may be referenced via dot notation.
+* Slots are typically reserved for the Shadow DOM, but in our case they are polyfilled by the Stencil library in which the CBPDS web components are built, so they work even without the Shadow DOM.
+
+## Web Component APIs
+
+The web component <abbr title="Application Programming Interface">API</abbr>s allow applications to interact with the web components and are comprised of several parts:
+
+* Properties (and attributes)
+* Slots
+* Events
+* Methods
+* CSS Properties
+
+### Properties and Attributes
+
+Properties define the inputs for web components, along with slotted content. Properties are exposed in HTML as attributes, but there are some subtle differences between the two that are important to understand:
+
+<table>
+  <caption hidden>Properties vs. Attributes</caption>
+  <thead>
+    <tr>
+      <th>Properties</th>
+      <th>Attributes</th>
+    </tr>
+  </thead>
+  <tbody>
+    <tr>
+      <td>The preferred interface in JavaScript and JavaScript frameworks.</td>
+      <td>The preferred interface for HTML.</td>
+    </tr>
+    <tr>
+      <td>Use camelCase.</td>
+      <td>Use dash-case.</td>
+    </tr>
+    <tr>
+      <td>Booleans may have values explicitly set to true or false.</td>
+      <td>Booleans are true by their existence (e.g., checked or hidden).</td>
+    </tr>
+    <tr>
+      <td>Can be accessed or set in JavaScript using dot notation.</td>
+      <td>Can be accessed or set in JavaScript using getAttribute() and setAttribute().</td>
+    </tr>
+    <tr>
+      <td>Only present in the DOM if the component specifies that the property is reflected to the attribute.</td>
+      <td>Always present in the DOM (when viewed in the browser developer tools).</td>
+    </tr>
+  </tbody>
+</table>
+
+Custom elements are HTML elements and extend the HTMLElement Interface. This means all global attributes are also valid on custom elements (e.g., class, id, style, aria-, data-, etc.)
+
+**Caveat:** One point of confusion is that some web components have a property that mirrors an attribute of a rendered element (e.g., `href`). This leads developers to incorrectly assume that any property or attribute placed on a custom element will be passed down to a rendered element. This behavior only occurs if implemented in the component in that way. Always reference the component API documentation to see which properties are allowed/supported and keep in mind that a custom element is an HTML Element as well.
+
+#### Common Properties
+
+Consistency in naming makes for a more predictable and memorable API and therefore there are a number of properties repeated across components throughout the design system.
+
+* `color` - Components that have different color variants use the color property to specify them (as opposed to the `variant` property). Color variants are most commonly some subset of names defined by the design tokens, such as "danger", "info", "success", or "warning". See the specific component's API docs to confirm acceptable values.
+* `variant` - Components that have different variations not based on color alone use the `variant` property to specify those.
+* `accessibilityText` - The implementation may vary, but the `accessibilityText` property exists on many components to provide an accessible name for elements when there is no visible text to do so. E.g., buttons or links with only an icon.
+* `context` - The context property exists on most components where there is a possibility to place the component on a different background, allowing you to specify that a component displays in "dark mode" on a dark background even if the site is in "light mode."
+* `sx` - The `sx` property provides a way to add custom styles to a component. These styles are usually placed on the host element, but in some cases the styles are placed on an element rendered by or within the custom element. The `sx` property is not reactive in most cases.
+
+### Slots
+
+Almost all components contain a default slot that determines where content placed between the opening and closing web component tags is placed within the component's rendered content.
+
+Named slots allow web components to use multiple slot definitions for placing each piece of content in different places within the rendered content. Named slots are always namespaced with "cbp-" and are defined in each component's API documentation. To specify an element for a named slot, the `slot` attribute is used on wrapping tag, e.g., `<div slot="cbp-accordion-title"></div>`
+
+Named slots are typically used in two specific cases:
+
+* To provide structure to the slotted content, such as "cbp-dialog-header", "cbp-dialog-body", and "cbp-dialog-actions" in the dialog component, without the need for creating child components to wrap them.
+* As an optional named slot that provides an alternative to a property. This is useful when the value contains markup or embedded components, since property values cannot contain markup.
+
+### Events
+
+Custom events are often implemented in the web components to make working with them easier. When interactive elements are rendered by a component's asynchronous lifecycle, it can make it difficult to attach an event listener on those elements. So, by emitting custom events, an application can listen for them directly on the custom element.
+
+In many cases, custom events are provided so that the apps can piggyback application logic onto a user interaction.
+
+#### Common Custom Events and Keys
+
+Some events and event keys are common across components:
+
+* `valueChange` event - The `valueChange` event is typically fired similar to the native `onChange` event on custom form elements and `cbp-form-field`, which wraps most form fields.
+* `host` key - Every custom event should have a `host` key, which provides a reference to the DOM node of the custom element emitting the event.
+* `nativeElement` key - Many custom events contain a reference to the native element that triggered the event. This provides easier access to interactive controls for use cases like toggling `aria-` attributes, etc. This key may be named something more specific when the element is more predictable, such as `button`, `link`, or `control`.
+* `nativeEvent` key - When possible, a reference to the native event is included in the custom event. This exposes all other event properties and methods, making it easier to `stopPropagation()` or `preventDefault()` on the native event, which may be difficult to access if it's coming from a DOM node rendered behind a web component's own asynchronous lifecycle.
+
+### Methods
+
+While the vast majority of web component interactivity is achieved via properties (e.g., `open`), some components implement public methods as well. These methods can be called in JavaScript using dot notation (on the custom element) like any other JavaScript method.
+
+Methods are `async` and `await` may be used to chain subsequent logic onto the behavior.
+
+### CSS Properties
+
+While a goal of the design system is consistency, many facets of a reusable component may vary based on context. A robust CSS API is built into the web components for ease of customizing the appearance of a component in such cases. CSS properties are also instrumental in the implementation of dark mode.
+
+Using CSS properties make these overrides easier to manage, as specificity is flattened for the most part. The initial values are set on the `:root` (in most cases) with the lowest specificity. Color variants typically require more specificity, however. Overrides should typically be done on the host (custom element) selector. They can be applied with the `sx` property (where it exists), `style` attribute, etc., or in a regular CSS file (using the custom element or class/id on the custom element as a selector).


### PR DESCRIPTION
* Create test story for the size calculation issues when hidden initially.
* Remove overflow hidden on accordion items - I think this was meant for animation purposes, which isn't working, but it's showing issues on my test page where a dropdown is truncated.
* Add resize observer to dropdown and form field wrapper to handle case where sizing is wrong when initially hidden.
* Updated docs/code comments.

It turns out that the resize observer automatically handles the hidden case because it reports a size change when revealed. So resize observer, tabs, and breadcrumbs worked properly when hidden. Only dropdown and form field wrapper did not.