### PR TITLE
Resolve techdebt in pagination, toast, and grid

### DIFF
--- a/packages/web-components/src/components/cbp-app/core.scss
+++ b/packages/web-components/src/components/cbp-app/core.scss
@@ -103,15 +103,5 @@ textarea:read-only {
 
 /* Expose a generic class for visually hiding content in an accessible manner */
 .cbp-visually-hidden {
-  border: 0;
-  clip: rect(1px, 1px, 1px, 1px);
-  -webkit-clip-path: inset(50%);
-  clip-path: inset(50%);
-  height: 1px;
-  overflow: hidden;
-  margin: -1px;
-  padding: 0;
-  position: absolute;
-  width: 1px;
-  white-space: nowrap;
+  @include visuallyHidden
 }

--- a/packages/web-components/src/components/cbp-grid-item/cbp-grid-item.stories.tsx
+++ b/packages/web-components/src/components/cbp-grid-item/cbp-grid-item.stories.tsx
@@ -56,7 +56,6 @@ export default {
   },
 };
 
-// TechDebt: I can't figure out why it is not setting the CSS props for gridColumnStart, gridColumnEnd, gridRowStart, gridRowEnd
 const Template = ({ gridColumnStart, gridColumnEnd, gridRowStart, gridRowEnd, alignSelf, justifySelf, gridArea, content, sx }) => {
   return ` 
     <cbp-grid

--- a/packages/web-components/src/components/cbp-pagination/cbp-pagination.scss
+++ b/packages/web-components/src/components/cbp-pagination/cbp-pagination.scss
@@ -27,19 +27,7 @@ cbp-pagination {
   [slot=cbp-pagination-items-per-page],
   [slot=cbp-pagination-pages] {
     label {
-      //display: none;
-      // TechDebt: this should be a mixin
-      border: 0;
-      clip: rect(1px, 1px, 1px, 1px);
-      -webkit-clip-path: inset(50%);
-      clip-path: inset(50%);
-      height: 1px;
-      overflow: hidden;
-      margin: -1px;
-      padding: 0;
-      position: absolute;
-      width: 1px;
-      white-space: nowrap;
+      @include hiddenText //see global/styles/index.scss for declaration
     }
   }
 

--- a/packages/web-components/src/components/cbp-pagination/cbp-pagination.scss
+++ b/packages/web-components/src/components/cbp-pagination/cbp-pagination.scss
@@ -27,7 +27,7 @@ cbp-pagination {
   [slot=cbp-pagination-items-per-page],
   [slot=cbp-pagination-pages] {
     label {
-      @include hiddenText //see global/styles/index.scss for declaration
+      @include visuallyHidden //see global/styles/index.scss for declaration
     }
   }
 

--- a/packages/web-components/src/components/cbp-toast/cbp-toast.scss
+++ b/packages/web-components/src/components/cbp-toast/cbp-toast.scss
@@ -53,7 +53,6 @@ cbp-toast {
     animation: dismiss 1s ease-in-out forwards;
   }
 
-  // TechDebt: Can the color be set here too rather than inline in the story code?
   .cbp-toast-sidebar {
     --cbp-icon-size: var(--cbp-space-8x);
     display: flex;
@@ -92,7 +91,7 @@ cbp-toast {
   .cbp-toast-button-bar {
     display: flex;
     justify-content: center;
-    padding-top: var(--cbp-space-3x); //TODO: confrim this is correct on spec. might be needed around sides/inbetween buttons as well
+    padding-top: var(--cbp-space-3x);
 
     & > div {
       display: flex;

--- a/packages/web-components/src/global/styles/index.scss
+++ b/packages/web-components/src/global/styles/index.scss
@@ -4,7 +4,7 @@
  */
 @forward 'breakpoints';
 
-@mixin hiddenText {
+@mixin visuallyHidden {
     border: 0;
     clip: rect(1px, 1px, 1px, 1px);
     -webkit-clip-path: inset(50%);

--- a/packages/web-components/src/global/styles/index.scss
+++ b/packages/web-components/src/global/styles/index.scss
@@ -3,3 +3,17 @@
  * These should only include SASS variables and mixins that are not written out to CSS directly
  */
 @forward 'breakpoints';
+
+@mixin hiddenText {
+    border: 0;
+    clip: rect(1px, 1px, 1px, 1px);
+    -webkit-clip-path: inset(50%);
+    clip-path: inset(50%);
+    height: 1px;
+    overflow: hidden;
+    margin: -1px;
+    padding: 0;
+    position: absolute;
+    width: 1px;
+    white-space: nowrap;
+}


### PR DESCRIPTION
Resolve techdebt:
*Toast: techdebt already resolved, removing techdebt tag and TODO that was resolved
*Grid: techdebt already resolved as part of recent reorg chore
*Pagination: added mixin to global/style/index.scss as discussed in sync