### PR TITLE
Creation of circle variant for Button

### DIFF
--- a/packages/web-components/src/components/cbp-button/cbp-button.scss
+++ b/packages/web-components/src/components/cbp-button/cbp-button.scss
@@ -429,6 +429,16 @@ cbp-button {
     }
   }
 
+  &[variant=circle] {
+    button, a {
+      --cbp-button-height: 2.25rem; 
+      --cbp-button-width: var(--cbp-button-height); 
+      --cbp-button-border-radius: var(--cbp-border-radius-circle);
+      padding: unset;
+      letter-spacing: unset;
+    }
+  }
+
   &[variant=cta] {
     button, a {
       font-size: var(--cbp-font-size-heading-sm);

--- a/packages/web-components/src/components/cbp-button/cbp-button.specs.mdx
+++ b/packages/web-components/src/components/cbp-button/cbp-button.specs.mdx
@@ -12,7 +12,7 @@ The Button component represents a UI control visually styled like a button (rega
 
 * The Button component may render either a `button` or anchor (`a`) tag with a consistent visual style.
 * Buttons may have a number or variants based on fill (solid, outline, ghost) and color (based on design tokens).
-* Additional variants include "call-to-action" and "square" (primarily for icons-only).
+* Additional variants include "call-to-action", "square", and 'circle' (primarily for icons-only).
 * A Button component may have any content slotted as the label, including icons and other components, barring other interactive elements.
 * The Button component allows slotting of a custom control (rather than rendering one) to support component-based routers and/or directives places directly on the control.
 * Buttons are the most common UI control and require a robust implementation, acting as a control for segmented button groups, menus, dialogs, etc.

--- a/packages/web-components/src/components/cbp-button/cbp-button.stories.tsx
+++ b/packages/web-components/src/components/cbp-button/cbp-button.stories.tsx
@@ -61,7 +61,7 @@ export default {
     variant: {
       description: 'Variants includes a larger "Call to Action" and a square button for icons-only.',
       control: 'select',
-      options: ['default', 'square', 'cta'],
+      options: ['default', 'square', 'circle', 'cta'],
     },
     accessibilityText: {
       description: 'Accessibility text is applied as an `aria-label` and should be supplied when the button does not contain text or it is not sufficiently and uniquely descriptive.',

--- a/packages/web-components/src/components/cbp-button/cbp-button.tsx
+++ b/packages/web-components/src/components/cbp-button/cbp-button.tsx
@@ -29,7 +29,7 @@ export class CbpButton {
   /** The color of the button: primary, secondary, or danger. Defaults to "primary." */
   @Prop({ reflect: true }) color: 'primary' | 'secondary' | 'danger' = 'primary';
   /** Specifies a variant of the buttons, such as square for buttons with only an icon and call-to-action button. */
-  @Prop({ reflect: true }) variant: 'square' | 'cta';
+  @Prop({ reflect: true }) variant: 'square' | 'circle' | 'cta';
 
   /** Optionally specify the ID of the control here, which is used to generate related pattern node IDs and associate everything for accessibility */
   @Prop() controlId: string = createNamespaceKey('cbp-button');


### PR DESCRIPTION
Creation of the 'circle' variant of cbp-button. Intended for icon only similar to the square button variant