### PR TITLE
updates to address accessibility flags in storybook

### DIFF
--- a/packages/web-components/src/components/cbp-action-bar/cbp-action-bar.scss
+++ b/packages/web-components/src/components/cbp-action-bar/cbp-action-bar.scss
@@ -10,10 +10,10 @@
   --cbp-action-bar-color: var(--cbp-color-text-darkest);
   --cbp-action-bar-color-dark: var(--cbp-color-text-lightest);
   --cbp-action-bar-color-bg: var(--cbp-color-gray-cool-5);
-  --cbp-action-bar-color-bg-dark: var(--cbp-color-gray-cool-70);
+  --cbp-action-bar-color-bg-dark: var(--cbp-color-gray-cool-80);
 
   --cbp-action-bar-floating-color-bg: var(--cbp-color-white);
-  --cbp-action-bar-floating-color-bg-dark: var(--cbp-color-gray-cool-90);
+  --cbp-action-bar-floating-color-bg-dark: var(--cbp-color-gray-cool-80);
 }
 
 [data-cbp-theme=light] cbp-action-bar[context*=dark]:not([context=light-always]),

--- a/packages/web-components/src/components/cbp-action-bar/cbp-action-bar.stories.tsx
+++ b/packages/web-components/src/components/cbp-action-bar/cbp-action-bar.stories.tsx
@@ -35,15 +35,17 @@ export default {
             <cbp-button 
             ${context && context != 'light-inverts' ? `context=${context}` : ''}   
             fill="ghost"
-            >
+            sx='{"--cbp-button-color-dark":"var(--cbp-color-blue-20"}'
+          >
               Action 1
-            </cbp-button>
-            <cbp-button 
+          </cbp-button>
+          <cbp-button 
               ${context && context != 'light-inverts' ? `context=${context}` : ''}     
               fill="ghost"
-            >
+              sx='{"--cbp-button-color-dark":"var(--cbp-color-blue-20"}'
+          >
               Action 2
-            </cbp-button>
+          </cbp-button>
         </cbp-action-bar>
       `;
   };

--- a/packages/web-components/src/components/cbp-action-bar/cbp-action-bar.stories.tsx
+++ b/packages/web-components/src/components/cbp-action-bar/cbp-action-bar.stories.tsx
@@ -35,14 +35,13 @@ export default {
             <cbp-button 
             ${context && context != 'light-inverts' ? `context=${context}` : ''}   
             fill="ghost"
-            sx='{"--cbp-button-color-dark":"var(--cbp-color-blue-20"}'
           >
               Action 1
           </cbp-button>
           <cbp-button 
               ${context && context != 'light-inverts' ? `context=${context}` : ''}     
               fill="ghost"
-              sx='{"--cbp-button-color-dark":"var(--cbp-color-blue-20"}'
+              color="secondary"
           >
               Action 2
           </cbp-button>

--- a/packages/web-components/src/components/cbp-card/cbp-card.stories.tsx
+++ b/packages/web-components/src/components/cbp-card/cbp-card.stories.tsx
@@ -135,7 +135,7 @@ const FlagTemplate = ({ title, color, bodyText, withIcon, context, sx }) => {
       ${sx ? 'sx=' + JSON.stringify(sx) : ''}
     >
       <div slot="cbp-card-flag">
-        <img src="https://api.dicebear.com/9.x/personas/svg" />
+        <img src="https://api.dicebear.com/9.x/personas/svg" alt="Flag Card random image"/>
       </div>
       <cbp-typography tag="h4" slot="cbp-card-title">
         ${withIcon ? `<cbp-icon name="triangle-exclamation" size="1.25rem"></cbp-icon>` : ''}

--- a/packages/web-components/src/components/cbp-footer/cbp-footer.scss
+++ b/packages/web-components/src/components/cbp-footer/cbp-footer.scss
@@ -29,6 +29,10 @@ cbp-footer {
     font-size: var(--cbp-font-size-body);
     font-weight: var(--cbp-font-weight-regular);
     line-height: var(--cbp-line-height-xs);
-    padding: var(--cbp-space-5x) var(--cbp-responsive-spacing-outer)
+    padding: var(--cbp-space-5x) var(--cbp-responsive-spacing-outer);
+
+      cbp-link {
+      --cbp-link-color-dark: var(--cbp-color-blue-20);
+      }
     }
 }

--- a/packages/web-components/src/components/cbp-footer/cbp-footer.stories.tsx
+++ b/packages/web-components/src/components/cbp-footer/cbp-footer.stories.tsx
@@ -43,8 +43,8 @@ const InternalTemplate = ({ footerNav }) => {
         
         <cbp-flex gap="var(--cbp-space-4x)" wrap="wrap">
           <span><i>Having an issue?</i></span>
-          <span><b>Email: </b><cbp-link href="mailto:somebody@example.com" context="dark-always">this-application-support@abc.def.gov</cbp-link></span>
-          <span><b>CBP Helpdesk: </b><cbp-link href="tel:555-555-5555" context="dark-always">(555) 555-5555</cbp-link></span>
+          <span><b>Email: </b><cbp-link href="mailto:somebody@example.com" context="dark-always" sx='{"--cbp-link-color-dark":"var(--cbp-color-blue-20)"}'>this-application-support@abc.def.gov</cbp-link></span>
+          <span><b>CBP Helpdesk: </b><cbp-link href="tel:555-555-5555" context="dark-always" sx='{"--cbp-link-color-dark":"var(--cbp-color-blue-20)"}'>(555) 555-5555</cbp-link></span>
         </cbp-flex>
       </section>
     </cbp-footer>

--- a/packages/web-components/src/components/cbp-footer/cbp-footer.stories.tsx
+++ b/packages/web-components/src/components/cbp-footer/cbp-footer.stories.tsx
@@ -34,7 +34,7 @@ const InternalTemplate = ({ footerNav }) => {
       </nav>
 
       <section>
-        <cbp-typography tag="h6" variant="heading-md" context="dark-always" sx='{"margin-bottom":"var(--cbp-space-2x)"}'>
+        <cbp-typography tag="span" variant="heading-md" context="dark-always" sx='{"margin-bottom":"var(--cbp-space-2x)"}'>
           <cbp-icon name='headset' size='1.25rem'> </cbp-icon>
           Application Support
         </cbp-typography>

--- a/packages/web-components/src/components/cbp-footer/cbp-footer.stories.tsx
+++ b/packages/web-components/src/components/cbp-footer/cbp-footer.stories.tsx
@@ -43,8 +43,8 @@ const InternalTemplate = ({ footerNav }) => {
         
         <cbp-flex gap="var(--cbp-space-4x)" wrap="wrap">
           <span><i>Having an issue?</i></span>
-          <span><b>Email: </b><cbp-link href="mailto:somebody@example.com" context="dark-always" sx='{"--cbp-link-color-dark":"var(--cbp-color-blue-20)"}'>this-application-support@abc.def.gov</cbp-link></span>
-          <span><b>CBP Helpdesk: </b><cbp-link href="tel:555-555-5555" context="dark-always" sx='{"--cbp-link-color-dark":"var(--cbp-color-blue-20)"}'>(555) 555-5555</cbp-link></span>
+          <span><b>Email: </b><cbp-link href="mailto:somebody@example.com" context="dark-always" >this-application-support@abc.def.gov</cbp-link></span>
+          <span><b>CBP Helpdesk: </b><cbp-link href="tel:555-555-5555" context="dark-always" >(555) 555-5555</cbp-link></span>
         </cbp-flex>
       </section>
     </cbp-footer>

--- a/packages/web-components/src/components/cbp-multicol/cbp-multicol.stories.tsx
+++ b/packages/web-components/src/components/cbp-multicol/cbp-multicol.stories.tsx
@@ -86,5 +86,5 @@ Multicol.args = {
   columns: 2,
   width: '8rem',
   gap: 'var(--cbp-space-4x)',
-  sx: {"padding":"var(--cbp-space-4x)"}
+  sx: {"padding-inline-start":"var(--cbp-space-4x)"}
 };

--- a/packages/web-components/src/components/cbp-multicol/cbp-multicol.stories.tsx
+++ b/packages/web-components/src/components/cbp-multicol/cbp-multicol.stories.tsx
@@ -66,8 +66,8 @@ function createChildren(children) {
 }
 
 const Template = ({ content, columns, width, gap, rule, nobreak, sx }) => {
+  //TODO: removed UL to deal with accessibility flag
   return `
-    <ul>
       <cbp-multicol
         ${columns ? `columns="${columns}"` : ''}
         ${width ? `width="${width}"` : ''}
@@ -78,7 +78,6 @@ const Template = ({ content, columns, width, gap, rule, nobreak, sx }) => {
       >
         ${createChildren(content)}
       </cbp-multicol>
-    </ul>
   `;
 };
 

--- a/packages/web-components/src/components/cbp-multicol/cbp-multicol.stories.tsx
+++ b/packages/web-components/src/components/cbp-multicol/cbp-multicol.stories.tsx
@@ -66,7 +66,6 @@ function createChildren(children) {
 }
 
 const Template = ({ content, columns, width, gap, rule, nobreak, sx }) => {
-  //TODO: removed UL to deal with accessibility flag
   return `
       <cbp-multicol
         ${columns ? `columns="${columns}"` : ''}
@@ -75,6 +74,7 @@ const Template = ({ content, columns, width, gap, rule, nobreak, sx }) => {
         ${rule ? `rule="${rule}"` : ''}
         ${nobreak ? `nobreak` : ''}
         ${sx ? `sx=${JSON.stringify(sx)}` : ''}
+        role="list"
       >
         ${createChildren(content)}
       </cbp-multicol>
@@ -85,5 +85,6 @@ export const Multicol = Template.bind({});
 Multicol.args = {
   columns: 2,
   width: '8rem',
-  gap: 'var(--cbp-space-4x)'
+  gap: 'var(--cbp-space-4x)',
+  sx: {"padding":"var(--cbp-space-4x)"}
 };

--- a/packages/web-components/src/components/cbp-multicol/cbp-multicol.tsx
+++ b/packages/web-components/src/components/cbp-multicol/cbp-multicol.tsx
@@ -51,7 +51,7 @@ export class CbpMulticol {
 
   render() {
     return (
-      <Host>
+      <Host role="list">
         <slot />
       </Host>
     );

--- a/packages/web-components/src/components/cbp-multicol/cbp-multicol.tsx
+++ b/packages/web-components/src/components/cbp-multicol/cbp-multicol.tsx
@@ -51,7 +51,7 @@ export class CbpMulticol {
 
   render() {
     return (
-      <Host role="list">
+      <Host>
         <slot />
       </Host>
     );

--- a/packages/web-components/src/components/cbp-segmented-button-group/cbp-segmented-button-group.stories.tsx
+++ b/packages/web-components/src/components/cbp-segmented-button-group/cbp-segmented-button-group.stories.tsx
@@ -101,21 +101,21 @@ export const SegmentedButtonGroupIcons = IconTemplate.bind({});
 SegmentedButtonGroupIcons.args = {
   buttons: [
     {
-      label: '<cbp-icon name="user" aria-label="User"></cbp-icon>',
+      label: '<cbp-icon name="user" accessibility-text="User"></cbp-icon>',
       value: '1',
       pressed: false,
       disabled: false,
       variant: "square"
     },
     {
-      label: '<cbp-icon name="pen-to-square" aria-label="Edit"></cbp-icon>',
+      label: '<cbp-icon name="pen-to-square" accessibility-text="Edit"></cbp-icon>',
       value: '2',
       pressed: false,
       disabled: false,
       variant: "square"
     },
     {
-      label: '<cbp-icon name="filter" aria-label="Filter"></cbp-icon>',
+      label: '<cbp-icon name="filter" accessibility-text="Filter"></cbp-icon>',
       value: '3',
       pressed: false,
       disabled: false,

--- a/packages/web-components/src/components/cbp-segmented-button-group/cbp-segmented-button-group.stories.tsx
+++ b/packages/web-components/src/components/cbp-segmented-button-group/cbp-segmented-button-group.stories.tsx
@@ -36,6 +36,7 @@ function generateButtons(buttons) {
         ${pressed == true ? `pressed="${pressed}"` : ''}
         ${disabled == true ? 'disabled' : ''}
         ${variant ? `variant="${variant}"` : ''}
+        accessibility-text="segementedButtonExample"
       >
         ${label}
       </cbp-button>

--- a/packages/web-components/src/components/cbp-segmented-button-group/cbp-segmented-button-group.stories.tsx
+++ b/packages/web-components/src/components/cbp-segmented-button-group/cbp-segmented-button-group.stories.tsx
@@ -36,7 +36,6 @@ function generateButtons(buttons) {
         ${pressed == true ? `pressed="${pressed}"` : ''}
         ${disabled == true ? 'disabled' : ''}
         ${variant ? `variant="${variant}"` : ''}
-        accessibility-text="segementedButtonExample"
       >
         ${label}
       </cbp-button>
@@ -102,21 +101,21 @@ export const SegmentedButtonGroupIcons = IconTemplate.bind({});
 SegmentedButtonGroupIcons.args = {
   buttons: [
     {
-      label: '<cbp-icon name="user"></cbp-icon>',
+      label: '<cbp-icon name="user" aria-label="User"></cbp-icon>',
       value: '1',
       pressed: false,
       disabled: false,
       variant: "square"
     },
     {
-      label: '<cbp-icon name="pen-to-square"></cbp-icon>',
+      label: '<cbp-icon name="pen-to-square" aria-label="Edit"></cbp-icon>',
       value: '2',
       pressed: false,
       disabled: false,
       variant: "square"
     },
     {
-      label: '<cbp-icon name="filter"></cbp-icon>',
+      label: '<cbp-icon name="filter" aria-label="Filter"></cbp-icon>',
       value: '3',
       pressed: false,
       disabled: false,

--- a/packages/web-components/src/components/cbp-structured-list/cbp-structured-list.stories.tsx
+++ b/packages/web-components/src/components/cbp-structured-list/cbp-structured-list.stories.tsx
@@ -60,6 +60,7 @@ function generateSelectableItems(items, context){
         type="checkbox"
         name="checkbox"
         value=${index}
+        aria-label= ${content}
       />
       <span style='display: none'>Checkbox ${index}</span>
     </cbp-checkbox>
@@ -631,7 +632,7 @@ const StructuredListSelectableTemplate = ({ listItems, striped, showHeader, head
           ${context && context != 'light-inverts' ? `context=${context}` : ''}   
           ${sx ? `sx=${JSON.stringify(sx)}` : ''}
         >
-        ${showHeader ? `<div slot="cbp-structured-list-header" id="${headerId}"><cbp-checkbox><input type="checkbox" /><span style='display: none'>check all</span></cbp-checkbox> <span>5 Search Results</span></div>` : ''}
+        ${showHeader ? `<div slot="cbp-structured-list-header" id="${headerId}"><cbp-checkbox><input type="checkbox" aria-label="Select All"/><span style='display: none'>check all</span></cbp-checkbox> <span>5 Search Results</span></div>` : ''}
     
         ${generateSelectableItems(listItems, context)}
           <div slot="cbp-structured-list-footer">

--- a/packages/web-components/src/components/cbp-structured-list/cbp-structured-list.stories.tsx
+++ b/packages/web-components/src/components/cbp-structured-list/cbp-structured-list.stories.tsx
@@ -61,8 +61,9 @@ function generateSelectableItems(items, context){
         name="checkbox"
         value=${index}
       />
-      <cbp-hide>
-        <span>Checkbox ${index}</span>
+      <cbp-hide
+      visually-hide=true>
+        Checkbox ${index}
       </cbp-hide>
     </cbp-checkbox>
     ${content}
@@ -633,7 +634,7 @@ const StructuredListSelectableTemplate = ({ listItems, striped, showHeader, head
           ${context && context != 'light-inverts' ? `context=${context}` : ''}   
           ${sx ? `sx=${JSON.stringify(sx)}` : ''}
         >
-        ${showHeader ? `<div slot="cbp-structured-list-header" id="${headerId}"><cbp-checkbox><input type="checkbox"/><cbp-hide><span>check all</span></cbp-hide></cbp-checkbox> <span>5 Search Results</span></div>` : ''}
+        ${showHeader ? `<div slot="cbp-structured-list-header" id="${headerId}"><cbp-checkbox><input type="checkbox"/><cbp-hide visually-hide=true>check all</cbp-hide></cbp-checkbox> <span>5 Search Results</span></div>` : ''}
     
         ${generateSelectableItems(listItems, context)}
           <div slot="cbp-structured-list-footer">

--- a/packages/web-components/src/components/cbp-structured-list/cbp-structured-list.stories.tsx
+++ b/packages/web-components/src/components/cbp-structured-list/cbp-structured-list.stories.tsx
@@ -60,9 +60,10 @@ function generateSelectableItems(items, context){
         type="checkbox"
         name="checkbox"
         value=${index}
-        aria-label= ${content}
       />
-      <span style='display: none'>Checkbox ${index}</span>
+      <cbp-hide>
+        <span>Checkbox ${index}</span>
+      </cbp-hide>
     </cbp-checkbox>
     ${content}
     </cbp-structured-list-item>`;
@@ -632,7 +633,7 @@ const StructuredListSelectableTemplate = ({ listItems, striped, showHeader, head
           ${context && context != 'light-inverts' ? `context=${context}` : ''}   
           ${sx ? `sx=${JSON.stringify(sx)}` : ''}
         >
-        ${showHeader ? `<div slot="cbp-structured-list-header" id="${headerId}"><cbp-checkbox><input type="checkbox" aria-label="Select All"/><span style='display: none'>check all</span></cbp-checkbox> <span>5 Search Results</span></div>` : ''}
+        ${showHeader ? `<div slot="cbp-structured-list-header" id="${headerId}"><cbp-checkbox><input type="checkbox"/><cbp-hide><span>check all</span></cbp-hide></cbp-checkbox> <span>5 Search Results</span></div>` : ''}
     
         ${generateSelectableItems(listItems, context)}
           <div slot="cbp-structured-list-footer">

--- a/packages/web-components/src/components/cbp-structured-list/cbp-structured-list.stories.tsx
+++ b/packages/web-components/src/components/cbp-structured-list/cbp-structured-list.stories.tsx
@@ -62,7 +62,7 @@ function generateSelectableItems(items, context){
         value=${index}
       />
       <cbp-hide
-      visually-hide=true>
+      visually-hide>
         Checkbox ${index}
       </cbp-hide>
     </cbp-checkbox>
@@ -634,7 +634,7 @@ const StructuredListSelectableTemplate = ({ listItems, striped, showHeader, head
           ${context && context != 'light-inverts' ? `context=${context}` : ''}   
           ${sx ? `sx=${JSON.stringify(sx)}` : ''}
         >
-        ${showHeader ? `<div slot="cbp-structured-list-header" id="${headerId}"><cbp-checkbox><input type="checkbox"/><cbp-hide visually-hide=true>check all</cbp-hide></cbp-checkbox> <span>5 Search Results</span></div>` : ''}
+        ${showHeader ? `<div slot="cbp-structured-list-header" id="${headerId}"><cbp-checkbox><input type="checkbox"/><cbp-hide visually-hide>check all</cbp-hide></cbp-checkbox> <span>5 Search Results</span></div>` : ''}
     
         ${generateSelectableItems(listItems, context)}
           <div slot="cbp-structured-list-footer">

--- a/packages/web-components/src/components/cbp-tag/cbp-tag.scss
+++ b/packages/web-components/src/components/cbp-tag/cbp-tag.scss
@@ -6,7 +6,8 @@
  */
  :root{
   --cbp-tag-color: var(--cbp-color-info-lighter);
-  --cbp-tag-color-dark: var(--cbp-color-info-darker);
+  // --cbp-tag-color-dark: var(--cbp-color-info-darker);
+  --cbp-tag-color-dark: var(--cbp-color-blue-cool-80);
 
   --cbp-tag-color-background: var(--cbp-color-info-dark);
   --cbp-tag-color-background-dark: var(--cbp-color-info-light);

--- a/packages/web-components/src/components/cbp-tag/cbp-tag.scss
+++ b/packages/web-components/src/components/cbp-tag/cbp-tag.scss
@@ -7,7 +7,6 @@
  :root{
   --cbp-tag-color: var(--cbp-color-info-lighter);
   --cbp-tag-color-dark: var(--cbp-color-info-dark);
-  // --cbp-tag-color-dark: var(--cbp-color-blue-cool-80);
 
   --cbp-tag-color-background: var(--cbp-color-info-dark);
   --cbp-tag-color-background-dark: var(--cbp-color-info-lighter);

--- a/packages/web-components/src/components/cbp-tag/cbp-tag.scss
+++ b/packages/web-components/src/components/cbp-tag/cbp-tag.scss
@@ -6,11 +6,11 @@
  */
  :root{
   --cbp-tag-color: var(--cbp-color-info-lighter);
-  // --cbp-tag-color-dark: var(--cbp-color-info-darker);
-  --cbp-tag-color-dark: var(--cbp-color-blue-cool-80);
+  --cbp-tag-color-dark: var(--cbp-color-info-dark);
+  // --cbp-tag-color-dark: var(--cbp-color-blue-cool-80);
 
   --cbp-tag-color-background: var(--cbp-color-info-dark);
-  --cbp-tag-color-background-dark: var(--cbp-color-info-light);
+  --cbp-tag-color-background-dark: var(--cbp-color-info-lighter);
 }
 
 [data-cbp-theme=light] cbp-tag[context*=dark]:not([context=light-always]),

--- a/packages/web-components/src/components/cbp-tooltip/cbp-tooltip.stories.tsx
+++ b/packages/web-components/src/components/cbp-tooltip/cbp-tooltip.stories.tsx
@@ -35,7 +35,7 @@ const Template = ({ open, uid, alignment, title, content, tooltipControl, contex
             alignment=${alignment}
             ${context && context != 'light-inverts' ? `context=${context}` : ''}
             ${sx ? `sx=${JSON.stringify(sx)}` : ``}
-
+            aria-label=${title}
             >  
             
                 ${tooltipControl}

--- a/packages/web-components/src/components/cbp-tooltip/cbp-tooltip.stories.tsx
+++ b/packages/web-components/src/components/cbp-tooltip/cbp-tooltip.stories.tsx
@@ -54,7 +54,7 @@ Tooltip.args = {
     alignment: 'top-left',
     title: 'Test Tooltip Title',
     content: 'Stub text for tooltip.',
-    tooltipControl: '<cbp-icon name="user" aria-label="User"></cbp-icon>',
+    tooltipControl: '<cbp-icon name="user" accessibility-text="User"></cbp-icon>',
 }
 
 const DefinitionTemplate = ({ open, uid, alignment, title, content, tooltipControl, context, sx }) => {

--- a/packages/web-components/src/components/cbp-tooltip/cbp-tooltip.stories.tsx
+++ b/packages/web-components/src/components/cbp-tooltip/cbp-tooltip.stories.tsx
@@ -35,7 +35,6 @@ const Template = ({ open, uid, alignment, title, content, tooltipControl, contex
             alignment=${alignment}
             ${context && context != 'light-inverts' ? `context=${context}` : ''}
             ${sx ? `sx=${JSON.stringify(sx)}` : ``}
-            aria-label=${title}
             >  
             
                 ${tooltipControl}
@@ -55,7 +54,7 @@ Tooltip.args = {
     alignment: 'top-left',
     title: 'Test Tooltip Title',
     content: 'Stub text for tooltip.',
-    tooltipControl: '<cbp-icon name="user"></cbp-icon>',
+    tooltipControl: '<cbp-icon name="user" aria-label="User"></cbp-icon>',
 }
 
 const DefinitionTemplate = ({ open, uid, alignment, title, content, tooltipControl, context, sx }) => {

--- a/packages/web-components/src/stories/Archetype_Passenger.stories.tsx
+++ b/packages/web-components/src/stories/Archetype_Passenger.stories.tsx
@@ -289,7 +289,7 @@ function generatePassengers(passengerArgs, page, pageSize) {
                     style="width: 100px; border-radius: var(--cbp-border-radius-softer);"
                   />
                 <cbp-flex direction="column" gap="var(--cbp-space-2x) var(--cbp-space-1x)">
-                  <cbp-typography tag="h3">${name}</cbp-typography>
+                  <cbp-typography tag="h2">${name}</cbp-typography>
                   <cbp-tag> Arriving In: 01:12:45 </cbp-tag>
                   ${error ? `<cbp-tag color="danger"> T-list</cbp-tag>` : ``}
                 </cbp-flex>
@@ -1015,7 +1015,7 @@ const InternalTemplate = ({ isLoggedIn, username, hashid, navItems, search, sear
       </nav>
 
       <section>
-        <cbp-typography tag="h6" variant="heading-md" context="dark-always" sx='{"margin-bottom":"var(--cbp-space-2x)"}'>Application Support</cbp-typography>
+        <cbp-typography tag="span" variant="heading-md" context="dark-always" sx='{"margin-bottom":"var(--cbp-space-2x)"}'>Application Support</cbp-typography>
         <p><em>This application is maintained by The Office of Information Technology: <abbr title="Targeting and Analysis Systems Program Directorate">TASPD</abbr>.</em></p>
         <cbp-flex gap="var(--cbp-space-4x)" wrap="wrap">
           <span>Having an issue?</span>

--- a/packages/web-components/src/stories/Archetype_Passenger.stories.tsx
+++ b/packages/web-components/src/stories/Archetype_Passenger.stories.tsx
@@ -1011,7 +1011,7 @@ const InternalTemplate = ({ isLoggedIn, username, hashid, navItems, search, sear
           <cbp-flex-item role="listitem">
             <cbp-button tag="a" href="#" color="secondary" fill="ghost" context="dark-always">Release Notes</cbp-button>
           </cbp-flex-item>
-        <cbp-flex role="list">
+        </cbp-flex>
       </nav>
 
       <section>

--- a/packages/web-components/src/stories/Search_Result.stories.tsx
+++ b/packages/web-components/src/stories/Search_Result.stories.tsx
@@ -740,7 +740,7 @@ const searchResultsTemplate = ({isLoggedIn, username, hashid, navItems, searchTe
             <cbp-flex-item role="listitem">
               <cbp-button tag="a" href="#" color="secondary" fill="ghost" context="dark-always">Release Notes</cbp-button>
             </cbp-flex-item>
-          <cbp-flex role="list">
+          </cbp-flex>
         </nav>
 
         <section>

--- a/packages/web-components/src/stories/Search_Result.stories.tsx
+++ b/packages/web-components/src/stories/Search_Result.stories.tsx
@@ -744,7 +744,7 @@ const searchResultsTemplate = ({isLoggedIn, username, hashid, navItems, searchTe
         </nav>
 
         <section>
-          <cbp-typography tag="h6" variant="heading-md" context="dark-always" sx='{"margin-bottom":"var(--cbp-space-2x)"}'>Application Support</cbp-typography>
+          <cbp-typography tag="span" variant="heading-md" context="dark-always" sx='{"margin-bottom":"var(--cbp-space-2x)"}'>Application Support</cbp-typography>
           <p><em>This application is maintained by The Office of Information Technology: <abbr title="Targeting and Analysis Systems Program Directorate">TASPD</abbr>.</em></p>
           <cbp-flex gap="var(--cbp-space-4x)" wrap="wrap">
             <span>Having an issue?</span>

--- a/packages/web-components/src/stories/templates.stories.tsx
+++ b/packages/web-components/src/stories/templates.stories.tsx
@@ -551,6 +551,7 @@ function generateCards(numberOfCards) {
       <cbp-card variant="decision">
         <cbp-typography
           tag="h2"
+          variant="heading-lg"
           slot="cbp-card-title"
           id="card-heading-${i}"
         >

--- a/packages/web-components/src/stories/templates.stories.tsx
+++ b/packages/web-components/src/stories/templates.stories.tsx
@@ -551,7 +551,7 @@ function generateCards(numberOfCards) {
       <cbp-card variant="decision">
         <cbp-typography
           tag="h2"
-          variant="heading-lg"
+          variant="heading-md"
           slot="cbp-card-title"
           id="card-heading-${i}"
         >

--- a/packages/web-components/src/stories/templates.stories.tsx
+++ b/packages/web-components/src/stories/templates.stories.tsx
@@ -178,7 +178,7 @@ const InternalTemplate = ({ isLoggedIn, username, hashid, navItems, search, sear
             <cbp-flex-item role="listitem">
               <cbp-button tag="a" href="#" color="secondary" fill="ghost" context="dark-always">Release Notes</cbp-button>
             </cbp-flex-item>
-          <cbp-flex role="list">
+          </cbp-flex>
         </nav>
 
         <section>
@@ -315,7 +315,7 @@ const Internal2ColumnTemplate = ({ isLoggedIn, username, hashid, navItems, searc
             <cbp-flex-item role="listitem">
               <cbp-button tag="a" href="#" color="secondary" fill="ghost" context="dark-always">Release Notes</cbp-button>
             </cbp-flex-item>
-          <cbp-flex role="list">
+          </cbp-flex>
         </nav>
 
         <section>
@@ -684,7 +684,7 @@ const InternalCardsLayoutTemplate = ({ isLoggedIn, username, hashid, navItems, s
             <cbp-flex-item role="listitem">
               <cbp-button tag="a" href="#" color="secondary" fill="ghost" context="dark-always">Release Notes</cbp-button>
             </cbp-flex-item>
-          <cbp-flex role="list">
+          </cbp-flex>
         </nav>
 
         <section>

--- a/packages/web-components/src/stories/templates.stories.tsx
+++ b/packages/web-components/src/stories/templates.stories.tsx
@@ -182,7 +182,7 @@ const InternalTemplate = ({ isLoggedIn, username, hashid, navItems, search, sear
         </nav>
 
         <section>
-          <cbp-typography tag="h6" variant="heading-md" context="dark-always" sx='{"margin-bottom":"var(--cbp-space-2x)"}'>Application Support</cbp-typography>
+          <cbp-typography tag="span" variant="heading-md" context="dark-always" sx='{"margin-bottom":"var(--cbp-space-2x)"}'>Application Support</cbp-typography>
           <p><em>This application is maintained by The Office of Information Technology: <abbr title="Targeting and Analysis Systems Program Directorate">TASPD</abbr>.</em></p>
           <cbp-flex gap="var(--cbp-space-4x)" wrap="wrap">
             <span>Having an issue?</span>
@@ -289,7 +289,7 @@ const Internal2ColumnTemplate = ({ isLoggedIn, username, hashid, navItems, searc
         >
           <cbp-typography
             slot="cbp-panel-header"
-            tag="h3"
+            tag="h2"
             variant="heading-lg"
             id="sidebarpanelheader"
           >
@@ -319,7 +319,7 @@ const Internal2ColumnTemplate = ({ isLoggedIn, username, hashid, navItems, searc
         </nav>
 
         <section>
-          <cbp-typography tag="h6" variant="heading-md" context="dark-always" sx='{"margin-bottom":"var(--cbp-space-2x)"}'>Application Support</cbp-typography>
+          <cbp-typography tag="span" variant="heading-md" context="dark-always" sx='{"margin-bottom":"var(--cbp-space-2x)"}'>Application Support</cbp-typography>
           <p><em>This application is maintained by The Office of Information Technology: <abbr title="Targeting and Analysis Systems Program Directorate">TASPD</abbr>.</em></p>
           <cbp-flex gap="var(--cbp-space-4x)" wrap="wrap">
             <span>Having an issue?</span>
@@ -550,7 +550,7 @@ function generateCards(numberOfCards) {
     html+= `
       <cbp-card variant="decision">
         <cbp-typography
-          tag="h4"
+          tag="h2"
           slot="cbp-card-title"
           id="card-heading-${i}"
         >
@@ -688,7 +688,7 @@ const InternalCardsLayoutTemplate = ({ isLoggedIn, username, hashid, navItems, s
         </nav>
 
         <section>
-          <cbp-typography tag="h6" variant="heading-md" context="dark-always" sx='{"margin-bottom":"var(--cbp-space-2x)"}'>Application Support</cbp-typography>
+          <cbp-typography tag="span" variant="heading-md" context="dark-always" sx='{"margin-bottom":"var(--cbp-space-2x)"}'>Application Support</cbp-typography>
           <p><em>This application is maintained by The Office of Information Technology: <abbr title="Targeting and Analysis Systems Program Directorate">TASPD</abbr>.</em></p>
           <cbp-flex gap="var(--cbp-space-4x)" wrap="wrap">
             <span>Having an issue?</span>


### PR DESCRIPTION
*Action Bar => serious issues(2)  about color contrast (4.32) on the button color in dark mode (color-blue-30 over gray-cool-70)
*Card => flag card story: Image alt text required
*Footer => color contrast of 4.32 (foreground: (-{}cbp-color-interactive-primary-light background: ({-}-cbp-color-gray-cool-70))   
*Multicol => 
	*List structure(1): list element has direct children that are not allowed: cbp-multicol 
 	*List Item(10): list item does not have a <ul>, <ol> parent element.
*Segmented Button Group => Button Name (3): every button needs a label or accessible name [Icon example]
*Tag => cbp-tag(default/info) has contrast of 4.24 (color: ({}cbp-color-info-darker) bg: ({-}-cbp-color-info-light))
*Tooltip -> ARIA command name : needs a label or accessible name (has role='button' but no aria-label or etc)
*structured list selectable story: form label (6) => Every form field needs an associated label
