### PR TITLE
Bugfix/universal header logo sizing

### DIFF
--- a/packages/web-components/src/components/cbp-app/reset.scss
+++ b/packages/web-components/src/components/cbp-app/reset.scss
@@ -61,7 +61,7 @@ picture {
   max-width: 100%;
   display: block;
 }
-img[width][height] {
+img:not([height]) {
   height: auto; /* Preserve aspect ratio */
 }
 

--- a/packages/web-components/src/components/cbp-dropdown/cbp-dropdown.scss
+++ b/packages/web-components/src/components/cbp-dropdown/cbp-dropdown.scss
@@ -102,8 +102,8 @@ cbp-dropdown {
     }
 
     // Attached buttons are overlays
-    &[slot=cbp-dropdown-attached-button-start],
-    &[slot=cbp-dropdown-attached-button-end] {
+    [slot=cbp-dropdown-attached-button-start],
+    [slot=cbp-dropdown-attached-button-end] {
       position: absolute;
       inset-block-start: 0; // Needed for Firefox
     }

--- a/packages/web-components/src/components/cbp-dropdown/cbp-dropdown.tsx
+++ b/packages/web-components/src/components/cbp-dropdown/cbp-dropdown.tsx
@@ -6,6 +6,7 @@ import { setCSSProps, createNamespaceKey, clickAwayListener } from '../../utils/
  * and support additional variants, such as a multi-select and/or combobox.
  * 
  * @slot - Only Dropdown Items should be placed in the default slot. They get auto-slotted into 'cbp-dropdown-items' behind the scenes.
+ * @slot cbp-dropdown-items - Dropdown items are auto-slotted here. Not need to specify this named slot.
  * @slot cbp-dropdown-attached-button-start - Allows for an optional button control to be slotted as an overlay at the start of the dropdown (such as a "previous" button).
  * @slot cbp-dropdown-attached-button-end - Allows for an optional button control to be slotted as an overlay at the end of the dropdown (such as a "next" button).
  */
@@ -60,7 +61,7 @@ export class CbpDropdown {
   /** A JSON object (or stringified JSON) containing an array of labels and values. Labels may contain markup as needed, but in such cases, a value should always be specified explicitly. */
   @Prop() items: string | object;
 
-  /** Specifies that when no items are found for a search string (for combobox functionality), an option to create the string as a new item is presented. */
+  /** Specifies that when an exact match is not found for a search string (for combobox functionality), an option to create a new item is presented. */
   @Prop() create: boolean;
 
   /** 
@@ -1010,8 +1011,6 @@ export class CbpDropdown {
               ? [...this.generatedItems]
               : <slot name="cbp-dropdown-items" onSlotchange ={ (e) => this.handleSlotChange(e)} />
             }
-
-            <slot name="cbp-dropdown-item-created" />
 
             { ( this.create && 
                 this.filter && 

--- a/packages/web-components/src/components/cbp-universal-header/cbp-universal-header.specs.mdx
+++ b/packages/web-components/src/components/cbp-universal-header/cbp-universal-header.specs.mdx
@@ -30,11 +30,11 @@ The Universal Header component establishes CBP branding, displaying the seal in 
 
 ### Accessibility
 
-* The Universal Header does not render a `header` landmark tag or contain a header role since a full page header is usually comprised of the Universal Header in addition to the Application Header.
-* It is recommended that your page markup wrap the Universal Header and Application Header in the HTML5 `header` tags to identify it as a header landmark in the accessibility tree.
+* The Universal Header has `role="banner"` applied automatically, representing a header landmark.
 * The accessibility of any content slotted into this component is the responsibility of the application developer.
 * The default story content uses the `visuallyHideAt` property of `cbp-hide` to hide the text labels in a screen reader-friendly, accessible manner at small screen sizes.
 
 ### Additional Notes and Considerations
 
+* The CBP Seal is sized to the smallest allowable size fitting to the 4 pixel grid, allowing the Universal Header to take as little vertical real estate possible.
 * Links placed in a list as the slotted content will automatically be laid out using Flexbox and aligned to the right.

--- a/packages/web-components/src/stories/tests/form-field-groups.stories.tsx
+++ b/packages/web-components/src/stories/tests/form-field-groups.stories.tsx
@@ -1,5 +1,5 @@
 export default {
-  title: 'Patterns/Form Field Groups',
+  title: 'Test/Form Field Groups',
   argTypes: {
     label: {
       control: 'text',

--- a/packages/web-components/src/stories/tests/form-processing.stories.tsx
+++ b/packages/web-components/src/stories/tests/form-processing.stories.tsx
@@ -157,47 +157,6 @@ const FormProcessingTemplate = ({ name, action, method, enctype }) => {
         </cbp-flex>
       </cbp-form-field>
 
-
-      <cbp-form-field
-        label="Numeric Counter Field"
-        field-id="numeric-input"
-      >
-        <cbp-form-field-wrapper>
-          <input
-            type="number"
-            name="number"
-          />
-
-          <span slot="cbp-form-field-unattached-buttons">
-            <cbp-button
-              name="decrement"
-              type="button"
-              fill="outline"
-              color="secondary"
-              variant="square"
-              accessibility-text="Decrement"
-              controls="numeric-input"
-              aria-describedby="numeric-input-label"
-            >
-              <cbp-icon name="minus"></cbp-icon>
-            </cbp-button>
-
-            <cbp-button
-              name="increment"
-              type="button"
-              fill="outline"
-              color="secondary"
-              variant="square"
-              accessibility-text="Increment"
-              controls="numeric-input"
-              aria-describedby="numeric-input-label"
-            >
-              <cbp-icon name="plus"></cbp-icon>
-            </cbp-button>
-          </span>
-        </cbp-form-field-wrapper>
-      </cbp-form-field>
-
       <cbp-form-field group
         label="Checklist Group Label"
         description="Field description."

--- a/packages/web-components/src/stories/tests/universal-header-resize-observer.stories.tsx
+++ b/packages/web-components/src/stories/tests/universal-header-resize-observer.stories.tsx
@@ -1,0 +1,108 @@
+export default {
+  title: 'Test/Universal Header Resize Observer',
+  parameters: {
+    layout: 'fullscreen',
+  },
+  argTypes: {
+    logoSrcLg: {
+      description: 'The src to the large-viewport seal/branding.',
+      control: 'text',
+    },
+    logoSrcSm: {
+      description: 'The src to the small-viewport seal/branding.',
+      control: 'text',
+    },
+  },
+};
+
+
+const UniversalHeaderResizeObserverTemplate = ({ logoSrcLg, logoSrcSm, username, isLoggedIn }) => {
+
+  setTimeout(() => {
+    // Cancel events on anchors to prevent navigating away from the story
+    let anchors = document.querySelectorAll('cbp-universal-header a');
+    anchors.forEach(anchor => {
+      anchor.addEventListener('click', function(e) { e.preventDefault(); })
+    });
+
+    let ro = document.querySelector('cbp-universal-header cbp-resize-observer');
+    ro.addEventListener('resized', function(e) {
+      console.log('Resized: ', e);
+    });
+
+  }, 500);
+
+  return `
+      <cbp-universal-header
+        ${logoSrcLg ? `logo-src-lg=${logoSrcLg}` : ''}
+        ${logoSrcSm ? `logo-src-sm=${logoSrcSm}` : ''}
+      >
+        <cbp-resize-observer>
+        <cbp-flex 
+          align-items="center"
+          justify-content="flex-end"
+          sx='{"width":"100%"}'
+        >
+          ${ isLoggedIn
+            ? `
+          
+              <cbp-flex-item>
+                <cbp-button tag="a" href="#" color="secondary" fill="ghost" context="dark-always">
+                  <cbp-icon name="book"></cbp-icon>
+                  <cbp-hide>App Directory</cbp-hide>
+                </cbp-button>
+              </cbp-flex-item>
+
+              <cbp-flex-item>
+                <cbp-button color="secondary" fill="ghost" context="dark-always">
+                  <cbp-icon name="comment"></cbp-icon>  
+                  <cbp-hide>Feedback</cbp-hide>
+                </cbp-button>
+              </cbp-flex-item>
+
+              <cbp-flex-item>
+                <cbp-button
+                  color="secondary"
+                  fill="ghost"
+                  context="dark-always"
+                >
+                  <cbp-icon name="user"></cbp-icon>
+                  <cbp-hide>${username}</cbp-hide>
+                </cbp-button>
+              </cbp-flex-item>
+            `
+            : `
+              <cbp-flex-item>
+                <cbp-button tag="a" href="#" color="secondary" fill="ghost" context="dark-always">
+                  <cbp-icon name="right-to-bracket"></cbp-icon>
+                  Login
+                </cbp-button>
+              </cbp-flex-item>
+            `
+          }
+        </cbp-flex>
+        </cbp-resize-observer>
+      </cbp-universal-header>
+    `;
+};
+
+
+export const UniversalHeaderResizeObserver = UniversalHeaderResizeObserverTemplate.bind({});
+UniversalHeaderResizeObserver.args = {
+  logoSrcLg: "./assets/images/cbp-header-logo.svg",
+  logoSrcSm: "./assets/images/cbp-seal.svg",
+  username: 'HASHIDX',
+  isLoggedIn: true,
+};
+UniversalHeaderResizeObserver.argTypes = {
+  username: {
+    name: 'User Name',
+    type: { name: 'string', required: true },
+    description: 'Name of user to be displayed in the Universal Header',
+  },
+  isLoggedIn: {
+    name: 'User Log In',
+    type: { name: 'boolean' },
+    description: 'Display Universal Header controls for user log in/out',
+  },
+};


### PR DESCRIPTION
* Fix dropdown CSS that broke pagination.
* Update img reset css to not affect image height when specified, fixing universal header image heights.
* Updated some test stories.
* Update dropdown docs.
* Updated universal header requirements doc.
* WIP test case for using resize observer in universal header.

Main things to test:
* Pagination looks right (not broken)
* Universal header images are sized properly at both breakpoints.