### PR TITLE
bugfix/html-panel-prerendered-code

### DIFF
--- a/packages/web-components/.storybook/preview.ts
+++ b/packages/web-components/.storybook/preview.ts
@@ -64,25 +64,29 @@ const withAnimationControl: DecoratorFunction<WebComponentsRenderer> = (storyFn)
  *    Switch sx back to single quotes and unescape the JSON double quotes?
  *    Represent booleans properly as just the attribute, without ="" per innerHTML
  *    Remove multiple line breaks
- *    Can we reference the story's root to accurately get the innerHTML of the proper element?
  */
+var DEFAULT_ROOT_SELECTOR = "#storybook-root, #root";
 const renderPreHydrated: DecoratorFunction<WebComponentsRenderer> = (storyFn, context) => {
   //console.log(context);
+  const parameters = context.parameters?.html || {};
+  const rootSelector = parameters.root || DEFAULT_ROOT_SELECTOR;
   const channel = addons.getChannel();
   const story = storyFn();
 
   // Capture before hydration tick
   requestAnimationFrame( () => {
-    const root = document.getElementById('storybook-root');
+    const root = document.querySelector(rootSelector);
     const rawSnapshot = root?.innerHTML;
     // store it somewhere or pass via context
     context.parameters.__preHydratedHTML = rawSnapshot;
+
+    console.log(channel,rawSnapshot);
 
     setTimeout( async () => {
       channel.emit('storybook/html/codeUpdate', {
         code: rawSnapshot?.replace(/<!---->/g,'')
         .split('\n')
-          .slice(1,-1) // replace the cbp-app tag we added via decorator
+          //.filter(line => line.trim() != '' ? line.replace(/^ {0,4}/,'') : null) 
           .map(line => line.replace(/^ {0,4}/,''))
         .join('\n')
       });

--- a/packages/web-components/CHANGELOG.md
+++ b/packages/web-components/CHANGELOG.md
@@ -6,12 +6,12 @@ The React components are wrappers generated from this package and will share the
 
 ## [unpublished] TBD
 
-* Initial creation of the `cbp-floating-action` component, used for positioning buttons/controls in a fixed position on the viewport.
+* Initial creation of the `cbp-floating-action` component, used for positioning buttons/controls in a fixed position within the viewport.
 * Added a "circular" variant to `cbp-button`.
 * Updated the `cbp-table` component with responsive functionality and other bug fixes:
   * Added the `overflow` property, which tells the component how to respond when the table overflows its container:
     * "Scroll" is the default and displays a horizontal scrollbar and controls above the table to scroll left or right.
-    * "Linearize" may be used when data does not need to be compared across columns and rows.
+    * "Linearize" stacks the table cells and is ideal for when data does not need to be compared across columns and rows.
   * Added the column name (text) to the `tableSort` event emitter.
   * Added a named slot for a toolbar, which displays application-specific controls alongside the table scroll buttons (when visible).
   * Added a named slot for an `aria-live` region to quantify complex table's data (filters, column sort, pagination, etc.).
@@ -19,6 +19,8 @@ The React components are wrappers generated from this package and will share the
   * Added keyboard shortcuts for quicker navigation of the treeview control.
   * Added `aria-owns` to Treeview and Treeview Items with nested children for improved accessibility.
   * Refactored some CSS to make it more robust.
+* Upgraded to Storybook 10.3.3.
+* Fixed the Storybook HTML Panel to work again and show pre-rendered web component code that can easily be copied into your application.
 
 ## [0.0.1-develop.32] 03-16-2026
 


### PR DESCRIPTION
* Updated changelog 
* Updated the HTML panel to reference the proper root element

This means that most stories do not show the `cbp-app` component, but the templates, which specify a higher-level root, do include the `cbp-app` as desired.