### PR TITLE
updates to card stories and reorganizing action button functionality

### DIFF
--- a/packages/web-components/src/components/cbp-card/cbp-card.scss
+++ b/packages/web-components/src/components/cbp-card/cbp-card.scss
@@ -149,9 +149,9 @@ cbp-card {
     }
   }
 
-  &[variant=decision] [slot=cbp-card-title] {
-    margin-bottom: var(--cbp-space-2x);
-  }
+  // &:has([slot="cbp-card-actions"]) [slot=cbp-card-title] {
+  //   margin-bottom: var(--cbp-space-2x);
+  // }
   
   &[color=info] {
     --cbp-card-color-background: var(--cbp-color-info-lighter);
@@ -198,7 +198,7 @@ cbp-card {
   }
 
   // Decision Card Variant
-  &[variant=decision] {
+  &:has([slot="cbp-card-actions"]){
     border: 0;
 
      .cbp-card-body {

--- a/packages/web-components/src/components/cbp-card/cbp-card.stories.tsx
+++ b/packages/web-components/src/components/cbp-card/cbp-card.stories.tsx
@@ -2,6 +2,12 @@ export default {
   title: 'Content/Card',
   tags: ['beta'],
   argTypes: {
+    variant: {
+      name: "Variant",
+      description: "set Variant of the card",
+      control: "select",
+      options: ["generic", "banner", "decision", "flag"]
+    },
     title: {
       name: 'Title (slotted)',
       description: 'Set the title in the banner area of the card',
@@ -12,6 +18,27 @@ export default {
       description: 'Set the body text of the card',
       control: 'text',
     },
+
+    actionsLayout:{
+      name: "Actions Layout",
+      description: "Choose actions layout of the card component",
+      control: "select",
+      options: ["single", "double", "triple"],
+    },
+    actionsFill: {
+      name: "Actions Fill",
+      description: "Choose the fill of the actions in the card component",
+      control: "radio",
+      options: ["solid", "outline", "ghost"],
+      if: {arg: "actionsLayout"}
+    },
+    actionsConfig: {
+      name: "Decision Card Actions",
+      description: "Configure card button labels and colors. Available button colors: `primary`, `secondary`, `tertiary` and `danger`",
+      control: "object",
+      if: {arg: "actionsLayout"}
+    },
+
     stretch: {
       control: 'boolean',
     },
@@ -83,13 +110,13 @@ const renderActions = (layout, fill, color, context, withIcon, headingId,{ btn1,
 const GeneralTemplate = ({ variant, color, title, headingId, bodyText, actionsLayout, actionsFill, actionsConfig, withIcon, stretch, context, sx }) => {
   return ` 
     <cbp-card
-      ${variant ? `variant=${variant}` : ``}
+      ${variant != 'generic'? `variant=${variant}` : ``}
       ${color ? `color="${color}"` : ''}
       ${stretch ? `stretch` : ``}
       ${context && context != 'light-inverts' ? `context="${context}"` : ''}      
       ${sx ? `sx='${JSON.stringify(sx)}'` : ''}
     >
-      <cbp-typography tag="h4" slot="cbp-card-title">
+      <cbp-typography tag="h4" slot="cbp-card-title" id=${headingId}>
         ${withIcon ? `<cbp-icon name="triangle-exclamation" size="1.25rem"></cbp-icon>` : ''}
         ${title}
       </cbp-typography>
@@ -111,7 +138,7 @@ const FlagTemplate = ({ title, color, bodyText, withIcon, context, sx }) => {
       <div slot="cbp-card-flag">
         <img src="https://api.dicebear.com/9.x/personas/svg" alt="Flag Card random image"/>
       </div>
-      <cbp-typography tag="h4" slot="cbp-card-title">
+      <cbp-typography tag="h4" slot="cbp-card-title" >
         ${withIcon ? `<cbp-icon name="triangle-exclamation" size="1.25rem"></cbp-icon>` : ''}
         ${title}
       </cbp-typography>
@@ -131,7 +158,7 @@ const InteractiveTemplate = ({ title, color, disabled, bodyText, withIcon, inter
 
   return ` 
     <cbp-card
-      ${variant !=='default' ? `variant="${variant}"` : ''}
+      ${variant !=='generic' ? `variant="${variant}"` : ''}
       ${interactive ? `interactive="${interactive}"` : ''}
       ${href ? `href="${href}"` : ''}
       ${disabled ? 'disabled' : ''}
@@ -206,25 +233,27 @@ GeneralCard.args = {
     },
   },
 };
-GeneralCard.argTypes = {
-actionsLayout:{
-      name: "Actions Layout",
-      description: "Choose actions layout of the card component",
-      control: "select",
-      options: ["single", "double", "triple"],
-    },
-    actionsFill: {
-      name: "Actions Fill",
-      description: "Choose the fill of the actions in the card component",
-      control: "radio",
-      options: ["solid", "outline", "ghost"]
-    },
-    actionsConfig: {
-      name: "Decision Card Actions",
-      description: "Configure card button labels and colors. Available button colors: `primary`, `secondary`, `tertiary` and `danger`",
-      control: "object",
-    },
-};
+// GeneralCard.argTypes = {
+//   actionsLayout:{
+//     name: "Actions Layout",
+//     description: "Choose actions layout of the card component",
+//     control: "select",
+//     options: ["single", "double", "triple"],
+//   },
+//   actionsFill: {
+//     name: "Actions Fill",
+//     description: "Choose the fill of the actions in the card component",
+//     control: "radio",
+//     options: ["solid", "outline", "ghost"],
+//     if: {arg: "actionsLayout"}
+//   },
+//   actionsConfig: {
+//     name: "Decision Card Actions",
+//     description: "Configure card button labels and colors. Available button colors: `primary`, `secondary`, `tertiary` and `danger`",
+//     control: "object",
+//     if: {arg: "actionsLayout"}
+//   },
+// };
 
 export const BannerCard = GeneralTemplate.bind({});
 BannerCard.args = {
@@ -252,25 +281,27 @@ BannerCard.args = {
   }
 };
 
-BannerCard.argTypes={
-  actionsLayout:{
-    name: "Actions Layout",
-    description: "Choose actions layout of the card component",
-    control: "select",
-    options: ["single", "double", "triple"],
-  },
-  actionsFill: {
-    name: "Actions Fill",
-    description: "Choose the fill of the actions in the card component",
-    control: "radio",
-    options: ["solid", "outline", "ghost"]
-  },
-  actionsConfig: {
-    name: "Decision Card Actions",
-    description: "Configure card button labels and colors. Available button colors: `primary`, `secondary`, `tertiary` and `danger`",
-    control: "object",
-  },
-}
+// BannerCard.argTypes={
+//   actionsLayout:{
+//     name: "Actions Layout",
+//     description: "Choose actions layout of the card component",
+//     control: "select",
+//     options: ["single", "double", "triple"],
+//   },
+//   actionsFill: {
+//     name: "Actions Fill",
+//     description: "Choose the fill of the actions in the card component",
+//     control: "radio",
+//     options: ["solid", "outline", "ghost"],
+//     if: {arg: "actionsLayout"}
+//   },
+//   actionsConfig: {
+//     name: "Decision Card Actions",
+//     description: "Configure card button labels and colors. Available button colors: `primary`, `secondary`, `tertiary` and `danger`",
+//     control: "object",
+//     if: {arg: "actionsLayout"}
+//   },
+// }
 
 export const FlagCard = FlagTemplate.bind({});
 FlagCard.args = {
@@ -278,12 +309,18 @@ FlagCard.args = {
   bodyText: "Here is an example of some body text for this purely informational card",
 };
 
+FlagCard.argTypes ={
+  actionLayout: {
+    control: false
+  }
+}
+
 export const InteractiveCard = InteractiveTemplate.bind({});
 InteractiveCard.args = {
   title: "Banner Card Title",
   bodyText: "Here is an example of some supplementary text for this purely informational card",
   interactive: "clickable",
-  variant: "default",
+  variant: "generic",
   href: "https://us-cbp.github.io/design-system/?path=/story/introduction--introduction"
 };
 
@@ -300,12 +337,9 @@ InteractiveCard.argTypes = {
   disabled: {
     control: "boolean",
   },
-  variant: {
-    name: "Variant",
-    description: "set Variant of the card",
-    control: "select",
-    options: ["default", "flag"]
-  },
+  actionLayout: {
+    control: false
+  }
 };
 
 const InteractiveRadioListTemplate = ({ title, color, disabled, bodyText, withIcon, href, variant, context, sx }) => {
@@ -394,7 +428,7 @@ InteractiveRadioList.args = {
   title: "Banner Card Title",
   bodyText: "Here is an example of some supplementary text for this purely informational card",
   interactive: "clickable",
-  variant: "default",
+  variant: "generic",
   href: "https://us-cbp.github.io/design-system/?path=/story/introduction--introduction",
   sx: {"margin-bottom":"var(--cbp-space-1x)"}
 };
@@ -412,10 +446,7 @@ InteractiveRadioList.argTypes = {
   disabled: {
     control: "boolean",
   },
-  variant: {
-    name: "Variant",
-    description: "set Variant of the card",
-    control: "select",
-    options: ["default", "flag"]
+  actionLayout: {
+    control: false
   }
 };

--- a/packages/web-components/src/components/cbp-card/cbp-card.stories.tsx
+++ b/packages/web-components/src/components/cbp-card/cbp-card.stories.tsx
@@ -18,6 +18,12 @@ export default {
     withIcon: {
       control: 'boolean',
     },
+    color: {
+      name: "Color",
+      description: "Set the color of the card",
+      control: "select",
+      options: ["default", "info", "success", "warning", "danger"],
+    },
     context : {
       control: 'select',
       options: [ 'light-inverts', 'light-always', 'dark-inverts', 'dark-always']
@@ -74,10 +80,11 @@ const renderActions = (layout, fill, color, context, withIcon, headingId,{ btn1,
   }
 };
 
-const GeneralTemplate = ({ color, title, bodyText, withIcon, context, sx }) => {
+const GeneralTemplate = ({ color, title, headingId, bodyText, actionsLayout, actionsFill, actionsConfig, withIcon, stretch, context, sx }) => {
   return ` 
     <cbp-card
       ${color ? `color="${color}"` : ''}
+      ${stretch ? `stretch` : ``}
       ${context && context != 'light-inverts' ? `context="${context}"` : ''}      
       ${sx ? `sx='${JSON.stringify(sx)}'` : ''}
     >
@@ -86,29 +93,12 @@ const GeneralTemplate = ({ color, title, bodyText, withIcon, context, sx }) => {
         ${title}
       </cbp-typography>
       <p>${bodyText}</p>
+      ${actionsLayout ? renderActions(actionsLayout, actionsFill, color, context, withIcon, headingId, actionsConfig) : ``}
     </cbp-card>
   `;
 };
 
-const DecisionTemplate = ({ title, headingId, color, bodyText, actionsLayout, actionsFill, actionsConfig, withIcon, context, sx }) => {
-  return ` 
-    <cbp-card
-      variant="decision" 
-      ${color ? `color="${color}"` : ''}
-      ${context && context != 'light-inverts' ? `context="${context}"` : ''}
-      ${sx ? `sx='${JSON.stringify(sx)}'` : ''}
-    >
-      <cbp-typography tag="h4" slot="cbp-card-title" ${headingId ? `id=${headingId}` : ``}>
-        ${withIcon ? `<cbp-icon name="triangle-exclamation" size="1.25rem"></cbp-icon>` : ''}
-        ${title}
-      </cbp-typography>
-      <p>${bodyText}</p>  
-      ${renderActions(actionsLayout, actionsFill, color,context, withIcon, headingId, actionsConfig)}
-    </cbp-card>
-  `;
-};
-
-const BannerTemplate = ({ title, color, bodyText, withIcon, context, sx }) => {
+const BannerTemplate = ({ title, headingId, color, bodyText, actionsLayout, actionsFill, actionsConfig, withIcon, context, sx }) => {
   return ` 
     <cbp-card
       variant="banner"
@@ -121,6 +111,7 @@ const BannerTemplate = ({ title, color, bodyText, withIcon, context, sx }) => {
         ${title}
       </cbp-typography>
       <p>${bodyText}</p>  
+      ${actionsLayout ? renderActions(actionsLayout, actionsFill, color, context, withIcon, headingId, actionsConfig) : ``}
     </cbp-card>
   `;
 };
@@ -141,7 +132,7 @@ const FlagTemplate = ({ title, color, bodyText, withIcon, context, sx }) => {
         ${withIcon ? `<cbp-icon name="triangle-exclamation" size="1.25rem"></cbp-icon>` : ''}
         ${title}
       </cbp-typography>
-      <p>${bodyText}</p>  
+      <p>${bodyText}</p>
     </cbp-card>
   `;
 };
@@ -211,16 +202,8 @@ const InteractiveTemplate = ({ title, color, disabled, bodyText, withIcon, inter
 export const GeneralCard = GeneralTemplate.bind({});
 GeneralCard.args = {
   title: "Card Title",
+  headingId: "card-heading",
   bodyText: "Here is an example of some body text for this purely informational card",
-};
-GeneralCard.argTypes = {};
-
-export const DecisionCard = DecisionTemplate.bind({});
-DecisionCard.args = {
-  title: "Card Title",
-  headingId: "decision-card-heading",
-  bodyText: "Here is an example of some body text for this decision card.",
-  actionsLayout: "single",
   actionsFill: "solid",
   actionsConfig: {
     btn1: {
@@ -240,17 +223,56 @@ DecisionCard.args = {
     },
   },
 };
-DecisionCard.argTypes = {
-  color: {
-    name: "Color",
-    description: "Set the color of the card",
-    control: "select",
-    options: ["default", "danger"],
-  },
-  actionsLayout: {
+GeneralCard.argTypes = {
+actionsLayout:{
+      name: "Actions Layout",
+      description: "Choose actions layout of the card component",
+      control: "select",
+      options: ["single", "double", "triple"],
+    },
+    actionsFill: {
+      name: "Actions Fill",
+      description: "Choose the fill of the actions in the card component",
+      control: "radio",
+      options: ["solid", "outline", "ghost"]
+    },
+    actionsConfig: {
+      name: "Decision Card Actions",
+      description: "Configure card button labels and colors. Available button colors: `primary`, `secondary`, `tertiary` and `danger`",
+      control: "object",
+    },
+};
+
+export const BannerCard = BannerTemplate.bind({});
+BannerCard.args = {
+  title: "Banner Card Title",
+  headingId: "banner-card-heading",
+  bodyText: "Here is an example of some supplementary text for this purely informational card",
+  actionsFill: "solid",
+  actionsConfig: {
+    btn1: {
+      label: "Action 1",
+      tag: "button",
+      color: "primary",
+    },
+    btn2: {
+      label: "Action 2",
+      tag: "button",
+      color: "secondary",
+    },
+    btn3: {
+      label: "Action 3",
+      tag: "button",
+      color: "tertiary",
+    },
+  }
+};
+
+BannerCard.argTypes={
+  actionsLayout:{
     name: "Actions Layout",
     description: "Choose actions layout of the card component",
-    control: "radio",
+    control: "select",
     options: ["single", "double", "triple"],
   },
   actionsFill: {
@@ -264,26 +286,12 @@ DecisionCard.argTypes = {
     description: "Configure card button labels and colors. Available button colors: `primary`, `secondary`, `tertiary` and `danger`",
     control: "object",
   },
-};
-
-export const BannerCard = BannerTemplate.bind({});
-BannerCard.args = {
-  title: "Banner Card Title",
-  bodyText: "Here is an example of some supplementary text for this purely informational card",
-};
+}
 
 export const FlagCard = FlagTemplate.bind({});
 FlagCard.args = {
   title: "Card Title",
   bodyText: "Here is an example of some body text for this purely informational card",
-};
-FlagCard.argTypes = {
-  color: {
-    name: "Color",
-    description: "Set the color of the card",
-    control: "select",
-    options: ["default", "info", "success", "warning", "danger"],
-  },
 };
 
 export const InteractiveCard = InteractiveTemplate.bind({});
@@ -308,59 +316,11 @@ InteractiveCard.argTypes = {
   disabled: {
     control: "boolean",
   },
-  color: {
-    control: "select",
-    options: ["default", "danger"],
-  },
   variant: {
     name: "Variant",
     description: "set Variant of the card",
     control: "select",
     options: ["default", "flag"]
-  },
-};
-
-
-const BannerAndDecisionTemplate = ({ title, headingId, color, bodyText, actionsLayout, actionsConfig, withIcon, context, sx }) => {
-  return ` 
-    <cbp-card
-      variant="banner"
-      ${color ? `color="${color}"` : ''}
-      ${context && context != 'light-inverts' ? `context="${context}"` : ''}
-      ${sx ? `sx='${JSON.stringify(sx)}'` : ''}
-    >
-      <cbp-typography tag="h4" slot="cbp-card-title" ${headingId ? `id=${headingId}` : ``}>
-        ${withIcon ? `<cbp-icon name="triangle-exclamation" size="1.25rem"></cbp-icon>` : ''}
-        ${title}
-      </cbp-typography>
-      <p>${bodyText}</p>
-      ${renderActions(actionsLayout, "solid", color,context, withIcon, headingId, actionsConfig)}  
-    </cbp-card>
-  `;
-};
-
-export const BannerAndDecisionCard = BannerAndDecisionTemplate.bind({});
-BannerAndDecisionCard.args = {
-  title: "Banner Card Title",
-  headingId: "banner-and-decision-card",
-  bodyText: "Here is an example of some supplementary text for this purely informational card",
-  actionsLayout: "single",
-  actionsConfig: {
-    btn1: {
-      label: "Action 1",
-      tag: "button",
-      color: "primary",
-    },
-    btn2: {
-      label: "Action 2",
-      tag: "button",
-      color: "secondary",
-    },
-    btn3: {
-      label: "Action 3",
-      tag: "button",
-      color: "tertiary",
-    },
   },
 };
 
@@ -467,10 +427,6 @@ InteractiveRadioList.argTypes = {
   },
   disabled: {
     control: "boolean",
-  },
-  color: {
-    control: "select",
-    options: ["default", "danger"],
   },
   variant: {
     name: "Variant",

--- a/packages/web-components/src/components/cbp-card/cbp-card.stories.tsx
+++ b/packages/web-components/src/components/cbp-card/cbp-card.stories.tsx
@@ -80,9 +80,10 @@ const renderActions = (layout, fill, color, context, withIcon, headingId,{ btn1,
   }
 };
 
-const GeneralTemplate = ({ color, title, headingId, bodyText, actionsLayout, actionsFill, actionsConfig, withIcon, stretch, context, sx }) => {
+const GeneralTemplate = ({ variant, color, title, headingId, bodyText, actionsLayout, actionsFill, actionsConfig, withIcon, stretch, context, sx }) => {
   return ` 
     <cbp-card
+      ${variant ? `variant=${variant}` : ``}
       ${color ? `color="${color}"` : ''}
       ${stretch ? `stretch` : ``}
       ${context && context != 'light-inverts' ? `context="${context}"` : ''}      
@@ -93,24 +94,6 @@ const GeneralTemplate = ({ color, title, headingId, bodyText, actionsLayout, act
         ${title}
       </cbp-typography>
       <p>${bodyText}</p>
-      ${actionsLayout ? renderActions(actionsLayout, actionsFill, color, context, withIcon, headingId, actionsConfig) : ``}
-    </cbp-card>
-  `;
-};
-
-const BannerTemplate = ({ title, headingId, color, bodyText, actionsLayout, actionsFill, actionsConfig, withIcon, context, sx }) => {
-  return ` 
-    <cbp-card
-      variant="banner"
-      ${color ? `color="${color}"` : ''}
-      ${context && context != 'light-inverts' ? `context="${context}"` : ''}
-      ${sx ? `sx='${JSON.stringify(sx)}'` : ''}
-    >
-      <cbp-typography tag="h4" slot="cbp-card-title">
-        ${withIcon ? `<cbp-icon name="triangle-exclamation" size="1.25rem"></cbp-icon>` : ''}
-        ${title}
-      </cbp-typography>
-      <p>${bodyText}</p>  
       ${actionsLayout ? renderActions(actionsLayout, actionsFill, color, context, withIcon, headingId, actionsConfig) : ``}
     </cbp-card>
   `;
@@ -243,8 +226,9 @@ actionsLayout:{
     },
 };
 
-export const BannerCard = BannerTemplate.bind({});
+export const BannerCard = GeneralTemplate.bind({});
 BannerCard.args = {
+  variant: "banner",
   title: "Banner Card Title",
   headingId: "banner-card-heading",
   bodyText: "Here is an example of some supplementary text for this purely informational card",

--- a/packages/web-components/src/components/cbp-card/cbp-card.stories.tsx
+++ b/packages/web-components/src/components/cbp-card/cbp-card.stories.tsx
@@ -298,6 +298,9 @@ InteractiveCard.argTypes = {
   },
   actionsLayout: {
     control: false
+  },
+  variant:{
+    control: false
   }
 };
 

--- a/packages/web-components/src/components/cbp-card/cbp-card.stories.tsx
+++ b/packages/web-components/src/components/cbp-card/cbp-card.stories.tsx
@@ -6,7 +6,7 @@ export default {
       name: "Variant",
       description: "set Variant of the card",
       control: "select",
-      options: ["generic", "banner", "decision", "flag"]
+      options: ["banner", "flag"]
     },
     title: {
       name: 'Title (slotted)',
@@ -33,7 +33,7 @@ export default {
       if: {arg: "actionsLayout"}
     },
     actionsConfig: {
-      name: "Decision Card Actions",
+      name: "Card Actions",
       description: "Configure card button labels and colors. Available button colors: `primary`, `secondary`, `tertiary` and `danger`",
       control: "object",
       if: {arg: "actionsLayout"}
@@ -110,8 +110,8 @@ const renderActions = (layout, fill, color, context, withIcon, headingId,{ btn1,
 const GeneralTemplate = ({ variant, color, title, headingId, bodyText, actionsLayout, actionsFill, actionsConfig, withIcon, stretch, context, sx }) => {
   return ` 
     <cbp-card
-      ${variant != 'generic'? `variant=${variant}` : ``}
-      ${color ? `color="${color}"` : ''}
+      ${variant? `variant=${variant}` : ``}
+      ${color !="default"? `color="${color}"` : ''}
       ${stretch ? `stretch` : ``}
       ${context && context != 'light-inverts' ? `context="${context}"` : ''}      
       ${sx ? `sx='${JSON.stringify(sx)}'` : ''}
@@ -158,7 +158,7 @@ const InteractiveTemplate = ({ title, color, disabled, bodyText, withIcon, inter
 
   return ` 
     <cbp-card
-      ${variant !=='generic' ? `variant="${variant}"` : ''}
+      ${variant ? `variant="${variant}"` : ''}
       ${interactive ? `interactive="${interactive}"` : ''}
       ${href ? `href="${href}"` : ''}
       ${disabled ? 'disabled' : ''}
@@ -233,27 +233,6 @@ GeneralCard.args = {
     },
   },
 };
-// GeneralCard.argTypes = {
-//   actionsLayout:{
-//     name: "Actions Layout",
-//     description: "Choose actions layout of the card component",
-//     control: "select",
-//     options: ["single", "double", "triple"],
-//   },
-//   actionsFill: {
-//     name: "Actions Fill",
-//     description: "Choose the fill of the actions in the card component",
-//     control: "radio",
-//     options: ["solid", "outline", "ghost"],
-//     if: {arg: "actionsLayout"}
-//   },
-//   actionsConfig: {
-//     name: "Decision Card Actions",
-//     description: "Configure card button labels and colors. Available button colors: `primary`, `secondary`, `tertiary` and `danger`",
-//     control: "object",
-//     if: {arg: "actionsLayout"}
-//   },
-// };
 
 export const BannerCard = GeneralTemplate.bind({});
 BannerCard.args = {
@@ -281,28 +260,6 @@ BannerCard.args = {
   }
 };
 
-// BannerCard.argTypes={
-//   actionsLayout:{
-//     name: "Actions Layout",
-//     description: "Choose actions layout of the card component",
-//     control: "select",
-//     options: ["single", "double", "triple"],
-//   },
-//   actionsFill: {
-//     name: "Actions Fill",
-//     description: "Choose the fill of the actions in the card component",
-//     control: "radio",
-//     options: ["solid", "outline", "ghost"],
-//     if: {arg: "actionsLayout"}
-//   },
-//   actionsConfig: {
-//     name: "Decision Card Actions",
-//     description: "Configure card button labels and colors. Available button colors: `primary`, `secondary`, `tertiary` and `danger`",
-//     control: "object",
-//     if: {arg: "actionsLayout"}
-//   },
-// }
-
 export const FlagCard = FlagTemplate.bind({});
 FlagCard.args = {
   title: "Card Title",
@@ -310,7 +267,10 @@ FlagCard.args = {
 };
 
 FlagCard.argTypes ={
-  actionLayout: {
+  actionsLayout: {
+    control: false
+  },
+  variant:{
     control: false
   }
 }
@@ -320,7 +280,6 @@ InteractiveCard.args = {
   title: "Banner Card Title",
   bodyText: "Here is an example of some supplementary text for this purely informational card",
   interactive: "clickable",
-  variant: "generic",
   href: "https://us-cbp.github.io/design-system/?path=/story/introduction--introduction"
 };
 
@@ -337,12 +296,12 @@ InteractiveCard.argTypes = {
   disabled: {
     control: "boolean",
   },
-  actionLayout: {
+  actionsLayout: {
     control: false
   }
 };
 
-const InteractiveRadioListTemplate = ({ title, color, disabled, bodyText, withIcon, href, variant, context, sx }) => {
+const InteractiveRadioListTemplate = ({ title, color, disabled, bodyText, withIcon, href, context, sx }) => {
 
   return ` 
     <cbp-form-field group
@@ -351,7 +310,6 @@ const InteractiveRadioListTemplate = ({ title, color, disabled, bodyText, withIc
       field-id="cardRadioGroup"
     >
       <cbp-card
-        ${variant !=='default' ? `variant="${variant}"` : ''}
         interactive="radio"
         ${href ? `href="${href}"` : ''}
         ${disabled ? 'disabled' : ''}
@@ -374,7 +332,6 @@ const InteractiveRadioListTemplate = ({ title, color, disabled, bodyText, withIc
       </cbp-card>
       
       <cbp-card
-        ${variant !=='default' ? `variant="${variant}"` : ''}
         interactive="radio"
         ${href ? `href="${href}"` : ''}
         ${disabled ? 'disabled' : ''}
@@ -397,7 +354,6 @@ const InteractiveRadioListTemplate = ({ title, color, disabled, bodyText, withIc
       </cbp-card>
 
       <cbp-card
-        ${variant !=='default' ? `variant="${variant}"` : ''}
         interactive= 'radio'
         ${href ? `href="${href}"` : ''}
         ${disabled ? 'disabled' : ''}
@@ -428,7 +384,6 @@ InteractiveRadioList.args = {
   title: "Banner Card Title",
   bodyText: "Here is an example of some supplementary text for this purely informational card",
   interactive: "clickable",
-  variant: "generic",
   href: "https://us-cbp.github.io/design-system/?path=/story/introduction--introduction",
   sx: {"margin-bottom":"var(--cbp-space-1x)"}
 };
@@ -446,7 +401,10 @@ InteractiveRadioList.argTypes = {
   disabled: {
     control: "boolean",
   },
-  actionLayout: {
+  actionsLayout: {
+    control: false
+  },
+  variant:{
     control: false
   }
 };

--- a/packages/web-components/src/components/cbp-card/cbp-card.tsx
+++ b/packages/web-components/src/components/cbp-card/cbp-card.tsx
@@ -6,7 +6,7 @@ import { setCSSProps } from '../../utils/utils';
  * 
  * @slot - The default slot contains the body of the card.
  * @slot cbp-card-title - Contains the card title, if present.
- * @slot cbp-card-actions - Contains the links/buttons for decision cards.
+ * @slot cbp-card-actions - Contains the links/buttons for cards.
  */
 @Component({
   tag: 'cbp-card',
@@ -19,7 +19,7 @@ export class CbpCard {
   @Prop({ reflect: true }) color: "info" | "success" | "warning" | "danger";
   
   /** Specifies optional variants with difference from the default card. */
-  @Prop({ reflect: true }) variant: "banner" | "decision" | "flag";
+  @Prop({ reflect: true }) variant: "banner" | "flag";
 
   /** Specifies the interactivity of the card. */
   @Prop({ reflect: true}) interactive: "clickable" | "selectable" | "radio";


### PR DESCRIPTION
* confirm story prop for stretch is populating example correctly
*move color control to all cards stories
*consolidate story templates to reuse general template where possible and add action button templates as story control to applicable stories
