### PR TITLE
Bugfix/table responsiveness

### DIFF
--- a/packages/web-components/src/components/cbp-breadcrumb/cbp-breadcrumb.tsx
+++ b/packages/web-components/src/components/cbp-breadcrumb/cbp-breadcrumb.tsx
@@ -1,5 +1,5 @@
 import { Component, Prop, State, Element, Host, h } from '@stencil/core';
-import { setCSSProps, debounce } from '../../utils/utils';
+import { setCSSProps } from '../../utils/utils';
 
 /**
  * Breadcrumbs give users an indicator of where they are within a site/application hierarchy, 
@@ -155,12 +155,9 @@ export class CbpBreadcrumb {
     return (
       <Host>
         <cbp-resize-observer 
-          debounce={50}
+          debounce={10}
           ref={el => this.ro = el}
-          //onResized={(e) => this.handleResize(e.detail.width)}
-          onResized={ debounce((e) => {
-            this.handleResize(e.detail.width);
-          }, 10)}
+          onResized={(e) => this.handleResize(e.detail.width)}
         >
           <nav 
             aria-label="Breadcrumb" 

--- a/packages/web-components/src/components/cbp-resize-observer/cbp-resize-observer.tsx
+++ b/packages/web-components/src/components/cbp-resize-observer/cbp-resize-observer.tsx
@@ -1,5 +1,5 @@
 import { Component, Element, Prop, Event, EventEmitter, Host, h } from '@stencil/core';
-//import { debounce } from '../../utils/utils';
+import { debounce } from '../../utils/utils';
 
 /**
  * The Resize Observer component is a wrapper that implements a resizeObserver to detect changes to its size,
@@ -20,10 +20,14 @@ export class CbpResizeObserver {
  
   @Element() private host: HTMLElement;
 
-  /** The number of milliseconds to debounce the event emitter. (not currently working) */
+  /**
+   * The number of milliseconds to debounce the event emitter. Defaults to 0.
+   * While the native resize observer is very performant, the calculations within its handler function may
+   * not be, and performance may benefit from debouncing this event emitter.
+   */
   @Prop() debounce: number = 0;
 
-  /** A custom event emitted when the component is resized to give new values for size of component*/
+  /** A custom event emitted when the component is resized to give new values for size of component. */
   @Event() resized!: EventEmitter;
   
 
@@ -56,7 +60,7 @@ export class CbpResizeObserver {
             devicePixelContentBoxSize[]: ResizeObserverSize
             target
     */
-    this.observer = new ResizeObserver( ([{ contentRect }]) => {
+    this.observer = new ResizeObserver( debounce( ([{ contentRect }]) => {
       const {width, height, top, bottom, left, right, x, y} = contentRect;
 
       const customEvent = {
@@ -71,15 +75,10 @@ export class CbpResizeObserver {
         y: y
       }
 
-      // TechDebt: should this be debounced?
-      /* not working
-      debounce( () => {
-        this.resized.emit( customEvent);
-       }, this.debounce);
-      */
       this.resized.emit(customEvent);
+    } , this.debounce)
+  );
 
-    });
 
     // Observe the element
     this.observer.observe(this.observedEl);

--- a/packages/web-components/src/components/cbp-table/cbp-table.scss
+++ b/packages/web-components/src/components/cbp-table/cbp-table.scss
@@ -162,7 +162,7 @@ cbp-table {
   // Responsive linearized table
   &.cbp-table-linearize {
     thead {
-      display: none; // TechDebt: test for accessibility; possibly needs visually hidden styles
+      display: none;
     }
     td,th {
       display: block;

--- a/packages/web-components/src/components/cbp-table/cbp-table.scss
+++ b/packages/web-components/src/components/cbp-table/cbp-table.scss
@@ -1,46 +1,48 @@
 /**
- *  @prop --cbp-table-color: var(--cbp-color-text-darkest);
- *  @prop --cbp-table-color-dark: var(--cbp-color-text-lightest);
+ * @prop --cbp-table-color: var(--cbp-color-text-darkest);
+ * @prop --cbp-table-color-dark: var(--cbp-color-text-lightest);
    
- *  @prop --cbp-table-header-color: var(--cbp-color-interactive-secondary-darker);
- *  @prop --cbp-table-header-color-dark: var(--cbp-color-interactive-secondary-lighter);
- *  @prop --cbp-table-header-color-hover: var(--cbp-color-interactive-secondary-lighter);
- *  @prop --cbp-table-header-color-hover-dark: var(--cbp-color-interactive-secondary-darker);
- *  @prop --cbp-table-header-color-focus: var(--cbp-color-text-lightest);
- *  @prop --cbp-table-header-color-focus-dark: var(--cbp-color-text-darkest);
- *  @prop --cbp-table-header-color-active: var(--cbp-color-text-darkest);
- *  @prop --cbp-table-header-color-active-dark: var(--cbp-color-text-darkest);
+ * @prop --cbp-table-header-color: var(--cbp-color-interactive-secondary-darker);
+ * @prop --cbp-table-header-color-dark: var(--cbp-color-interactive-secondary-lighter);
+ * @prop --cbp-table-header-color-hover: var(--cbp-color-interactive-secondary-lighter);
+ * @prop --cbp-table-header-color-hover-dark: var(--cbp-color-interactive-secondary-darker);
+ * @prop --cbp-table-header-color-focus: var(--cbp-color-text-lightest);
+ * @prop --cbp-table-header-color-focus-dark: var(--cbp-color-text-darkest);
+ * @prop --cbp-table-header-color-active: var(--cbp-color-text-darkest);
+ * @prop --cbp-table-header-color-active-dark: var(--cbp-color-text-darkest);
 
- *  @prop --cbp-table-header-color-bg: var(--cbp-color-gray-cool-20);
- *  @prop --cbp-table-header-color-bg-dark: var(--cbp-color-gray-cool-60);
- *  @prop --cbp-table-header-color-bg-hover: var(--cbp-color-interactive-secondary-darker);
- *  @prop --cbp-table-header-color-bg-hover-dark: var(--cbp-color-interactive-secondary-lighter);
- *  @prop --cbp-table-header-color-bg-focus: var(--cbp-color-interactive-focus-dark);
- *  @prop --cbp-table-header-color-bg-focus-dark: var(--cbp-color-interactive-focus-light);
- *  @prop --cbp-table-header-color-bg-active: var(--cbp-color-interactive-active-dark);
- *  @prop --cbp-table-header-color-bg-active-dark: var(--cbp-color-interactive-active-light);
+ * @prop --cbp-table-header-color-bg: var(--cbp-color-gray-cool-20);
+ * @prop --cbp-table-header-color-bg-dark: var(--cbp-color-gray-cool-60);
+ * @prop --cbp-table-header-color-bg-hover: var(--cbp-color-interactive-secondary-darker);
+ * @prop --cbp-table-header-color-bg-hover-dark: var(--cbp-color-interactive-secondary-lighter);
+ * @prop --cbp-table-header-color-bg-focus: var(--cbp-color-interactive-focus-dark);
+ * @prop --cbp-table-header-color-bg-focus-dark: var(--cbp-color-interactive-focus-light);
+ * @prop --cbp-table-header-color-bg-active: var(--cbp-color-interactive-active-dark);
+ * @prop --cbp-table-header-color-bg-active-dark: var(--cbp-color-interactive-active-light);
 
- *  @prop --cbp-table-header-color-outline: var(--cbp-color-white);
- *  @prop --cbp-table-header-color-outline-dark: var(--cbp-color-black);
+ * @prop --cbp-table-header-color-outline: var(--cbp-color-white);
+ * @prop --cbp-table-header-color-outline-dark: var(--cbp-color-black);
 
- *  @prop --cbp-table-row-color-bg: var(--cbp-color-white);
- *  @prop --cbp-table-row-color-bg-dark: var(--cbp-color-gray-cool-70);
- *  @prop --cbp-table-row-color-bg-striped: var(--cbp-color-gray-cool-4);
- *  @prop --cbp-table-row-color-bg-striped-dark: var(--cbp-color-gray-cool-80);
- *  @prop --cbp-table-row-color-bg-hover: var(--cbp-color-gray-cool-10);
- *  @prop --cbp-table-row-color-bg-hover-dark: var(--cbp-color-gray-cool-90);
- *  @prop --cbp-table-row-color-bg-selected: var(--cbp-color-interactive-selected-light);
- *  @prop --cbp-table-row-color-bg-selected-dark: var(--cbp-color-interactive-selected-dark);
- *  @prop --cbp-table-color-bg-danger: var(--cbp-color-danger-lighter);
- *  @prop --cbp-table-color-bg-danger-dark: var(--cbp-color-danger-darker);
- *  @prop --cbp-table-row-color-bg-highlight: var(--cbp-color-highlight);
+ * @prop --cbp-table-row-color-bg: var(--cbp-color-white);
+ * @prop --cbp-table-row-color-bg-dark: var(--cbp-color-gray-cool-70);
+ * @prop --cbp-table-row-color-bg-striped: var(--cbp-color-gray-cool-4);
+ * @prop --cbp-table-row-color-bg-striped-dark: var(--cbp-color-gray-cool-80);
+ * @prop --cbp-table-row-color-bg-hover: var(--cbp-color-gray-cool-10);
+ * @prop --cbp-table-row-color-bg-hover-dark: var(--cbp-color-gray-cool-90);
+ * @prop --cbp-table-row-color-bg-selected: var(--cbp-color-interactive-selected-light);
+ * @prop --cbp-table-row-color-bg-selected-dark: var(--cbp-color-interactive-selected-dark);
+ * @prop --cbp-table-color-bg-danger: var(--cbp-color-danger-lighter);
+ * @prop --cbp-table-color-bg-danger-dark: var(--cbp-color-danger-darker);
+ * @prop --cbp-table-row-color-bg-highlight: var(--cbp-color-highlight);
  
- *  @prop --cbp-table-row-color-border: var(--cbp-color-gray-cool-30);
- *  @prop --cbp-table-row-color-border-dark: var(--cbp-color-gray-cool-50);
- *  @prop --cbp-table-row-border-size: var(--cbp-border-size-md); 
+ * @prop --cbp-table-row-color-border: var(--cbp-color-gray-cool-30);
+ * @prop --cbp-table-row-color-border-dark: var(--cbp-color-gray-cool-50);
+ * @prop --cbp-table-row-border-size: var(--cbp-border-size-md); 
 
- *  @prop --cbp-table-cell-padding: var(--cbp-space-4x) var(--cbp-space-3x);
+ * @prop --cbp-table-cell-padding: var(--cbp-space-4x) var(--cbp-space-3x);
+ * @prop --cbp-table-linearized-cell-padding: var(--cbp-space-2x) var(--cbp-space-3x);
  */
+
 :root {
   --cbp-table-color: var(--cbp-color-text-darkest);
   --cbp-table-color-dark: var(--cbp-color-text-lightest);
@@ -83,14 +85,14 @@
   --cbp-table-row-border-size: var(--cbp-border-size-md); 
 
   --cbp-table-cell-padding: var(--cbp-space-4x) var(--cbp-space-3x);
+  --cbp-table-linearized-cell-padding: var(--cbp-space-2x) var(--cbp-space-3x);
 }
-
 
 /* 
  * Dark Mode - display dark design based on mode or context
  */
  [data-cbp-theme=light] cbp-table[context*=dark],
- [data-cbp-theme=dark] cbp-table:not([context=dark-inverts]):not([context=light-always]){
+ [data-cbp-theme=dark] cbp-table:not([context=dark-inverts]):not([context=light-always]) {
   --cbp-table-color: var(--cbp-table-color-dark) !important;
   
   --cbp-table-header-color: var(--cbp-table-header-color-dark) !important;
@@ -110,12 +112,71 @@
   --cbp-table-color-bg-danger: var(--cbp-table-color-bg-danger-dark) !important;
 
   --cbp-table-row-color-border: var(--cbp-table-row-color-border-dark) !important;
- }
+}
 
 cbp-table {
   display: block;
   max-width: 100%;
-  overflow-x: auto;
+  //overflow-x: auto;
+
+  .cbp-table-toolbar {
+    display: flex;
+    align-items: flex-end;
+    flex-wrap: wrap;
+    gap: var(--cbp-space-2x);
+    width: 100%;
+    margin-block-end: var(--cbp-space-2x);
+  }
+
+  .cbp-table-toolbar-scroll {
+    display: none;
+    flex-grow: 1;
+    text-align: end;
+  }
+
+  .cbp-table-scroll-gradient {
+    display: none;
+  }
+
+  // Responsive horizontally scrolling table
+  &.cbp-table-scroll {
+    .cbp-table-toolbar-scroll {
+      --cbp-button-border-radius: 0;
+      display: block;
+    }
+
+    .cbp-table-wrapper {
+      position: relative;
+      overflow-x: scroll;
+      mask: linear-gradient(to right,#0003,#ffff var(--left-fade) calc(100% - var(--right-fade)), #0003);
+      animation: scrollfade;
+      animation-timeline: --scrollfade;
+      scroll-timeline: --scrollfade x;
+    }
+
+    // When a row header is used, make it sticky when scrolling overflow
+    table:has(tbody th:first-child) th:first-child {
+      //position: sticky;
+      //left: 0;
+      inset-inline-start: 0;
+    }
+  }
+  
+  // Responsive linearized table
+  &.cbp-table-linearize {
+    thead {
+      display: none; // TechDebt: test for accessibility; possibly needs visually hidden styles
+    }
+    td,th {
+      display: block;
+      padding: var(--cbp-table-linearized-cell-padding);
+    }
+    tbody td::before {
+      content: attr(data-column-header);
+      font-weight: var(--cbp-font-weight-medium);
+    }
+  }
+  
 
   // General classes for danger and highlighting (selected rows overrides, however)
   .cbp-table--danger td,
@@ -123,8 +184,8 @@ cbp-table {
     background-color: var(--cbp-table-color-bg-danger);
   }
 
-  .cbp-table--hightlight td,
-  td.cbp-table--hightlight {
+  .cbp-table--highlight td,
+  td.cbp-table--highlight {
     color: var(--cbp-color-text-darkest);
     background-color: var(--cbp-table-row-color-bg-highlight);
   }
@@ -154,8 +215,8 @@ cbp-table {
           background-color: var(--cbp-table-row-color-bg-hover);
         }
         
-        td.cbp-table--hightlight,
-        &.cbp-table--hightlight td {
+        td.cbp-table--highlight,
+        &.cbp-table--highlight td {
           color: var(--cbp-color-text-darkest);
           background-color: var(--cbp-table-row-color-bg-highlight);
         }
@@ -169,7 +230,7 @@ cbp-table {
       td:hover{
           background-color: var(--cbp-table-row-color-bg-hover);
         
-        &.cbp-table--hightlight{
+        &.cbp-table--highlight{
           color: var(--cbp-color-text-darkest);
           background-color: var(--cbp-table-row-color-bg-highlight);
         }
@@ -191,7 +252,7 @@ cbp-table {
     table:has(thead tr > *:nth-child(8):hover) tr > *:nth-child(8),
     table:has(thead tr > *:nth-child(9):hover) tr > *:nth-child(9),
     table:has(thead tr > *:nth-child(10):hover) tr > *:nth-child(10) {
-      &:not([aria-sort]):not(.cbp-table--highlight) {
+      &:not([aria-sort]) {
         color: var(--cbp-table-color);
         background-color: var(--cbp-table-row-color-bg-hover);
       }
@@ -202,17 +263,18 @@ cbp-table {
     margin: 0;
     padding: 0;
     max-width: 100%;
+    text-align: left;
     border-collapse: collapse;
 
     caption {
-      text-align: left;
+      text-align: start;
       font-size: var(--cbp-font-size-heading-xl);
       line-height: var(--cbp-line-height-xl);
     }
 
     th, td {
       color: var(--cbp-table-color);
-      text-align: left;
+      //text-align: left;
       vertical-align: top;
       padding: var(--cbp-table-cell-padding);
 
@@ -236,7 +298,7 @@ cbp-table {
 
         &[aria-sort=none] button {
           // Use padding as a placeholder to keep columns from shifting when sorted and an icon is added.
-          padding-inline-end: var(--cbp-space-9x); // icon = 4 + gap = 2 + end padding = 3 = 9
+          padding-inline-end: var(--cbp-space-9x); // icon = 4x + gap = 2x + end padding = 3x = 9x
         }
 
         &:has(button) {
@@ -314,7 +376,7 @@ cbp-table {
       tr {
         background-color: var(--cbp-table-row-color-bg);
 
-        // Selected state should override all others (striping, danger, highlight), but still show a hover effect 
+        // Selected state should override all others (striping, danger, highlight)
         &:has(input[type=checkbox]:checked) td {
           color: var(--cbp-table-color);
           background-color: var(--cbp-table-row-color-bg-selected);
@@ -322,7 +384,7 @@ cbp-table {
       }
 
       td:has(cbp-button){
-        padding: 0; // TechDebt: should probably be padding-block, but alignment appears off in both cases.
+        padding-block: 0;
         vertical-align: middle;
       }
     }
@@ -347,5 +409,33 @@ cbp-table {
     td {
       text-wrap: pretty;
     }
+  }
+}
+
+
+@property --left-fade {
+  syntax: "<length>";
+  inherits: false;
+  initial-value: 0;
+}
+
+@property --right-fade {
+  syntax: "<length>";
+  inherits: false;
+  initial-value: 0;
+}
+
+@keyframes scrollfade {
+  0% {
+    --left-fade: 0;
+  }
+  10%, 100% {
+    --left-fade: 1rem;
+  }
+  0%, 90% {
+    --right-fade: 1rem;
+  }
+  100% {
+    --right-fade: 0;
   }
 }

--- a/packages/web-components/src/components/cbp-table/cbp-table.scss
+++ b/packages/web-components/src/components/cbp-table/cbp-table.scss
@@ -117,7 +117,6 @@
 cbp-table {
   display: block;
   max-width: 100%;
-  //overflow-x: auto;
 
   .cbp-table-toolbar {
     display: flex;
@@ -156,6 +155,7 @@ cbp-table {
 
     // When a row header is used, make it sticky when scrolling overflow
     table:has(tbody th:first-child) th:first-child {
+      // TechDebt: need test case - enable for testing later
       //position: sticky;
       //left: 0;
       inset-inline-start: 0;
@@ -274,7 +274,6 @@ cbp-table {
 
     th, td {
       color: var(--cbp-table-color);
-      //text-align: left;
       vertical-align: top;
       padding: var(--cbp-table-cell-padding);
 
@@ -412,7 +411,7 @@ cbp-table {
   }
 }
 
-
+// Shows a gradient mask on the table for either direction that has overflowed content
 @property --left-fade {
   syntax: "<length>";
   inherits: false;

--- a/packages/web-components/src/components/cbp-table/cbp-table.scss
+++ b/packages/web-components/src/components/cbp-table/cbp-table.scss
@@ -133,10 +133,6 @@ cbp-table {
     text-align: end;
   }
 
-  .cbp-table-scroll-gradient {
-    display: none;
-  }
-
   // Responsive horizontally scrolling table
   &.cbp-table-scroll {
     .cbp-table-toolbar-scroll {
@@ -147,6 +143,7 @@ cbp-table {
     .cbp-table-wrapper {
       position: relative;
       overflow-x: scroll;
+      // Gradient mask for visual affordance of additional content
       mask: linear-gradient(to right,#0003,#ffff var(--left-fade) calc(100% - var(--right-fade)), #0003);
       animation: scrollfade;
       animation-timeline: --scrollfade;
@@ -171,7 +168,7 @@ cbp-table {
       display: block;
       padding: var(--cbp-table-linearized-cell-padding);
     }
-    tbody td::before {
+    tbody td:not(:has(cbp-checkbox))::before {
       content: attr(data-column-header);
       font-weight: var(--cbp-font-weight-medium);
     }

--- a/packages/web-components/src/components/cbp-table/cbp-table.specs.mdx
+++ b/packages/web-components/src/components/cbp-table/cbp-table.specs.mdx
@@ -41,11 +41,16 @@ The Table component is a wrapper component encapsulating design system styles fo
     * Linearization stacks the table cells vertically and places the column headings before each cell's data.
     * This option allows for scanning of each row's data without comparing columns between rows.
     * The table head is hidden since the column heading text is duplicated within each cell for context.
+    * This method is not recommended for data that is compared between rows and columns, or for selectable table rows.
 
 ### Accessibility
 
 * The slotted table is expected to be marked up semantically, using `thead` and `tbody` elements and denoting headings with `th` elements (not `td`s).
-* A table caption is mandatory, using the `caption` tag inside of the `table` element. If it is not desired to have a visible caption, place a `hidden` attribute on the `caption` element.
+* Tables must be accessibly labeled. Two of the easiest way to achieve this are:
+  * A table caption may be supplied using the `caption` tag inside of the `table` element.
+    * If it is not desired to have a visible caption, place a `hidden` attribute on the `caption` element.
+    * If the table utilizes a toolbar, it is advised not to show a visible caption.
+  * Specifying an accessible label via an `aria-label` on the native `table` tag.
 * The `summary` attribute of the `table` is deprecated in HTML5 and should not be used.
 * Table headers (`th`) in the `thead` will automatically have `scope="col"` applied to them.
 * Table headers (`th`) in the `tbody` will automatically have `scope="row"` applied to them.
@@ -61,6 +66,10 @@ The Table component is a wrapper component encapsulating design system styles fo
 * The Table component exposes the following classes that you may use on the native table HTML markup:
   * `class="cbp-table--danger"` may be applied to table rows or cells to mark an error or similar state.
   * `class="cbp-table--highlight"` may be applied to table cells when the cell contains matching search/filter text.
+* It is not advised to slot the `cbp-action-bar` or `cbp-pagination` within the `cbp-table` when scrolling is used for responsiveness. Place them after the `cbp-table` so that they are not impacted by the table's responsive behavior.
 * When the table has a horizontal scrollbar, positioned elements such as tooltips and menus may be adversely affected.
   * The table then behaves like `position: relative`.
   * This is native browser behavior when `overflow-x` is applied and cannot be changed.
+* For selectable table rows (multi-row action table pattern):
+  * The checkboxes are slotted and loosely coupled; any functionality including "select all" functionality an optional header checkbox must be implemented via application code.
+  * It is not advised to use linearization for responsive behavior in this case.

--- a/packages/web-components/src/components/cbp-table/cbp-table.specs.mdx
+++ b/packages/web-components/src/components/cbp-table/cbp-table.specs.mdx
@@ -33,9 +33,9 @@ The Table component is a wrapper component encapsulating design system styles fo
 * There are a number of ways to display table data responsively, the "best" being largely contextual based on the data presented and its purpose.
 * The table uses a resize observer to detect overflow (of the table to its parent) and trigger one of the responsive modes:
   * The default responsive mode is scrolling.
-    * Scrolling is optimal for data where comparisons across columns are necessary.
+    * Scrolling is optimal for data where comparisons across columns and rows are necessary.
     * A native horizontal scrollbar is shown below the table when the table is too large to fit in its parent.
-    * Controls to scroll left or right are also displayed above the table in the controls area.
+    * Controls to scroll left or right, one column at a time, are also displayed above the table in the controls area.
     * If the table body contains row headers, they will be made sticky.
   * The other option is linearization.
     * Linearization stacks the table cells vertically and places the column headings before each cell's data.

--- a/packages/web-components/src/components/cbp-table/cbp-table.specs.mdx
+++ b/packages/web-components/src/components/cbp-table/cbp-table.specs.mdx
@@ -30,7 +30,15 @@ The Table component is a wrapper component encapsulating design system styles fo
 
 ### Responsiveness
 
-* TODO: There are a number of ways to display table data responsively, the "best" being largely contextual based on the data presented and its purpose.
+* There are a number of ways to display table data responsively, the "best" being largely contextual based on the data presented and its purpose.
+* The table uses a resize observer to detect overflow (of the table to its parent) and trigger one of the responsive modes:
+  * The default responsive mode is scrolling.
+    * Scrolling is optimal for data where comparisons across columns are necessary.
+    * If the table body contains row headers, they will be made sticky.
+  * The other option is linearization.
+    * Linearization stacks the table cells vertically and places the column headings before each cell's data.
+    * The table head is hidden since the heading text is duplicated within each cell.
+    * This option allows for scanning of each row's data without comparing columns between rows.
 
 ### Accessibility
 
@@ -48,6 +56,6 @@ The Table component is a wrapper component encapsulating design system styles fo
 
 ### Additional Notes and Considerations
 
-* TODO: With potentially a large amount of DOM manipulation, evaluate if this is a good use case for using ShadowDOM.
-  * This has styling implications at a minimum.
-  * What is the interaction with using non-DS components (such as a router outlet) within the slotted content in the ShadowDOM?
+* The Table component exposes the following classes that you may use on the native table HTML markup:
+  * `class="cbp-table--danger"` may be applied to table rows or cells to mark an error or similar state.
+  * `class="cbp-table--highlight"` may be applied to table cells when the cell contains matching search/filter text.

--- a/packages/web-components/src/components/cbp-table/cbp-table.specs.mdx
+++ b/packages/web-components/src/components/cbp-table/cbp-table.specs.mdx
@@ -34,11 +34,13 @@ The Table component is a wrapper component encapsulating design system styles fo
 * The table uses a resize observer to detect overflow (of the table to its parent) and trigger one of the responsive modes:
   * The default responsive mode is scrolling.
     * Scrolling is optimal for data where comparisons across columns are necessary.
+    * A native horizontal scrollbar is shown below the table when the table is too large to fit in its parent.
+    * Controls to scroll left or right are also displayed above the table in the controls area.
     * If the table body contains row headers, they will be made sticky.
   * The other option is linearization.
     * Linearization stacks the table cells vertically and places the column headings before each cell's data.
-    * The table head is hidden since the heading text is duplicated within each cell.
     * This option allows for scanning of each row's data without comparing columns between rows.
+    * The table head is hidden since the column heading text is duplicated within each cell for context.
 
 ### Accessibility
 
@@ -59,3 +61,6 @@ The Table component is a wrapper component encapsulating design system styles fo
 * The Table component exposes the following classes that you may use on the native table HTML markup:
   * `class="cbp-table--danger"` may be applied to table rows or cells to mark an error or similar state.
   * `class="cbp-table--highlight"` may be applied to table cells when the cell contains matching search/filter text.
+* When the table has a horizontal scrollbar, positioned elements such as tooltips and menus may be adversely affected.
+  * The table then behaves like `position: relative`.
+  * This is native browser behavior when `overflow-x` is applied and cannot be changed.

--- a/packages/web-components/src/components/cbp-table/cbp-table.stories.tsx
+++ b/packages/web-components/src/components/cbp-table/cbp-table.stories.tsx
@@ -16,6 +16,13 @@ export default {
     selectable: {
       control: 'boolean'
     },
+    overflow: {
+      control: 'select',
+      options: ['scroll', 'linearize'],
+    },
+    showToolbar: {
+      control: 'boolean'
+    },
     context : {
       control: 'select',
       options: [ "light-inverts", "light-always", "dark-inverts", "dark-always"]
@@ -66,7 +73,7 @@ function generateTableRows(data, selectable, context) {
         `;
       }else if(highlight){
         return `
-          <td class="cbp-table--hightlight">${td}</td>
+          <td class="cbp-table--highlight">${td}</td>
         `;
       }
        return `
@@ -92,26 +99,47 @@ function generateTableRows(data, selectable, context) {
 }
 
 
-const Template = ({ tableData, headers, selectable, striped, hover, columnHover, context, sx }) => {
-  
- /*
-  const toolbar=`
+function toolbar() {
+  return `
     <div slot="cbp-table-toolbar">
-      Test toolbar.
+      <cbp-form-field sx='{"--cbp-form-field-margin-bottom":"0"}'>
+        <cbp-form-field-wrapper>  
+          <input
+            type="search"
+            name="tablesearch"
+            placeholder="Filter Results"
+          />
+          <span slot="cbp-form-field-attached-button">
+            <cbp-button
+              type="submit"
+              fill="solid"
+              color="secondary"
+              variant="square"
+              accessibility-text="Search"
+            >
+              <cbp-icon name="magnifying-glass"></cbp-icon>
+            </cbp-button>
+          </span>
+         </cbp-form-field-wrapper>
+      </cbp-form-field>
     </div>
   `;
-  */
+}
 
+const Template = ({ tableData, headers, selectable, striped, hover, columnHover, overflow, showToolbar, context, sx }) => {
+  
   return ` 
       <cbp-table
         ${striped != 'none' ? `striped="${striped}"` : ''}
         ${hover == 'cell' ? `hover="${hover}"` : ''}
         ${columnHover ? `column-hover` : ''}
+        ${overflow ? `overflow="${overflow}"` : ''}
         ${context && context != 'light-inverts' ? `context="${context}"` : ''}
         ${sx ? `sx='${JSON.stringify(sx)}'` : ''}
       >
-        <table style="width: 100%">
-          <caption>Table Caption</caption>
+        ${showToolbar ? toolbar() : ''}
+        <table style="min-width:1200px">
+          <caption hidden>Table Caption</caption>
           <thead>
             <tr>
               ${generateTableHeaders(headers, selectable, context)}
@@ -206,7 +234,7 @@ BasicTable.args = {
   ]
 }
 
-const tableDangerTemplate = ({ tableData, headers, selectable, striped, hover, columnHover, context, sx }) => {
+const tableDangerTemplate = ({ tableData, headers, selectable, striped, hover, columnHover, overflow, context, sx }) => {
   
  /*
   const toolbar=`
@@ -221,11 +249,12 @@ const tableDangerTemplate = ({ tableData, headers, selectable, striped, hover, c
         ${striped != 'none' ? `striped="${striped}"` : ''}
         ${hover == 'cell' ? `hover="${hover}"` : ''}
         ${columnHover ? `column-hover` : ''}
+        ${overflow ? `overflow="${overflow}"` : ''}
         ${context && context != 'light-inverts' ? `context="${context}"` : ''}
         ${sx ? `sx='${JSON.stringify(sx)}'` : ''}
       >
         <table style="width: 100%">
-          <caption>Table Caption</caption>
+          <caption hidden>Table Caption</caption>
           <thead>
             <tr>
               ${generateTableHeaders(headers, selectable, context)}
@@ -321,7 +350,7 @@ dangerTable.args = {
   ]
 }
 
-const tableHighlightTemplate = ({ tableData, headers, selectable, striped, hover, columnHover, context, sx }) => {
+const tableHighlightTemplate = ({ tableData, headers, selectable, striped, hover, columnHover, overflow, context, sx }) => {
   
  /*
   const toolbar=`
@@ -336,11 +365,12 @@ const tableHighlightTemplate = ({ tableData, headers, selectable, striped, hover
         ${striped != 'none' ? `striped="${striped}"` : ''}
         ${hover == 'cell' ? `hover="${hover}"` : ''}
         ${columnHover ? `column-hover` : ''}
+        ${overflow ? `overflow="${overflow}"` : ''}
         ${context && context != 'light-inverts' ? `context="${context}"` : ''}
         ${sx ? `sx='${JSON.stringify(sx)}'` : ''}
       >
         <table style="width: 100%">
-          <caption>Table Caption</caption>
+          <caption hidden>Table Caption</caption>
           <thead>
             <tr>
               ${generateTableHeaders(headers, selectable, context)}
@@ -436,7 +466,7 @@ highlightTable.args = {
 }
 
 
-const singleRowActionTableTemplate = ({ tableData, headers, selectable, striped, hover, columnHover, context, sx }) => {
+const singleRowActionTableTemplate = ({ tableData, headers, selectable, striped, hover, columnHover, overflow, context, sx }) => {
   
  /*
   const toolbar=`
@@ -451,11 +481,12 @@ const singleRowActionTableTemplate = ({ tableData, headers, selectable, striped,
         ${striped != 'none' ? `striped="${striped}"` : ''}
         ${hover == 'cell' ? `hover="${hover}"` : ''}
         ${columnHover ? `column-hover` : ''}
+        ${overflow ? `overflow="${overflow}"` : ''}
         ${context && context != 'light-inverts' ? `context="${context}"` : ''}
         ${sx ? `sx=${JSON.stringify(sx)}` : ''}
       >
         <table style="width: 100%">
-          <caption>Table Caption</caption>
+          <caption hidden>Table Caption</caption>
           <thead>
             <tr>
               ${generateTableHeaders(headers, selectable, context)}
@@ -505,7 +536,7 @@ singleRowActionTable.args = {
         {td: 'Row 1 Column 2 Cell Text'},
         {td: 'Row 1 Column 3 Cell Text'},
         {td: `  <cbp-button
-                  fill="ghost"
+                  fill="outline"
                   color="secondary"
                   accessibility-text="View details of Row 1"
                 > 
@@ -520,7 +551,7 @@ singleRowActionTable.args = {
         {td: 'Row 2 Column 2 Cell Text'},
         {td: 'Row 2 Column 3 Cell Text'},
         {td: `  <cbp-button
-                  fill="ghost"
+                  fill="outline"
                   color="secondary"
                   accessibility-text="View details of Row 2"
                 > 
@@ -535,7 +566,7 @@ singleRowActionTable.args = {
         {td: 'Row 3 Column 2 Cell Text'},
         {td: 'Row 3 Column 3 Cell Text'},
         {td: `  <cbp-button
-                  fill="ghost"
+                  fill="outline"
                   color="secondary"
                   accessibility-text="View details of Row 3"
                 > 
@@ -550,7 +581,7 @@ singleRowActionTable.args = {
         {td: 'Row 4 Column 2 Cell Text'},
         {td: 'Row 4 Column 3 Cell Text'},
         {td: `  <cbp-button
-                  fill="ghost"
+                  fill="outline"
                   color="secondary"
                   accessibility-text="View details of Row 4"
                 > 
@@ -565,7 +596,7 @@ singleRowActionTable.args = {
         {td: 'Row 5 Column 2 Cell Text'},
         {td: 'Row 5 Column 3 Cell Text'},
         {td: `  <cbp-button
-                  fill="ghost"
+                  fill="outline"
                   color="secondary"
                   accessibility-text="View details of Row 5"
                 > 
@@ -577,7 +608,7 @@ singleRowActionTable.args = {
   ]
 }
 
-const OverflowTemplate = ({ tableData, headers, selectable, striped, hover, columnHover, context, sx }) => {
+const OverflowTemplate = ({ tableData, headers, selectable, striped, hover, columnHover, overflow, context, sx }) => {
   
  /*
   const toolbar=`
@@ -592,11 +623,12 @@ const OverflowTemplate = ({ tableData, headers, selectable, striped, hover, colu
         ${striped != 'none' ? `striped="${striped}"` : ''}
         ${hover == 'cell' ? `hover="${hover}"` : ''}
         ${columnHover ? `column-hover` : ''}
+        ${overflow ? `overflow="${overflow}"` : ''}
         ${context && context != 'light-inverts' ? `context="${context}"` : ''}
         ${sx ? `sx=${JSON.stringify(sx)}` : ''}
       >
         <table style="width: 100%">
-          <caption>Table Caption</caption>
+          <caption hidden>Table Caption</caption>
           <thead>
             <tr>
               ${generateTableHeaders(headers, selectable, context)}
@@ -758,7 +790,7 @@ OverflowMenu.args = {
         {td: `
           <cbp-menu
             uid="menuId3"
-            position="top-end"
+            position="bottom-end"
           >
 
             <cbp-button
@@ -812,7 +844,7 @@ OverflowMenu.args = {
         {td: `
           <cbp-menu
             uid="menuId4"
-            position="top-end"
+            position="bottom-end"
           >
 
             <cbp-button
@@ -866,7 +898,7 @@ OverflowMenu.args = {
        {td: `
           <cbp-menu
             uid="menuId5"
-            position="top-end"
+            position="bottom-end"
           >
 
             <cbp-button

--- a/packages/web-components/src/components/cbp-table/cbp-table.stories.tsx
+++ b/packages/web-components/src/components/cbp-table/cbp-table.stories.tsx
@@ -23,6 +23,12 @@ export default {
     showToolbar: {
       control: 'boolean'
     },
+    showCaption: {
+      control: 'boolean'
+    },
+    liveRegion: {
+      control: 'text',
+    },
     context : {
       control: 'select',
       options: [ "light-inverts", "light-always", "dark-inverts", "dark-always"]
@@ -126,7 +132,8 @@ function toolbar() {
   `;
 }
 
-const Template = ({ tableData, headers, selectable, striped, hover, columnHover, overflow, showToolbar, context, sx }) => {
+
+const Template = ({ tableData, headers, selectable, striped, hover, columnHover, overflow, showToolbar, showCaption, liveRegion, context, sx }) => {
   
   return ` 
       <cbp-table
@@ -138,8 +145,9 @@ const Template = ({ tableData, headers, selectable, striped, hover, columnHover,
         ${sx ? `sx='${JSON.stringify(sx)}'` : ''}
       >
         ${showToolbar ? toolbar() : ''}
+        ${liveRegion ? `<div slot="cbp-table-live-region">${liveRegion}</div>` : ''}
         <table style="width: 100%">
-          <caption hidden>Table Caption</caption>
+          <caption ${ showCaption ? '' : 'hidden' }>Table Caption</caption>
           <thead>
             <tr>
               ${generateTableHeaders(headers, selectable, context)}
@@ -149,15 +157,15 @@ const Template = ({ tableData, headers, selectable, striped, hover, columnHover,
             ${generateTableRows(tableData, selectable, context)}
           </tbody>
         </table>
-
-        ${ selectable ? `
-            <cbp-action-bar variant="inline" context="dark-inverts">
-              <div slot="cbp-action-bar-info">0 items selected.</div>
-              <cbp-button fill="ghost" color="danger" context="dark-inverts" accessibility-text="Delete selected items">Delete</cbp-button>
-              <cbp-button fill="ghost" context="dark-inverts" accessibility-text="Compare selected items">Compare</cbp-button>
-            </cbp-action-bar>          
-          ` : ''}
-      </cbp-typography>
+      </cbp-table>
+      
+      ${ selectable ? `
+        <cbp-action-bar variant="inline" context="dark-inverts">
+          <div slot="cbp-action-bar-info">0 items selected.</div>
+          <cbp-button fill="ghost" color="danger" context="dark-inverts" accessibility-text="Delete selected items">Delete</cbp-button>
+          <cbp-button fill="ghost" context="dark-inverts" accessibility-text="Compare selected items">Compare</cbp-button>
+        </cbp-action-bar>          
+      ` : ''}
     `;
 };
 
@@ -234,16 +242,8 @@ BasicTable.args = {
   ]
 }
 
-const tableDangerTemplate = ({ tableData, headers, selectable, striped, hover, columnHover, overflow, context, sx }) => {
+const tableDangerTemplate = ({ tableData, headers, selectable, striped, hover, columnHover, overflow, showToolbar, showCaption, liveRegion, context, sx }) => {
   
- /*
-  const toolbar=`
-    <div slot="cbp-table-toolbar">
-      Test toolbar.
-    </div>
-  `;
-  */
-
   return ` 
       <cbp-table
         ${striped != 'none' ? `striped="${striped}"` : ''}
@@ -253,8 +253,10 @@ const tableDangerTemplate = ({ tableData, headers, selectable, striped, hover, c
         ${context && context != 'light-inverts' ? `context="${context}"` : ''}
         ${sx ? `sx='${JSON.stringify(sx)}'` : ''}
       >
+        ${showToolbar ? toolbar() : ''}
+        ${liveRegion ? `<div slot="cbp-table-live-region">${liveRegion}</div>` : ''}
         <table style="width: 100%">
-          <caption hidden>Table Caption</caption>
+          <caption ${ showCaption ? '' : 'hidden' }>Table Caption</caption>
           <thead>
             <tr>
               ${generateTableHeaders(headers, selectable, context)}
@@ -264,15 +266,15 @@ const tableDangerTemplate = ({ tableData, headers, selectable, striped, hover, c
             ${generateTableRows(tableData, selectable, context)}
           </tbody>
         </table>
-
-        ${ selectable ? `
-            <cbp-action-bar variant="inline" context="dark-inverts">
-              <div slot="cbp-action-bar-info">0 items selected.</div>
-              <cbp-button fill="ghost" color="danger" context="dark-inverts" accessibility-text="Delete selected items">Delete</cbp-button>
-              <cbp-button fill="ghost" context="dark-inverts" accessibility-text="Compare selected items">Compare</cbp-button>
-            </cbp-action-bar>          
-          ` : ''}
-      </cbp-typography>
+      </cbp-table>
+            
+      ${ selectable ? `
+        <cbp-action-bar variant="inline" context="dark-inverts">
+          <div slot="cbp-action-bar-info">0 items selected.</div>
+          <cbp-button fill="ghost" color="danger" context="dark-inverts" accessibility-text="Delete selected items">Delete</cbp-button>
+          <cbp-button fill="ghost" context="dark-inverts" accessibility-text="Compare selected items">Compare</cbp-button>
+        </cbp-action-bar>          
+      ` : ''}
     `;
 };
 
@@ -350,16 +352,8 @@ dangerTable.args = {
   ]
 }
 
-const tableHighlightTemplate = ({ tableData, headers, selectable, striped, hover, columnHover, overflow, context, sx }) => {
+const tableHighlightTemplate = ({ tableData, headers, selectable, striped, hover, columnHover, overflow, showToolbar, showCaption, liveRegion, context, sx }) => {
   
- /*
-  const toolbar=`
-    <div slot="cbp-table-toolbar">
-      Test toolbar.
-    </div>
-  `;
-  */
-
   return ` 
       <cbp-table
         ${striped != 'none' ? `striped="${striped}"` : ''}
@@ -369,8 +363,10 @@ const tableHighlightTemplate = ({ tableData, headers, selectable, striped, hover
         ${context && context != 'light-inverts' ? `context="${context}"` : ''}
         ${sx ? `sx='${JSON.stringify(sx)}'` : ''}
       >
+        ${showToolbar ? toolbar() : ''}
+        ${liveRegion ? `<div slot="cbp-table-live-region">${liveRegion}</div>` : ''}
         <table style="width: 100%">
-          <caption hidden>Table Caption</caption>
+          <caption ${ showCaption ? '' : 'hidden' }>Table Caption</caption>
           <thead>
             <tr>
               ${generateTableHeaders(headers, selectable, context)}
@@ -380,15 +376,15 @@ const tableHighlightTemplate = ({ tableData, headers, selectable, striped, hover
             ${generateTableRows(tableData, selectable, context)}
           </tbody>
         </table>
-
-        ${ selectable ? `
-            <cbp-action-bar variant="inline" context="dark-inverts">
-              <div slot="cbp-action-bar-info">0 items selected.</div>
-              <cbp-button fill="ghost" color="danger" context="dark-inverts" accessibility-text="Delete selected items">Delete</cbp-button>
-              <cbp-button fill="ghost" context="dark-inverts" accessibility-text="Compare selected items">Compare</cbp-button>
-            </cbp-action-bar>          
-          ` : ''}
-      </cbp-typography>
+      </cbp-table>
+            
+      ${ selectable ? `
+        <cbp-action-bar variant="inline" context="dark-inverts">
+          <div slot="cbp-action-bar-info">0 items selected.</div>
+          <cbp-button fill="ghost" color="danger" context="dark-inverts" accessibility-text="Delete selected items">Delete</cbp-button>
+          <cbp-button fill="ghost" context="dark-inverts" accessibility-text="Compare selected items">Compare</cbp-button>
+        </cbp-action-bar>          
+      ` : ''}
     `;
 };
 
@@ -466,16 +462,8 @@ highlightTable.args = {
 }
 
 
-const singleRowActionTableTemplate = ({ tableData, headers, selectable, striped, hover, columnHover, overflow, context, sx }) => {
+const singleRowActionTableTemplate = ({ tableData, headers, selectable, striped, hover, columnHover, overflow, showToolbar, showCaption, liveRegion, context, sx }) => {
   
- /*
-  const toolbar=`
-    <div slot="cbp-table-toolbar">
-      Test toolbar.
-    </div>
-  `;
-  */
-
   return ` 
       <cbp-table
         ${striped != 'none' ? `striped="${striped}"` : ''}
@@ -485,8 +473,10 @@ const singleRowActionTableTemplate = ({ tableData, headers, selectable, striped,
         ${context && context != 'light-inverts' ? `context="${context}"` : ''}
         ${sx ? `sx=${JSON.stringify(sx)}` : ''}
       >
+        ${showToolbar ? toolbar() : ''}
+        ${liveRegion ? `<div slot="cbp-table-live-region">${liveRegion}</div>` : ''}
         <table style="width: 100%">
-          <caption hidden>Table Caption</caption>
+          <caption ${ showCaption ? '' : 'hidden' }>Table Caption</caption>
           <thead>
             <tr>
               ${generateTableHeaders(headers, selectable, context)}
@@ -496,15 +486,15 @@ const singleRowActionTableTemplate = ({ tableData, headers, selectable, striped,
             ${generateTableRows(tableData, selectable, context)}
           </tbody>
         </table>
-
-        ${ selectable ? `
-            <cbp-action-bar variant="inline" context="dark-inverts">
-              <div slot="cbp-action-bar-info">0 items selected.</div>
-              <cbp-button fill="ghost" color="danger" context="dark-inverts" accessibility-text="Delete selected items">Delete</cbp-button>
-              <cbp-button fill="ghost" context="dark-inverts" accessibility-text="Compare selected items">Compare</cbp-button>
-            </cbp-action-bar>          
-          ` : ''}
-      </cbp-typography>
+      </cbp-table>
+            
+      ${ selectable ? `
+        <cbp-action-bar variant="inline" context="dark-inverts">
+          <div slot="cbp-action-bar-info">0 items selected.</div>
+          <cbp-button fill="ghost" color="danger" context="dark-inverts" accessibility-text="Delete selected items">Delete</cbp-button>
+          <cbp-button fill="ghost" context="dark-inverts" accessibility-text="Compare selected items">Compare</cbp-button>
+        </cbp-action-bar>          
+      ` : ''}
     `;
 };
 
@@ -608,16 +598,8 @@ singleRowActionTable.args = {
   ]
 }
 
-const OverflowTemplate = ({ tableData, headers, selectable, striped, hover, columnHover, overflow, context, sx }) => {
+const OverflowTemplate = ({ tableData, headers, selectable, striped, hover, columnHover, overflow, showToolbar, showCaption, liveRegion, context, sx }) => {
   
- /*
-  const toolbar=`
-    <div slot="cbp-table-toolbar">
-      Test toolbar.
-    </div>
-  `;
-  */
-
   return ` 
       <cbp-table
         ${striped != 'none' ? `striped="${striped}"` : ''}
@@ -627,8 +609,10 @@ const OverflowTemplate = ({ tableData, headers, selectable, striped, hover, colu
         ${context && context != 'light-inverts' ? `context="${context}"` : ''}
         ${sx ? `sx=${JSON.stringify(sx)}` : ''}
       >
+        ${showToolbar ? toolbar() : ''}
+        ${liveRegion ? `<div slot="cbp-table-live-region">${liveRegion}</div>` : ''}
         <table style="width: 100%">
-          <caption hidden>Table Caption</caption>
+          <caption ${ showCaption ? '' : 'hidden' }>Table Caption</caption>
           <thead>
             <tr>
               ${generateTableHeaders(headers, selectable, context)}
@@ -638,21 +622,20 @@ const OverflowTemplate = ({ tableData, headers, selectable, striped, hover, colu
             ${generateTableRows(tableData, selectable, context)}
           </tbody>
         </table>
-
-        ${ selectable ? `
-            <cbp-action-bar variant="inline" context="dark-inverts">
-              <div slot="cbp-action-bar-info">0 items selected.</div>
-              <cbp-button fill="ghost" color="danger" context="dark-inverts" accessibility-text="Delete selected items">Delete</cbp-button>
-              <cbp-button fill="ghost" context="dark-inverts" accessibility-text="Compare selected items">Compare</cbp-button>
-            </cbp-action-bar>          
-          ` : ''}
-      </cbp-typography>
+      </cbp-table>
+            
+      ${ selectable ? `
+        <cbp-action-bar variant="inline" context="dark-inverts">
+          <div slot="cbp-action-bar-info">0 items selected.</div>
+          <cbp-button fill="ghost" color="danger" context="dark-inverts" accessibility-text="Delete selected items">Delete</cbp-button>
+          <cbp-button fill="ghost" context="dark-inverts" accessibility-text="Compare selected items">Compare</cbp-button>
+        </cbp-action-bar>          
+      ` : ''}
     `;
 };
 
 export const OverflowMenu = OverflowTemplate.bind({});
 OverflowMenu.storyName = "Single Action Table with Overflow Menu"
-// AppHeaderWithSubnav.storyName = "Application Header with Sub-Nav"
 OverflowMenu.args = {
   striped: 'even',
   headers: [

--- a/packages/web-components/src/components/cbp-table/cbp-table.stories.tsx
+++ b/packages/web-components/src/components/cbp-table/cbp-table.stories.tsx
@@ -138,7 +138,7 @@ const Template = ({ tableData, headers, selectable, striped, hover, columnHover,
         ${sx ? `sx='${JSON.stringify(sx)}'` : ''}
       >
         ${showToolbar ? toolbar() : ''}
-        <table style="min-width:1200px">
+        <table style="width: 100%">
           <caption hidden>Table Caption</caption>
           <thead>
             <tr>

--- a/packages/web-components/src/components/cbp-table/cbp-table.stories.tsx
+++ b/packages/web-components/src/components/cbp-table/cbp-table.stories.tsx
@@ -146,7 +146,8 @@ const Template = ({ tableData, headers, selectable, striped, hover, columnHover,
       >
         ${showToolbar ? toolbar() : ''}
         ${liveRegion ? `<div slot="cbp-table-live-region">${liveRegion}</div>` : ''}
-        <table style="width: 100%">
+
+        <table style="width:100%">
           <caption ${ showCaption ? '' : 'hidden' }>Table Caption</caption>
           <thead>
             <tr>
@@ -242,43 +243,8 @@ BasicTable.args = {
   ]
 }
 
-const tableDangerTemplate = ({ tableData, headers, selectable, striped, hover, columnHover, overflow, showToolbar, showCaption, liveRegion, context, sx }) => {
-  
-  return ` 
-      <cbp-table
-        ${striped != 'none' ? `striped="${striped}"` : ''}
-        ${hover == 'cell' ? `hover="${hover}"` : ''}
-        ${columnHover ? `column-hover` : ''}
-        ${overflow ? `overflow="${overflow}"` : ''}
-        ${context && context != 'light-inverts' ? `context="${context}"` : ''}
-        ${sx ? `sx='${JSON.stringify(sx)}'` : ''}
-      >
-        ${showToolbar ? toolbar() : ''}
-        ${liveRegion ? `<div slot="cbp-table-live-region">${liveRegion}</div>` : ''}
-        <table style="width: 100%">
-          <caption ${ showCaption ? '' : 'hidden' }>Table Caption</caption>
-          <thead>
-            <tr>
-              ${generateTableHeaders(headers, selectable, context)}
-            </tr>
-          </thead>
-          <tbody>
-            ${generateTableRows(tableData, selectable, context)}
-          </tbody>
-        </table>
-      </cbp-table>
-            
-      ${ selectable ? `
-        <cbp-action-bar variant="inline" context="dark-inverts">
-          <div slot="cbp-action-bar-info">0 items selected.</div>
-          <cbp-button fill="ghost" color="danger" context="dark-inverts" accessibility-text="Delete selected items">Delete</cbp-button>
-          <cbp-button fill="ghost" context="dark-inverts" accessibility-text="Compare selected items">Compare</cbp-button>
-        </cbp-action-bar>          
-      ` : ''}
-    `;
-};
 
-export const dangerTable = tableDangerTemplate.bind({});
+export const dangerTable = Template.bind({});
 dangerTable.args = {
   striped: 'even',
   headers: [
@@ -352,43 +318,8 @@ dangerTable.args = {
   ]
 }
 
-const tableHighlightTemplate = ({ tableData, headers, selectable, striped, hover, columnHover, overflow, showToolbar, showCaption, liveRegion, context, sx }) => {
-  
-  return ` 
-      <cbp-table
-        ${striped != 'none' ? `striped="${striped}"` : ''}
-        ${hover == 'cell' ? `hover="${hover}"` : ''}
-        ${columnHover ? `column-hover` : ''}
-        ${overflow ? `overflow="${overflow}"` : ''}
-        ${context && context != 'light-inverts' ? `context="${context}"` : ''}
-        ${sx ? `sx='${JSON.stringify(sx)}'` : ''}
-      >
-        ${showToolbar ? toolbar() : ''}
-        ${liveRegion ? `<div slot="cbp-table-live-region">${liveRegion}</div>` : ''}
-        <table style="width: 100%">
-          <caption ${ showCaption ? '' : 'hidden' }>Table Caption</caption>
-          <thead>
-            <tr>
-              ${generateTableHeaders(headers, selectable, context)}
-            </tr>
-          </thead>
-          <tbody>
-            ${generateTableRows(tableData, selectable, context)}
-          </tbody>
-        </table>
-      </cbp-table>
-            
-      ${ selectable ? `
-        <cbp-action-bar variant="inline" context="dark-inverts">
-          <div slot="cbp-action-bar-info">0 items selected.</div>
-          <cbp-button fill="ghost" color="danger" context="dark-inverts" accessibility-text="Delete selected items">Delete</cbp-button>
-          <cbp-button fill="ghost" context="dark-inverts" accessibility-text="Compare selected items">Compare</cbp-button>
-        </cbp-action-bar>          
-      ` : ''}
-    `;
-};
 
-export const highlightTable = tableHighlightTemplate.bind({});
+export const highlightTable = Template.bind({});
 highlightTable.args = {
   striped: 'even',
   headers: [
@@ -462,43 +393,7 @@ highlightTable.args = {
 }
 
 
-const singleRowActionTableTemplate = ({ tableData, headers, selectable, striped, hover, columnHover, overflow, showToolbar, showCaption, liveRegion, context, sx }) => {
-  
-  return ` 
-      <cbp-table
-        ${striped != 'none' ? `striped="${striped}"` : ''}
-        ${hover == 'cell' ? `hover="${hover}"` : ''}
-        ${columnHover ? `column-hover` : ''}
-        ${overflow ? `overflow="${overflow}"` : ''}
-        ${context && context != 'light-inverts' ? `context="${context}"` : ''}
-        ${sx ? `sx=${JSON.stringify(sx)}` : ''}
-      >
-        ${showToolbar ? toolbar() : ''}
-        ${liveRegion ? `<div slot="cbp-table-live-region">${liveRegion}</div>` : ''}
-        <table style="width: 100%">
-          <caption ${ showCaption ? '' : 'hidden' }>Table Caption</caption>
-          <thead>
-            <tr>
-              ${generateTableHeaders(headers, selectable, context)}
-            </tr>
-          </thead>
-          <tbody>
-            ${generateTableRows(tableData, selectable, context)}
-          </tbody>
-        </table>
-      </cbp-table>
-            
-      ${ selectable ? `
-        <cbp-action-bar variant="inline" context="dark-inverts">
-          <div slot="cbp-action-bar-info">0 items selected.</div>
-          <cbp-button fill="ghost" color="danger" context="dark-inverts" accessibility-text="Delete selected items">Delete</cbp-button>
-          <cbp-button fill="ghost" context="dark-inverts" accessibility-text="Compare selected items">Compare</cbp-button>
-        </cbp-action-bar>          
-      ` : ''}
-    `;
-};
-
-export const singleRowActionTable = singleRowActionTableTemplate.bind({});
+export const singleRowActionTable = Template.bind({});
 singleRowActionTable.args = {
   striped: 'even',
   headers: [
@@ -598,43 +493,8 @@ singleRowActionTable.args = {
   ]
 }
 
-const OverflowTemplate = ({ tableData, headers, selectable, striped, hover, columnHover, overflow, showToolbar, showCaption, liveRegion, context, sx }) => {
-  
-  return ` 
-      <cbp-table
-        ${striped != 'none' ? `striped="${striped}"` : ''}
-        ${hover == 'cell' ? `hover="${hover}"` : ''}
-        ${columnHover ? `column-hover` : ''}
-        ${overflow ? `overflow="${overflow}"` : ''}
-        ${context && context != 'light-inverts' ? `context="${context}"` : ''}
-        ${sx ? `sx=${JSON.stringify(sx)}` : ''}
-      >
-        ${showToolbar ? toolbar() : ''}
-        ${liveRegion ? `<div slot="cbp-table-live-region">${liveRegion}</div>` : ''}
-        <table style="width: 100%">
-          <caption ${ showCaption ? '' : 'hidden' }>Table Caption</caption>
-          <thead>
-            <tr>
-              ${generateTableHeaders(headers, selectable, context)}
-            </tr>
-          </thead>
-          <tbody>
-            ${generateTableRows(tableData, selectable, context)}
-          </tbody>
-        </table>
-      </cbp-table>
-            
-      ${ selectable ? `
-        <cbp-action-bar variant="inline" context="dark-inverts">
-          <div slot="cbp-action-bar-info">0 items selected.</div>
-          <cbp-button fill="ghost" color="danger" context="dark-inverts" accessibility-text="Delete selected items">Delete</cbp-button>
-          <cbp-button fill="ghost" context="dark-inverts" accessibility-text="Compare selected items">Compare</cbp-button>
-        </cbp-action-bar>          
-      ` : ''}
-    `;
-};
 
-export const OverflowMenu = OverflowTemplate.bind({});
+export const OverflowMenu = Template.bind({});
 OverflowMenu.storyName = "Single Action Table with Overflow Menu"
 OverflowMenu.args = {
   striped: 'even',

--- a/packages/web-components/src/components/cbp-table/cbp-table.stories.tsx
+++ b/packages/web-components/src/components/cbp-table/cbp-table.stories.tsx
@@ -45,7 +45,7 @@ function generateTableHeaders(headers, selectable, context) {
   const checkbox = `<th>
       <cbp-checkbox ${context && context != 'light-inverts' ? `context=${context}` : ''}>
         <input type="checkbox" name="selectall" value="1">
-        <span style="display:none">Select All</span>
+        <span style="display:none">Select Rows</span>
       </cbp-checkbox>
     </th>`
   let cells = headers.map( ({label, sortable}, i)  => {

--- a/packages/web-components/src/components/cbp-table/cbp-table.tsx
+++ b/packages/web-components/src/components/cbp-table/cbp-table.tsx
@@ -1,11 +1,13 @@
 import { Component, Prop, State, Element, Event, EventEmitter, Method, Host, h } from '@stencil/core';
-import { setCSSProps } from '../../utils/utils';
+import { setCSSProps, createNamespaceKey } from '../../utils/utils';
 
 /**
  * The Table component is a wrapper component encapsulating design system styles for semantic HTML 
  * tables as well as applying progressive enhancements to the contained table.
  * 
  * @slot - The semantic table HTML is placed within the default slot.
+ * @slot cbp-table-live-toolbar - Any sort of filters or table controls may be slotted within this named slot.
+ * @slot cbp-table-live-region - For complex tables with many controls and/or pagination, the state of the data may be quantified and described accessibly via an `aria-live` region, which is hidden from view. E.g., Filtered by the term "test", ordered by Column 1 ascending, displaying records 100-200 of 1234.
  */
 @Component({
   tag: 'cbp-table',
@@ -14,22 +16,17 @@ import { setCSSProps } from '../../utils/utils';
 export class CbpTable {
 
   private table: HTMLTableElement;
-  private caption: HTMLTableCaptionElement;
   private columnHeadings: HTMLTableCellElement[];
   private sortableColumns: HTMLTableCellElement[] = [];
   private wrapper: HTMLElement;
 
-  private scrollLeft: HTMLCbpButtonElement;
-  private scrollRight: HTMLCbpButtonElement;
-
   private tableWidth;
   private tableBreakpoint;
-  
+
+  private liveRegionId=createNamespaceKey('cbp-table-live-region');
+
+
   @Element() private host: HTMLElement;
-
-
-  /** Specifies whether the table is striped, designating whether the colored rows are the odd or even rows (CBP DS standard is even when used). */
-  @Prop() overflow: 'scroll' | 'linearize' = 'scroll';
 
   /** Specifies whether the table is striped, designating whether the colored rows are the odd or even rows (CBP DS standard is even when used). */
   @Prop({ reflect: true }) striped: 'odd' | 'even';
@@ -40,6 +37,9 @@ export class CbpTable {
   /** Specifies whether a hover effect is applied to columns when the column header is hovered. This feature is opt-in. */
   @Prop({ reflect: true }) columnHover: boolean;
   
+  /** Specifies whether the table is striped, designating whether the colored rows are the odd or even rows (CBP DS standard is even when used). */
+  @Prop() overflow: 'scroll' | 'linearize' = 'scroll';
+
   /** Specifies the context of the component as it applies to the visual design and whether it inverts when light/dark mode is toggled. Default behavior is "light-inverts" and does not have to be specified. */
   @Prop({ reflect: true }) context: 'light-inverts' | 'light-always' | 'dark-inverts' | 'dark-always';
 
@@ -174,21 +174,22 @@ export class CbpTable {
     this.tableSort.emit({
       host: this.host,
       column: column, 
+      name: ColumnHeading.textContent.trim(),
       direction: direction,
       nativeEvent: e
     })
   }
 
+
+  // TechDebt: linearized starting at small size doesn't work to expand at larger size.
   // Called by the resize observer; also fires on initial render.
   private handleResize(width) {
     // Get the width of the content (and update the this.tableWidth) before doing responsive adjustments. (tables reflow, so we need to get this each comparison)
     this.tableWidth = this.table.getBoundingClientRect().width;
-    //console.log(`Resize observer fired - table width=${this.tableWidth}, Observer width=${width}, table breakpoint=${this.tableBreakpoint}`);
     
     // If the emitted size is less than the current mode's width, do responsive behavior (use a +5 different to account for table-reflow anomalies)
     if (width + 5 < this.tableWidth) {
       this.host.classList.add(`cbp-table-${this.overflow}`);
-      if(this.overflow=='scroll') this.makeScrollable();
     }
     // Return to full view (potentially)
     else if(this.overflow=='linearize') {
@@ -206,44 +207,47 @@ export class CbpTable {
     }
   }
 
-  private makeScrollable(){
-    this.scrollRight.disabled=false;
-    this.scrollLeft.disabled=false;
-    console.log('Table width: ', this.table.getBoundingClientRect().width);
-    console.log('Wrapper width: ', this.wrapper.getBoundingClientRect().width);
-  }
- 
-
+  // Do horizontal scroll via the button controls (recalculates every time in case something has changed such as scrolling or resize)
   private doHorizontalScroll(dir) {
-    /*
-        How to make it smarter? 
-          Intersection Observer?
-          Calculate heading sizes?
-          scrollIntoView({  behavior: "instant", block: "nearest", inline: 'start' });
-            scrollLeft  this.wrapper.scrollLeft += 20;
-          this.wrapper.scrollWidth 
+    let columns: Object[] = [];
+    const wrapperWidth = this.wrapper.getBoundingClientRect().width;
+    const wrapperScrollWidth = this.wrapper.scrollWidth;
+    const wrapperScroll = this.wrapper.scrollLeft;
+    const wrapperLeftBoundary = wrapperScroll;
+    const wrapperRightBoundary = wrapperWidth + wrapperScroll;
+    let firstVisible: number;
+    let lastVisible: number;
 
-          headings scrollOffset
+    // Loop over the column headings and get their positions
+    this.columnHeadings.forEach( (item, index) => {
+      const width = item.getBoundingClientRect().width;
+      const left = item.offsetLeft - this.wrapper.offsetLeft;
+      const right = item.offsetLeft - this.wrapper.offsetLeft + width;
+      let visible = ( left < wrapperLeftBoundary || right > wrapperRightBoundary) ? false : true; // Check if the column heading is fully visible
+      // Set the first and last visible items in the collection (by index)
+      if (visible) {
+        firstVisible == undefined ? firstVisible = index : null;
+        lastVisible = index;
+      }
+      columns = [...columns, { 'header': item, 'visible': visible, 'width': width, 'left': left, 'right': right }];
+    });
 
-          resizing while there is a scroll changes the wrapper size while the scroll position seems to remain static.
-          This means if you are scrolled to the end, but then shrink the size, more content will be overflowed to the right.
-
-     */
-    const step = 100; //px
-    this.wrapper.scrollBy( step * dir, 0 );
-    console.log('Scrolling: ', step * dir, this.table.getBoundingClientRect().width, this.wrapper.getBoundingClientRect().width);
+    // The amount of scrolling is relative to the ratio of the scroll size and visible width of the wrapper
+    if(dir==1) {
+      this.wrapper.scrollLeft = ( (columns?.[lastVisible+1]?.['right'] || wrapperScrollWidth) - wrapperWidth);
+    }
+    else {
+      this.wrapper.scrollLeft = columns?.[firstVisible-1]?.['left'] || 0;
+    }
   }
-
 
   private handleSlotChange(e) {
-    console.log(e);
+    console.log('cbp-table contents changed: ', e);
   }
 
 
   componentWillLoad() {
     this.table = this.host.querySelector('table');
-    this.caption = this.table?.querySelector('caption');
-    if (!this.caption) console.warn(`cbp-table: A caption tag is required for accessibility. If you don't want a visible caption, add a 'hidden' attribute to it.`);
     this.columnHeadings=Array.from(this.table?.querySelectorAll('thead th'));
 
     if (typeof this.sx == 'string') {
@@ -258,6 +262,26 @@ export class CbpTable {
     this.addScope();
     this.makeSortable();
     if(this.overflow == 'linearize') this.addHeaderDataAttrs();
+
+    // Hook up live regions and associate to the table, if they exist
+    // TechDebt: needs testing and also should be more reactive - this component has no insight into slotted content changes right now
+    const liveRegions = Array.from(this.host.querySelectorAll('[slot=cbp-table-live-region]'))
+    if (liveRegions) {
+      liveRegions.forEach( (item) => {
+        item.setAttribute('aria-live','polite');
+      });
+      this.table.setAttribute('aria-describedby',this.liveRegionId);
+    }
+  }
+
+  componentDidRender() {
+    const liveRegions = Array.from(this.host.querySelectorAll('[slot=cbp-table-live-region]'))
+    if (liveRegions) {
+      liveRegions.forEach( (item) => {
+        item.setAttribute('aria-live','polite');
+      });
+      this.table.setAttribute('aria-describedby',this.liveRegionId);
+    }
   }
 
   render() {
@@ -271,11 +295,9 @@ export class CbpTable {
                 color="secondary"
                 fill="outline"
                 variant="square"
-                accessibilityText="Scroll table left"
-                disabled={true}
+                accessibilityText="View table columns to the left"
                 context={this.context}
                 onClick={ () => this.doHorizontalScroll('-1')}
-                ref={el => (this.scrollLeft = el)}
               >
                 <cbp-icon name="chevron-right" size="var(--cbp-space-5x)" rotate={180}></cbp-icon>
               </cbp-button>
@@ -283,23 +305,26 @@ export class CbpTable {
                 color="secondary"
                 fill="outline"
                 variant="square"
-                accessibilityText="Scroll table right"
-                disabled={true}
+                accessibilityText="View table columns to the right"
                 context={this.context}
                 onClick={ () => this.doHorizontalScroll('1')}
-                ref={el => (this.scrollRight = el)}
               >
                 <cbp-icon name="chevron-right" size="var(--cbp-space-5x)"></cbp-icon>
               </cbp-button>
             </div>
           }
         </div>
+        
+        <div hidden 
+          id={this.liveRegionId}
+        >
+          <slot name="cbp-table-live-region" />
+        </div>
 
         <div 
           class="cbp-table-wrapper"
           ref={ el => this.wrapper = el}
         >
-          <div class="cbp-table-scroll-gradient"></div>
           <cbp-resize-observer
             debounce={10}
             onResized={ (e) => this.handleResize(e.detail.width) }

--- a/packages/web-components/src/components/cbp-table/cbp-table.tsx
+++ b/packages/web-components/src/components/cbp-table/cbp-table.tsx
@@ -274,16 +274,6 @@ export class CbpTable {
     }
   }
 
-  componentDidRender() {
-    const liveRegions = Array.from(this.host.querySelectorAll('[slot=cbp-table-live-region]'))
-    if (liveRegions) {
-      liveRegions.forEach( (item) => {
-        item.setAttribute('aria-live','polite');
-      });
-      this.table.setAttribute('aria-describedby',this.liveRegionId);
-    }
-  }
-
   render() {
     return (
       <Host>

--- a/packages/web-components/src/components/cbp-table/cbp-table.tsx
+++ b/packages/web-components/src/components/cbp-table/cbp-table.tsx
@@ -17,12 +17,22 @@ export class CbpTable {
   private caption: HTMLTableCaptionElement;
   private columnHeadings: HTMLTableCellElement[];
   private sortableColumns: HTMLTableCellElement[] = [];
+  private wrapper: HTMLElement;
+
+  private scrollLeft: HTMLCbpButtonElement;
+  private scrollRight: HTMLCbpButtonElement;
+
+  private tableWidth;
+  private tableBreakpoint;
   
   @Element() private host: HTMLElement;
 
 
   /** Specifies whether the table is striped, designating whether the colored rows are the odd or even rows (CBP DS standard is even when used). */
-  @Prop({ reflect: true }) striped: "odd" | "even";
+  @Prop() overflow: 'scroll' | 'linearize' = 'scroll';
+
+  /** Specifies whether the table is striped, designating whether the colored rows are the odd or even rows (CBP DS standard is even when used). */
+  @Prop({ reflect: true }) striped: 'odd' | 'even';
 
   /** Specifies whether the mouse cursor highlights the table row or cell on hover. Defaults to "row". */
   @Prop({ reflect: true }) hover: 'row' | 'cell' = 'row';
@@ -45,7 +55,7 @@ export class CbpTable {
   /** An event emitted when the table is sorted via user interaction activating a table header control. */
   @Event() tableSort: EventEmitter;
 
-  addScope(){
+  private addScope() {
     const columnHeadings = Array.from(this.host.querySelectorAll('thead th'));
     const rowHeadings = Array.from(this.host.querySelectorAll('tbody th'));
 
@@ -58,8 +68,29 @@ export class CbpTable {
     });
   }
 
-  makeSortable(){
-    this.columnHeadings = Array.from(this.host.querySelectorAll('thead th'));
+  // TechDebt: how to make this reactive?
+  private addHeaderDataAttrs() {
+    //const columnHeadings: HTMLElement[] = Array.from(this.host.querySelectorAll('thead th'));
+    //const tableCells: HTMLTableCellElement[] = Array.from(this.table?.querySelectorAll('tbody th,tbody td'));
+    const tableBodyRows: HTMLTableRowElement[] = Array.from(this.table?.querySelectorAll('tbody tr'));
+    
+    // loop over each body row, adding header data to each cell
+    tableBodyRows.forEach( ( row ) => {
+      const tableRowCells: HTMLTableCellElement[] = Array.from(row?.querySelectorAll('th,td'));
+      // We can only add the heading data if the number of headings match the number of cells per row
+      if (this.columnHeadings.length == tableRowCells.length) {
+        tableRowCells.forEach( ( cell, index ) => {
+          if(!!this.columnHeadings[index]?.textContent.trim()){
+            cell.setAttribute('data-column-header', `${this.columnHeadings[index].textContent.trim()}: `);
+          }
+        });
+      }
+    });
+  }
+
+
+  private makeSortable() {
+    //this.columnHeadings = Array.from(this.host.querySelectorAll('thead th'));
     
     this.columnHeadings.forEach( item => {
       const control = item.querySelector('cbp-button');
@@ -148,11 +179,72 @@ export class CbpTable {
     })
   }
 
+  // Called by the resize observer; also fires on initial render.
+  private handleResize(width) {
+    // Get the width of the content (and update the this.tableWidth) before doing responsive adjustments. (tables reflow, so we need to get this each comparison)
+    this.tableWidth = this.table.getBoundingClientRect().width;
+    //console.log(`Resize observer fired - table width=${this.tableWidth}, Observer width=${width}, table breakpoint=${this.tableBreakpoint}`);
+    
+    // If the emitted size is less than the current mode's width, do responsive behavior (use a +5 different to account for table-reflow anomalies)
+    if (width + 5 < this.tableWidth) {
+      this.host.classList.add(`cbp-table-${this.overflow}`);
+      if(this.overflow=='scroll') this.makeScrollable();
+    }
+    // Return to full view (potentially)
+    else if(this.overflow=='linearize') {
+      // For linearization, update the table breakpoint to the closest possible value (could vary slightly each time based on debouncing)
+      if( (this.tableBreakpoint == undefined || width < this.tableBreakpoint) && !this.host.classList.contains(`cbp-table-${this.overflow}`)) {
+        this.tableBreakpoint = width;
+      }
+      // Only remove responsive mode if the width is larger than the breakpoint, or else it removing linearization will bounce between states
+      if(width >= this.tableBreakpoint) {
+        this.host.classList.remove(`cbp-table-${this.overflow}`);
+      }
+    }
+    else {
+      this.host.classList.remove(`cbp-table-${this.overflow}`);
+    }
+  }
+
+  private makeScrollable(){
+    this.scrollRight.disabled=false;
+    this.scrollLeft.disabled=false;
+    console.log('Table width: ', this.table.getBoundingClientRect().width);
+    console.log('Wrapper width: ', this.wrapper.getBoundingClientRect().width);
+  }
+ 
+
+  private doHorizontalScroll(dir) {
+    /*
+        How to make it smarter? 
+          Intersection Observer?
+          Calculate heading sizes?
+          scrollIntoView({  behavior: "instant", block: "nearest", inline: 'start' });
+            scrollLeft  this.wrapper.scrollLeft += 20;
+          this.wrapper.scrollWidth 
+
+          headings scrollOffset
+
+          resizing while there is a scroll changes the wrapper size while the scroll position seems to remain static.
+          This means if you are scrolled to the end, but then shrink the size, more content will be overflowed to the right.
+
+     */
+    const step = 100; //px
+    this.wrapper.scrollBy( step * dir, 0 );
+    console.log('Scrolling: ', step * dir, this.table.getBoundingClientRect().width, this.wrapper.getBoundingClientRect().width);
+  }
+
+
+  private handleSlotChange(e) {
+    console.log(e);
+  }
+
+
   componentWillLoad() {
     this.table = this.host.querySelector('table');
     this.caption = this.table?.querySelector('caption');
     if (!this.caption) console.warn(`cbp-table: A caption tag is required for accessibility. If you don't want a visible caption, add a 'hidden' attribute to it.`);
-    this.columnHeadings=Array.from(this.host.querySelectorAll('thead > th'));
+    this.columnHeadings=Array.from(this.table?.querySelectorAll('thead th'));
 
     if (typeof this.sx == 'string') {
       this.sx = JSON.parse(this.sx) || {};
@@ -165,13 +257,56 @@ export class CbpTable {
   componentDidLoad() {
     this.addScope();
     this.makeSortable();
+    if(this.overflow == 'linearize') this.addHeaderDataAttrs();
   }
 
   render() {
     return (
       <Host>
-        <slot name="cbp-table-toolbar" />
-        <slot />
+        <div class="cbp-table-toolbar">
+          <slot name="cbp-table-toolbar" />
+          { this.overflow == 'scroll' &&
+            <div class="cbp-table-toolbar-scroll">
+              <cbp-button
+                color="secondary"
+                fill="outline"
+                variant="square"
+                accessibilityText="Scroll table left"
+                disabled={true}
+                context={this.context}
+                onClick={ () => this.doHorizontalScroll('-1')}
+                ref={el => (this.scrollLeft = el)}
+              >
+                <cbp-icon name="chevron-right" size="var(--cbp-space-5x)" rotate={180}></cbp-icon>
+              </cbp-button>
+              <cbp-button
+                color="secondary"
+                fill="outline"
+                variant="square"
+                accessibilityText="Scroll table right"
+                disabled={true}
+                context={this.context}
+                onClick={ () => this.doHorizontalScroll('1')}
+                ref={el => (this.scrollRight = el)}
+              >
+                <cbp-icon name="chevron-right" size="var(--cbp-space-5x)"></cbp-icon>
+              </cbp-button>
+            </div>
+          }
+        </div>
+
+        <div 
+          class="cbp-table-wrapper"
+          ref={ el => this.wrapper = el}
+        >
+          <div class="cbp-table-scroll-gradient"></div>
+          <cbp-resize-observer
+            debounce={10}
+            onResized={ (e) => this.handleResize(e.detail.width) }
+          >
+            <slot onSlotchange={(e) => this.handleSlotChange(e)}/>
+          </cbp-resize-observer>
+        </div>
       </Host>
     );
   }

--- a/packages/web-components/src/components/cbp-table/cbp-table.tsx
+++ b/packages/web-components/src/components/cbp-table/cbp-table.tsx
@@ -6,7 +6,7 @@ import { setCSSProps, createNamespaceKey } from '../../utils/utils';
  * tables as well as applying progressive enhancements to the contained table.
  * 
  * @slot - The semantic table HTML is placed within the default slot.
- * @slot cbp-table-live-toolbar - Any sort of filters or table controls may be slotted within this named slot.
+ * @slot cbp-table-toolbar - Any sort of filters or table controls may be slotted within this named slot.
  * @slot cbp-table-live-region - For complex tables with many controls and/or pagination, the state of the data may be quantified and described accessibly via an `aria-live` region, which is hidden from view. E.g., Filtered by the term "test", ordered by Column 1 ascending, displaying records 100-200 of 1234.
  */
 @Component({
@@ -70,8 +70,6 @@ export class CbpTable {
 
   // TechDebt: how to make this reactive?
   private addHeaderDataAttrs() {
-    //const columnHeadings: HTMLElement[] = Array.from(this.host.querySelectorAll('thead th'));
-    //const tableCells: HTMLTableCellElement[] = Array.from(this.table?.querySelectorAll('tbody th,tbody td'));
     const tableBodyRows: HTMLTableRowElement[] = Array.from(this.table?.querySelectorAll('tbody tr'));
     
     // loop over each body row, adding header data to each cell
@@ -90,8 +88,6 @@ export class CbpTable {
 
 
   private makeSortable() {
-    //this.columnHeadings = Array.from(this.host.querySelectorAll('thead th'));
-    
     this.columnHeadings.forEach( item => {
       const control = item.querySelector('cbp-button');
       if(control) {
@@ -180,19 +176,25 @@ export class CbpTable {
     })
   }
 
-
   // TechDebt: linearized starting at small size doesn't work to expand at larger size.
   // Called by the resize observer; also fires on initial render.
   private handleResize(width) {
     // Get the width of the content (and update the this.tableWidth) before doing responsive adjustments. (tables reflow, so we need to get this each comparison)
+    const OldTableWidth = this.tableWidth;
     this.tableWidth = this.table.getBoundingClientRect().width;
     
     // If the emitted size is less than the current mode's width, do responsive behavior (use a +5 different to account for table-reflow anomalies)
     if (width + 5 < this.tableWidth) {
       this.host.classList.add(`cbp-table-${this.overflow}`);
     }
+
     // Return to full view (potentially)
     else if(this.overflow=='linearize') {
+      // If no breakpoint was established, we need to keep trying to find it (only if size is getting larger)
+      if(this.tableBreakpoint == undefined && this.tableWidth > OldTableWidth && this.host.classList.contains(`cbp-table-${this.overflow}`)) {
+          this.host.classList.remove(`cbp-table-${this.overflow}`);
+          this.handleResize(width);
+      }
       // For linearization, update the table breakpoint to the closest possible value (could vary slightly each time based on debouncing)
       if( (this.tableBreakpoint == undefined || width < this.tableBreakpoint) && !this.host.classList.contains(`cbp-table-${this.overflow}`)) {
         this.tableBreakpoint = width;
@@ -202,6 +204,7 @@ export class CbpTable {
         this.host.classList.remove(`cbp-table-${this.overflow}`);
       }
     }
+
     else {
       this.host.classList.remove(`cbp-table-${this.overflow}`);
     }


### PR DESCRIPTION
* Got the resize-observer's debounce prop working.
* Updated breadcrumbs to use the debounce prop rather than import
* Implemented table responsiveness (linearization and horizontal scroll)
* Implemented controls that scroll by column.
* Added live region slot and basic hookup, but not full tested. (this will be revisited later because it's hard to test)

* Add story controls for showCaption (default hidden) and live region text, moved action bar outside of `cbp-table` component because it is adversely affected by responsiveness.

* Update table docs with new changes.