### PR TITLE
Bugfix/form investigations

### DIFF
--- a/packages/web-components/src/components/cbp-file-input/cbp-file-input.tsx
+++ b/packages/web-components/src/components/cbp-file-input/cbp-file-input.tsx
@@ -20,7 +20,7 @@ export class CbpFileInput {
   @Element() host: HTMLElement;
 
   /** The `name` attribute of the input, which is passed as part of formData (as a key). */
-  @Prop() name: string;
+  @Prop({ mutable: true }) name: string;
 
   /** 
    * Optionally specify the ID of the input here, which is used to generate related pattern 
@@ -29,7 +29,7 @@ export class CbpFileInput {
   @Prop({ mutable: true }) fieldId: string = createNamespaceKey('cbp-file-input');
 
   /** Specifies whether the file input accepts multiple files rather than a single file (may also be set directly on the slotted input). */
-  @Prop() multiple: boolean;
+  @Prop({ reflect: true }) multiple: boolean;
 
   /** 
    * Specifies the files types accepted by the file input (may also be set directly on the slotted input). 
@@ -110,15 +110,35 @@ export class CbpFileInput {
     this.valueChange.emit({
       host: this.host,
       nativeElement: this.formField,
+      name: this.name,
       value: this.files,
       nativeEvent: e
     });
   }
 
+  
+  /** 
+   * A custom method to reset the file input component (for enhanced/multi-file inputs) to its initial state and value 
+   * since it does not update properly on a native form reset. This method may be called manually, but is automatically 
+   * called on form reset when using the `cbp-form` component.
+   */
   @Method()
   async reset() {
     this.formField.value = this.initialValue ? this.initialValue: ''; // reset to empty string if undefined, which should always be the case
     this.files=[];
+  }
+
+
+  /* Testing: This method not yet fully supported */
+  @Method()
+  async getData() {
+    const Data={
+      host: this.host,
+      name: this.name,
+      files: this.files
+    }
+    //console.log('getData(): ', Data);
+    return Data;
   }
 
 
@@ -168,6 +188,7 @@ export class CbpFileInput {
     this.valueChange.emit({
       host: this.host,
       nativeElement: this.formField,
+      name: this.name,
       value: this.files,
       nativeEvent: e
     });
@@ -187,9 +208,11 @@ export class CbpFileInput {
     if (this.formField) {
       const Id = this.formField.getAttribute('id');
       Id ? this.fieldId = Id : this.formField.setAttribute('id', this.fieldId);
+      const Name = this.formField.getAttribute('name');
+      Name ? this.name = Name : this.formField.setAttribute('Name', this.name);
+      
       if (this.multiple) this.formField.setAttribute('multiple', '');
       if (this.accept) this.formField.setAttribute('accept', this.accept);
-      if (this.name) this.formField.setAttribute('name', this.name);
       if (this.disabled) this.formField.setAttribute('disabled', ``);
       // store the initialValue for reset functionality
       this.initialValue = this.formField?.value;

--- a/packages/web-components/src/components/cbp-form/cbp-form.tsx
+++ b/packages/web-components/src/components/cbp-form/cbp-form.tsx
@@ -1,4 +1,4 @@
-import { Component, Element, Host, h } from '@stencil/core';
+import { Component, Prop, Element, Event, EventEmitter, Host, h } from '@stencil/core';
 
 /**
  * The Form component may optionally be used to wrap a native HTML form, providing enhanced functionality and support 
@@ -13,39 +13,90 @@ import { Component, Element, Host, h } from '@stencil/core';
 export class CbpForm {
 
   private form: HTMLFormElement;
+  private enhancedFileInputs: HTMLCbpFileInputElement[] = [];
+  private files: object = {}; 
   
   @Element() host: HTMLCbpFormElement;
+
+  /** When specified, applies preventDefault() to the submit event and emits a custom event with the formData to hand off to the application. */
+  @Prop() preventSubmit: boolean;
   
-  handleSubmit(e) {
-    /*
-      Update FormData (or create a copy) with fields not supported natively:
-      * File input (allowing manipulation of FileList)
-    */
-      console.log('cbp-form - Submit event: ', e);
-      e.preventDefault();
+  @Event() suppressedSubmit: EventEmitter;
 
-      // Empty FormData object
-      //let formData = new FormData();
-      // FormData object populated from an existing form
-      let formData = new FormData(this?.form);
-
-      console.log('cbp-form - formData: ', formData);
-      // Spreading the formData as an array seems to give the same results as above.
-      console.log('formData (array spread): ',[...formData]);
-  }
-
+  
   handleReset() {
     // Call reset methods on form fields that do not natively support it.
     const SpecialCases: any = this.form.querySelectorAll('cbp-dropdown,cbp-slider,cbp-segmented-button-group,cbp-checkbox,cbp-radio,cbp-toggle,cbp-file-input');
     SpecialCases.forEach( item => {
       item.reset();
     });
+    // reset enhanced/multi-file inputs to []
+    Object.keys(this.files).forEach( key => {
+      this.files[key] = [];
+    });
   }
 
-  componentWillLoad(){
+  handleSubmit(e) {
+    const form = e.srcElement;
+    // FormData object populated from an existing form
+    let formData = new FormData(form);
+
+    e.preventDefault();
+
+    // Add files from enhanced/multi-file inputs
+    formData = this.addFiles(formData);
+
+    //console.log('resulting formData (array spread): ',[...formData]);
+    
+    // If the form submission is prevented, emit an event with the data instead
+    if (this.preventSubmit) {
+      this.suppressedSubmit.emit({
+        host: this.host,
+        form: form,
+        formData: formData,
+        nativeEvent: e
+      });
+    }
+    // otherwise submit after updating the formData
+    else form.submit();
+  }
+
+  addFiles(formData) {
+    /*
+      Update FormData (or create a copy) with fields not supported natively:
+      File input (multiple+enhanced, allowing manipulation of FileList)
+    */
+    Object.keys(this.files).forEach( key => {
+      if (this.files?.[`${key}`]?.length > 0){
+        // delete the empty key if there are files specified
+        formData.delete(key);
+        // loop over the files and add each as a new entry using append (set overrides the same entry)
+        this.files?.[key].forEach( file => {
+          formData.append(key, file);
+        });
+      }
+      formData[`${key}`] = this.files[`${key}`];
+    });
+    return formData;
+  }
+
+  handleEnhancedFileInput(e) {
+    // Keep tabs on enhanced/multi-file inputs' values
+    const {name, value} = e.detail;
+    this.files[name] = value;
+    console.log('cbp-form - Tracking enhanced/multi-file input: ', this.files);
+  }
+
+  componentWillLoad() {
     this.form=this.host.querySelector('form');
     this.form.addEventListener('submit', e => this.handleSubmit(e));
     this.form.addEventListener('reset', () => this.handleReset());
+
+    // Listen for changes to enhanced/multi-file inputs
+    this.enhancedFileInputs=Array.from(this.host.querySelectorAll('cbp-file-input[multiple]'));
+    this.enhancedFileInputs.forEach( item => {
+      item.addEventListener('valueChange', e => this.handleEnhancedFileInput(e));
+    });
   }
 
   render() {

--- a/packages/web-components/src/stories/tests/form-processing.stories.tsx
+++ b/packages/web-components/src/stories/tests/form-processing.stories.tsx
@@ -271,8 +271,20 @@ function HTMLForm( {name, action, method, enctype, prefix, firstName, middleInit
       <!-- File Inputs -->
       <label>
         Native File Input<br />
-        <input type="file" name="nativefileinput" />
+        <input type="file" name="nativefileinput" multiple/>
       </label><br /><br />
+
+ 
+      <cbp-form-field label="Native File Input" description="Although styled as a design system input, this is a native file input in function.">
+        <cbp-form-field-wrapper>
+          <input type="file" name="nativefileinput" multiple>
+          <span slot="cbp-form-field-attached-button">
+            <cbp-button fill="solid" color="secondary" aria-describedby="undefined-label" onclick="event.target.closest('cbp-form-field').querySelector('input').click()">
+              Browse
+            </cbp-button>
+          </span>
+        </cbp-form-field-wrapper>
+      </cbp-form-field>
 
       <cbp-form-field
         label="Single File"
@@ -427,7 +439,7 @@ const FormComponentProcessingTemplate = (args) => {
       Some component-enhanced functionality may not work with the native platform without using the cbp-form component. 
       This page demonstrates component interactions using a cbp-form wrapping a native HTML form and handling the form events such as submit and reset.
     </p>
-    <cbp-form>
+    <cbp-form prevent-submit>
       ${HTMLForm(args)}
     </cbp-form>
   `;


### PR DESCRIPTION
* Update cbp-form to handle file inputs on form submission
* Update the native input to use our wrapper/pattern in test story
* Update file input to work with cbp-form

It's pretty hard to test, but you can uncomment line 49 of cbp-form.tsx to see the updated formData when using the last multi-file input on the test page.