### PR TITLE
Bugfix/pagination pages emit event

### DIFF
--- a/packages/web-components/src/components/cbp-pagination/cbp-pagination.scss
+++ b/packages/web-components/src/components/cbp-pagination/cbp-pagination.scss
@@ -27,7 +27,19 @@ cbp-pagination {
   [slot=cbp-pagination-items-per-page],
   [slot=cbp-pagination-pages] {
     label {
-      display: none;
+      //display: none;
+      // TechDebt: this should be a mixin
+      border: 0;
+      clip: rect(1px, 1px, 1px, 1px);
+      -webkit-clip-path: inset(50%);
+      clip-path: inset(50%);
+      height: 1px;
+      overflow: hidden;
+      margin: -1px;
+      padding: 0;
+      position: absolute;
+      width: 1px;
+      white-space: nowrap;
     }
   }
 

--- a/packages/web-components/src/components/cbp-pagination/cbp-pagination.specs.mdx
+++ b/packages/web-components/src/components/cbp-pagination/cbp-pagination.specs.mdx
@@ -14,10 +14,10 @@ The Pagination component presents a common UI pattern for displaying data sets b
   * The number of items per page dropdown may be customized by the application with whatever values are desired.
   * The page selection dropdown is slotted by the application, but controlled (updated) by the pagination component based on the total records and number of items per page.
 * The text describing the items shown is determined by these values and generate by the pagination component.
-* The Pagination component does not handle displaying the data.
+* The Pagination component is loosely coupled to the application and does not handle displaying the data.
   * The Pagination component emits events as hooks for application logic whenever the controls are changed.
   * Changes to the component properties such as records, pagesize, and page are reactive and will cause the pagination component to re-render.
-* The "items per page" dropdown is application specified. It may be copied from Storybook as-is or modified.
+* The "items per page" dropdown is application-specified. It may be copied from Storybook as-is or modified.
 * The "pages" dropdown is managed by the Pagination component based on the number of records and page size (items per page) values. 
 * The empty `cbp-dropdown` with desired properties will be slotted by the application with the "next/previous" attached button controls.
 * The "previous" button will be disabled when the first item in the "pages" dropdown is selected.
@@ -41,7 +41,7 @@ The Pagination component presents a common UI pattern for displaying data sets b
 
 ### Accessibility
 
-* TBD
+* The labels for both dropdowns are visibly hidden in an accessible manner, but still read by screen readers.
 
 ### Additional Notes and Considerations
 

--- a/packages/web-components/src/components/cbp-pagination/cbp-pagination.stories.tsx
+++ b/packages/web-components/src/components/cbp-pagination/cbp-pagination.stories.tsx
@@ -54,31 +54,28 @@ const Template = ({ records, pagesize, page, context, sx }) => {
           field-id="pagination_pages"
         >
           <cbp-dropdown field-id="pagination_pages">
-
-          <div slot="cbp-dropdown-attached-button-start">
-            <cbp-button
-              fill="solid"
-              color="secondary"
-              variant="square"
-              value="previous page"
-              accessibility-text="Previous page"
-            >
-              <cbp-icon name="chevron-right" rotate="180" />
-            </cbp-button>
-          </div>
-
-          <div slot="cbp-dropdown-attached-button-end">
-            <cbp-button
-              fill="solid"
-              color="secondary"
-              variant="square"
-              value="next page"
-              accessibility-text="Next page"
-            >
-              <cbp-icon name="chevron-right" />
-            </cbp-button>
-          </div>
-
+            <div slot="cbp-dropdown-attached-button-start">
+              <cbp-button
+                fill="solid"
+                color="secondary"
+                variant="square"
+                value="previous page"
+                accessibility-text="Previous page"
+              >
+                <cbp-icon name="chevron-right" rotate="180" />
+              </cbp-button>
+            </div>
+            <div slot="cbp-dropdown-attached-button-end">
+              <cbp-button
+                fill="solid"
+                color="secondary"
+                variant="square"
+                value="next page"
+                accessibility-text="Next page"
+              >
+                <cbp-icon name="chevron-right" />
+              </cbp-button>
+            </div>
           </cbp-dropdown>
         </cbp-form-field>
 

--- a/packages/web-components/src/components/cbp-pagination/cbp-pagination.tsx
+++ b/packages/web-components/src/components/cbp-pagination/cbp-pagination.tsx
@@ -55,6 +55,7 @@ export class CbpPagination {
     if (value == 'previous page') this.handlePageChange(this.page-1);
   }
 
+
   handlePageSizeChange( value ) {
     this.page=1; // always reset the current page to 1 when changing the page size
     
@@ -72,7 +73,6 @@ export class CbpPagination {
       this.pagesDropdown.removeAttribute('hidden');
     }
 
-
     // Generate a new array of dropdown-items and replace them in the pages dropdown
     this.pagesDropdownItems=[];
     for (let i=1; i <= this.pages; i++ ) {
@@ -83,6 +83,16 @@ export class CbpPagination {
     }
     this.pagesDropdown.querySelector('[role=listbox]').replaceChildren(...this.pagesDropdownItems);
     
+    // Emit the custom event
+    this.paginationChange.emit({
+      host: this.host,
+      records: this.records,
+      pageSize: this.pageSize,
+      page: this.page,
+      pages: this.pages
+    });
+
+    // Update the current page to page 1 and the button states after it's had time to update
     setTimeout( () => {
       this.pagesDropdown.value=1;
       this.checkPageButtonStates();
@@ -92,6 +102,7 @@ export class CbpPagination {
   handlePageChange(value) {
     this.page = this.pagesDropdown.value = value; // updating this prop will cause a re-render, recalculating the pagination text
 
+    // Emit the custom event
     this.paginationChange.emit({
       host: this.host,
       records: this.records,


### PR DESCRIPTION
* Emit `paginationChange` event when page size dropdown is changed
* Make labels visually hidden so they are read properly (this may be revisited to make a SASS mixin later and leverage it here)
* Update docs