### PR TITLE
Deprecate universal header style and replace with flex component

### DIFF
--- a/packages/web-components/src/components/cbp-universal-header/cbp-universal-header.scss
+++ b/packages/web-components/src/components/cbp-universal-header/cbp-universal-header.scss
@@ -22,7 +22,7 @@ cbp-universal-header {
     }
   }
 
-  // Tech Debt: this should probably be replaced with cbp-flex in the story to achieve this functionality explicitly
+  // Deprecated: (6/2/2026) leaving to not break styling for apps
   .cbp-universal-header__content {
     ul,
     ol {

--- a/packages/web-components/src/components/cbp-universal-header/cbp-universal-header.stories.tsx
+++ b/packages/web-components/src/components/cbp-universal-header/cbp-universal-header.stories.tsx
@@ -32,6 +32,60 @@ const UniversalHeaderTemplate = ({ logoSrcLg, logoSrcSm, username, isLoggedIn })
       ${logoSrcLg ? `logo-src-lg=${logoSrcLg}` : ''}
       ${logoSrcSm ? `logo-src-sm=${logoSrcSm}` : ''}
     >
+      <cbp-flex
+        gap="var(--cbp-space-4x)"
+      >
+      ${isLoggedIn ? `
+        <cbp-flex-item>
+          <cbp-button tag="a" href="#" color="secondary" fill="ghost" context="dark-always">
+            <cbp-icon name="book"></cbp-icon>
+            <cbp-hide visually-hide-at="max-width: 64em">
+              App Directory
+            </cbp-hide>
+          </cbp-button>
+        </cbp-flex-item>
+
+        <cbp-flex-item>
+          <cbp-button color="secondary" fill="ghost" context="dark-always">
+            <cbp-icon name="comment"></cbp-icon>  
+            <cbp-hide visually-hide-at="max-width: 64em">
+              Feedback
+            </cbp-hide>
+          </cbp-button>
+        </cbp-flex-item>
+
+        <cbp-flex-item>
+          <cbp-button
+            color="secondary"
+            fill="ghost"
+            context="dark-always"
+          >
+            <cbp-icon name="user"></cbp-icon>
+            <cbp-hide visually-hide-at="max-width: 64em">
+              ${username}
+            </cbp-hide>
+          </cbp-button>
+        </cbp-flex-item>
+      ` : `
+        <cbp-flex-item>
+          <cbp-button tag="a" href="#" color="secondary" fill="ghost" context="dark-always">
+          <cbp-icon name="right-to-bracket"></cbp-icon>
+          Login
+          </cbp-button>
+        </cbp-flex-item>
+        `
+      }
+      </cbp-flex>
+    </cbp-universal-header>
+  `;
+
+  /***
+   * Deprecated code for Universal header using UL/LI instead of cbp-flex/cbp-flex-item
+   * return `
+    <cbp-universal-header
+      ${logoSrcLg ? `logo-src-lg=${logoSrcLg}` : ''}
+      ${logoSrcSm ? `logo-src-sm=${logoSrcSm}` : ''}
+    >
       <ul>
       ${isLoggedIn ? `
         <li>
@@ -76,6 +130,7 @@ const UniversalHeaderTemplate = ({ logoSrcLg, logoSrcSm, username, isLoggedIn })
       </ul>
     </cbp-universal-header>
   `;
+   */
 };
 
 export const UniversalHeader = UniversalHeaderTemplate.bind({});

--- a/packages/web-components/src/stories/Archetype_Passenger.stories.tsx
+++ b/packages/web-components/src/stories/Archetype_Passenger.stories.tsx
@@ -941,28 +941,29 @@ const InternalTemplate = ({ isLoggedIn, username, hashid, navItems, search, sear
       logo-src-lg="./assets/images/cbp-header-logo.svg"
       logo-src-sm="./assets/images/cbp-seal.svg"
     >
-      <ul>
+      <cbp-flex
+        gap="var(--cbp-space-4x)"
+      >
       ${
         isLoggedIn
           ? `
-        <li>
+        <cbp-flex-item>
           <cbp-button color="secondary" fill="ghost" context="dark-always">
             <cbp-icon name="book"></cbp-icon>
             <cbp-hide visually-hide-at="max-width: 64em">
                 App Directory
               </cbp-hide>
           </cbp-button>
-        </li>
-        <li>
+        </cbp-flex-item>
+        <cbp-flex-item>
           <cbp-button color="secondary" fill="ghost" context="dark-always">
             <cbp-icon name="comment"></cbp-icon>  
             <cbp-hide visually-hide-at="max-width: 64em">
               Feedback
             </cbp-hide>
           </cbp-button>
-        </li>
-        <li>
-
+        </cbp-flex-item>
+        <cbp-flex-item>
           <cbp-button 
           type="button"
           color="secondary" 
@@ -976,17 +977,17 @@ const InternalTemplate = ({ isLoggedIn, username, hashid, navItems, search, sear
               ${hashid}
             </cbp-hide>
           </cbp-button>
-        </li>
+        </cbp-flex-item>
         `
           : `
-        <li>
+        <cbp-flex-item>
           <cbp-button tag="a" href="#" color="secondary" fill="ghost" context="dark-always">
             <cbp-icon name="right-to-bracket"></cbp-icon>Login
           </cbp-button>
-        </li>
+        </cbp-flex-item>
         `
       }
-      </ul>
+      </cbp-flex>
     </cbp-universal-header>
 
     <cbp-app-header

--- a/packages/web-components/src/stories/Search_Result.stories.tsx
+++ b/packages/web-components/src/stories/Search_Result.stories.tsx
@@ -672,38 +672,40 @@ const searchResultsTemplate = ({isLoggedIn, username, hashid, navItems, searchTe
         logo-src-lg="./assets/images/cbp-header-logo.svg"
         logo-src-sm="./assets/images/cbp-seal.svg"
       >
-        <ul>
+        <cbp-flex
+          gap="var(--cbp-space-4x)"
+        >
         ${ isLoggedIn
           ? `
-          <li>
+          <cbp-flex-item>
             <cbp-button tag="a" href="#" color="secondary" fill="ghost" context="dark-always">
               <cbp-icon name="book"></cbp-icon>
               <cbp-hide visually-hide-at="max-width: 64em">App Directory</cbp-hide>
             </cbp-button>
-          </li>
-          <li>
+          </cbp-flex-item>
+          <cbp-flex-item>
             <cbp-button color="secondary" fill="ghost" context="dark-always">
               <cbp-icon name="comment"></cbp-icon>  
               <cbp-hide visually-hide-at="max-width: 64em">Feedback</cbp-hide>
             </cbp-button>
-          </li>
-          <li>
+          </cbp-flex-item>
+          <cbp-flex-item>
             <cbp-button color="secondary" fill="ghost" context="dark-always" controls="userPref" target-prop="open">
               <cbp-icon name="user"></cbp-icon>
               <cbp-hide visually-hide-at="max-width: 64em">${hashid}</cbp-hide>
             </cbp-button>
-          </li>
+          </cbp-flex-item>
           `
           : `
-          <li>
+          <cbp-flex-item>
             <cbp-button tag="a" href="#" color="secondary" fill="ghost" context="dark-always">
             <cbp-icon name="right-to-bracket"></cbp-icon>
             Login
             </cbp-button>
-          </li>
+          </cbp-flex-item>
           `
         }
-        </ul>
+        </cbp-flex>
       </cbp-universal-header>
 
       <cbp-app-header

--- a/packages/web-components/src/stories/templates/templates.stories.tsx
+++ b/packages/web-components/src/stories/templates/templates.stories.tsx
@@ -122,38 +122,40 @@ const InternalTemplate: any = ({ isLoggedIn, username, hashid, navItems, search,
         logo-src-lg="./assets/images/cbp-header-logo.svg"
         logo-src-sm="./assets/images/cbp-seal.svg"
       >
-        <ul>
+        <cbp-flex
+          gap="var(--cbp-space-4x)"
+        >
         ${ isLoggedIn
           ? `
-          <li>
+          <cbp-flex-item>
             <cbp-button tag="a" href="#" color="secondary" fill="ghost" context="dark-always">
               <cbp-icon name="book"></cbp-icon>
               <cbp-hide visually-hide-at="max-width: 64em">App Directory</cbp-hide>
             </cbp-button>
-          </li>
-          <li>
+          </cbp-flex-item>
+          <cbp-flex-item>
             <cbp-button color="secondary" fill="ghost" context="dark-always">
               <cbp-icon name="comment"></cbp-icon>  
               <cbp-hide visually-hide-at="max-width: 64em">Feedback</cbp-hide>
             </cbp-button>
-          </li>
-          <li>
+          </cbp-flex-item>
+          <cbp-flex-item>
             <cbp-button color="secondary" fill="ghost" context="dark-always" controls="userPref" target-prop="open">
               <cbp-icon name="user"></cbp-icon>
               <cbp-hide visually-hide-at="max-width: 64em">${hashid}</cbp-hide>
             </cbp-button>
-          </li>
+          </cbp-flex-item>
           `
           : `
-          <li>
+          <cbp-flex-item>
             <cbp-button tag="a" href="#" color="secondary" fill="ghost" context="dark-always">
             <cbp-icon name="right-to-bracket"></cbp-icon>
             Login
             </cbp-button>
-          </li>
+          </cbp-flex-item>
           `
         }
-        </ul>
+        </cbp-flex>
       </cbp-universal-header>
 
       <cbp-app-header
@@ -237,38 +239,40 @@ const Internal2ColumnTemplate: any = ({ isLoggedIn, username, hashid, navItems, 
         logo-src-lg="./assets/images/cbp-header-logo.svg"
         logo-src-sm="./assets/images/cbp-seal.svg"
       >
-        <ul>
+        <cbp-flex
+          gap="var(--cbp-space-4x)"
+        >
         ${ isLoggedIn
           ? `
-          <li>
+          <cbp-flex-item>
             <cbp-button tag="a" href="#" color="secondary" fill="ghost" context="dark-always">
               <cbp-icon name="book"></cbp-icon>
               <cbp-hide visually-hide-at="max-width:64em">App Directory</cbp-hide>
             </cbp-button>
-          </li>
-          <li>
+          </cbp-flex-item>
+          <cbp-flex-item>
             <cbp-button color="secondary" fill="ghost" context="dark-always">
               <cbp-icon name="comment"></cbp-icon>  
               <cbp-hide visually-hide-at="max-width:64em">Feedback</cbp-hide>
             </cbp-button>
-          </li>
-          <li>
+          </cbp-flex-item>
+          <cbp-flex-item>
             <cbp-button color="secondary" fill="ghost" context="dark-always" controls="userPref" target-prop="open">
               <cbp-icon name="user"></cbp-icon>
               <cbp-hide visually-hide-at="max-width:64em">${hashid}</cbp-hide>
             </cbp-button>
-          </li>
+          </cbp-flex-item>
           `
           : `
-          <li>
+          <cbp-flex-item>
             <cbp-button tag="a" href="#" color="secondary" fill="ghost" context="dark-always">
             <cbp-icon name="right-to-bracket"></cbp-icon>
             Login
             </cbp-button>
-          </li>
+          </cbp-flex-item>
           `
         }
-        </ul>
+        </cbp-flex>
       </cbp-universal-header>
 
       <cbp-app-header
@@ -627,38 +631,40 @@ const InternalCardsLayoutTemplate: any = ({ isLoggedIn, username, hashid, navIte
         logo-src-lg="./assets/images/cbp-header-logo.svg"
         logo-src-sm="./assets/images/cbp-seal.svg"
       >
-        <ul>
+        <cbp-flex
+          gap="var(--cbp-space-4x)"
+        >
         ${ isLoggedIn
           ? `
-          <li>
+          <cbp-flex-item>
             <cbp-button tag="a" href="#" color="secondary" fill="ghost" context="dark-always">
               <cbp-icon name="book"></cbp-icon>
               <cbp-hide visually-hide-at="max-width:64em">App Directory</cbp-hide>
             </cbp-button>
-          </li>
-          <li>
+          </cbp-flex-item>
+          <cbp-flex-item>
             <cbp-button color="secondary" fill="ghost" context="dark-always">
               <cbp-icon name="comment"></cbp-icon>  
               <cbp-hide visually-hide-at="max-width:64em">Feedback</cbp-hide>
             </cbp-button>
-          </li>
-          <li>
+          </cbp-flex-item>
+          <cbp-flex-item>
             <cbp-button color="secondary" fill="ghost" context="dark-always" controls="userPref" target-prop="open">
               <cbp-icon name="user"></cbp-icon>
               <cbp-hide visually-hide-at="max-width:64em">${hashid}</cbp-hide>
             </cbp-button>
-          </li>
+          </cbp-flex-item>
           `
           : `
-          <li>
+          <cbp-flex-item>
             <cbp-button tag="a" href="#" color="secondary" fill="ghost" context="dark-always">
             <cbp-icon name="right-to-bracket"></cbp-icon>
             Login
             </cbp-button>
-          </li>
+          </cbp-flex-item>
           `
         }
-        </ul>
+        </cbp-flex>
       </cbp-universal-header>
 
       <cbp-app-header


### PR DESCRIPTION
Address techdebt in cbp-universal-header.scss
*update stories, templates, and archetypes to use cbp-flex and cbp-flex-item instead of ul and li
*updating note for deprecating the styles w/ date of change