### PR TITLE
Add flags for chromatic testing

### DIFF
--- a/packages/web-components/src/stories/Archetype_Passenger.stories.tsx
+++ b/packages/web-components/src/stories/Archetype_Passenger.stories.tsx
@@ -5,6 +5,7 @@ export default {
     html: {
       root: '#storybook-root',
     },
+    chromatic: { ignoreSelectors: ['img[src="https://thispersondoesnotexist.com/"]'] },
   },
   argTypes: {    
     search: {

--- a/packages/web-components/src/stories/Design-tokens.stories.tsx
+++ b/packages/web-components/src/stories/Design-tokens.stories.tsx
@@ -25,6 +25,7 @@ export default {
   title: 'Design Tokens',
   parameters: {
     options: { showPanel: false },
+    chromatic: { disableSnapshot: true }
   },
 };
 


### PR DESCRIPTION
Adding parameters to storybook files to not run the chromatic testing on elements that will change and stories that are causing errors.

*Passenger Archetype: has a randomly generated image that will change on load, flagging this element to not be considered in chromatic visual testing. Rest of page will still be tested against baseline
*Design tokens: File is to large for visual test and is causing error on when running chromatic build

Looked at also flagging the doc/autodoc files but since they don't accept storybook param this approach will not work & from local testing they are not getting flagged as visual changes regardless.