### PR TITLE
Bugfix/icon alignment

### DIFF
--- a/packages/web-components/CHANGELOG.md
+++ b/packages/web-components/CHANGELOG.md
@@ -4,6 +4,13 @@ This CHANGELOG.md tracks the updates to the web components package of the CBP de
 
 The React components are wrappers generated from this package and will share the same changes. Projects using React 19 may use the native web components without React wrappers.
 
+## [unpublished] TBD
+
+* Imported and integrated the Float-UI library into `cbp-menu` to handle positioning and repositioning fallbacks when positioning goes off-screen.
+* BREAKING: Updated `cbp-icon` underlying CSS to address vertical alignment inconsistencies across several patterns.
+  * Some patterns, such as panel, drawer, and dialog were updated to use flex within the heading, which eliminates the need to apply a margin to the icon directly (when present).
+  * All icons in components and stories have been confirmed, but this change could potentially result in misaligned icons in custom code.
+
 ## [0.9.0-beta.1] 06-29-2026
 
 With significant foundational updates, including tokens and icons, this release marks the first official BETA release as we prepare for a full production-ready release.

--- a/packages/web-components/src/components/cbp-app-header/cbp-app-header.stories.tsx
+++ b/packages/web-components/src/components/cbp-app-header/cbp-app-header.stories.tsx
@@ -117,7 +117,7 @@ function renderDrawer(items, drawerId, store){
             variant="heading-lg"
             id="panelheader"
           >
-            Application Name
+            ${items?.[0]?.label}
           </cbp-typography>
 
           <cbp-form-field 

--- a/packages/web-components/src/components/cbp-badge/cbp-badge.scss
+++ b/packages/web-components/src/components/cbp-badge/cbp-badge.scss
@@ -19,6 +19,7 @@
 
 cbp-badge {
   display: inline-block;
+  flex-shrink: 0; // defensively prevent flex context from affecting the shape of the badge
   width: var(--cbp-space-6x);
   height: var(--cbp-space-6x);
   color: var(--cbp-badge-color);

--- a/packages/web-components/src/components/cbp-button/cbp-button.scss
+++ b/packages/web-components/src/components/cbp-button/cbp-button.scss
@@ -163,6 +163,15 @@ cbp-button {
       --cbp-button-color-bg: var(--cbp-button-color-bg-active);
       --cbp-button-color-border: var(--cbp-button-color-border-active);
     }
+
+    cbp-icon {
+      display: inline-block; // remove the nested flex context, which causes issues
+
+      svg {
+        vertical-align: text-top; // renders about 1px higher than middle and looks better on buttons, which have no descenders in ALL CAPS, if sized similarly
+      }
+    }
+
   }
 
   // For each button fill/color, only override what needs to change
@@ -427,6 +436,10 @@ cbp-button {
     button, a {
       padding: unset;
       letter-spacing: unset;
+
+      cbp-icon svg {
+        vertical-align: middle;
+      }
     }
   }
 

--- a/packages/web-components/src/components/cbp-button/cbp-button.scss
+++ b/packages/web-components/src/components/cbp-button/cbp-button.scss
@@ -163,7 +163,10 @@ cbp-button {
       --cbp-button-color-bg: var(--cbp-button-color-bg-active);
       --cbp-button-color-border: var(--cbp-button-color-border-active);
     }
+  }
 
+
+  &:not([variant=square]):not([variant=circle]) {
     cbp-icon {
       display: inline-block; // remove the nested flex context, which causes issues
 
@@ -171,8 +174,8 @@ cbp-button {
         vertical-align: text-top; // renders about 1px higher than middle and looks better on buttons, which have no descenders in ALL CAPS, if sized similarly
       }
     }
-
   }
+
 
   // For each button fill/color, only override what needs to change
   // e.g., focus/active states are the same across the board (except active for ghost buttons??)
@@ -429,29 +432,19 @@ cbp-button {
     }
   }
 
-  &[variant=square] {
-      --cbp-button-height: 2.25rem;
-      --cbp-button-width: var(--cbp-button-height); 
+  &[variant=square],
+  &[variant=circle] {
+    --cbp-button-height: 2.25rem;
+    --cbp-button-width: var(--cbp-button-height); 
     
     button, a {
       padding: unset;
       letter-spacing: unset;
-
-      cbp-icon svg {
-        vertical-align: middle;
-      }
     }
   }
 
   &[variant=circle] {
-      --cbp-button-height: 2.25rem; 
-      --cbp-button-width: var(--cbp-button-height); 
-      --cbp-button-border-radius: var(--cbp-border-radius-circle);
-    
-      button, a {
-      padding: unset;
-      letter-spacing: unset;
-    }
+    --cbp-button-border-radius: var(--cbp-border-radius-circle);
   }
 
   &[variant=cta] {

--- a/packages/web-components/src/components/cbp-card/cbp-card.scss
+++ b/packages/web-components/src/components/cbp-card/cbp-card.scss
@@ -142,8 +142,11 @@ cbp-card {
     font-size: var(--cbp-font-size-heading-lg);
     line-height: var(--cbp-line-height-sm);
     
-     > * {
+    // Targets the tag rendered by slotted cbp-typography (including a deeper one used in interactive radio cards)
+    > *,
+    cbp-typography > * {
       display: flex;
+      align-items: center;
       gap: var(--cbp-space-2x);
       color: var(--cbp-card-color-text);
     }

--- a/packages/web-components/src/components/cbp-card/cbp-card.scss
+++ b/packages/web-components/src/components/cbp-card/cbp-card.scss
@@ -360,9 +360,9 @@ cbp-card {
   }
 
   //interactive cards
-  &[interactive="clickable"],
-  &[interactive="selectable"],
-  &[interactive="radio"]{
+  &[interactive=clickable],
+  &[interactive=selectable],
+  &[interactive=radio]{
     --cbp-checkbox-min-height: var(--cbp-space-6x); //adjust spacing for checkbox in title for selectable variant
     --cbp-checkbox-color-border: var(--cbp-color-interactive-secondary-light);
     --cbp-checkbox-color-border-dark: var(--cbp-color-interactive-secondary-light);
@@ -377,6 +377,7 @@ cbp-card {
 
     --cbp-radio-color-bg: transparent;
     --cbp-radio-color-bg-dark: var(--cbp-color-gray-cool-70);
+    --cbp-radio-min-height: 0;
 
     a{
       color: var(--cbp-card-color-text); 

--- a/packages/web-components/src/components/cbp-card/cbp-card.stories.tsx
+++ b/packages/web-components/src/components/cbp-card/cbp-card.stories.tsx
@@ -209,7 +209,7 @@ const InteractiveTemplate = ({ title, color, disabled, bodyText, withIcon, inter
 };
 
 
-export const GeneralCard = GeneralTemplate.bind({});
+export const GeneralCard: any = GeneralTemplate.bind({});
 GeneralCard.args = {
   title: "Card Title",
   headingId: "card-heading",
@@ -234,7 +234,7 @@ GeneralCard.args = {
   },
 };
 
-export const BannerCard = GeneralTemplate.bind({});
+export const BannerCard: any = GeneralTemplate.bind({});
 BannerCard.args = {
   variant: "banner",
   title: "Banner Card Title",
@@ -260,7 +260,7 @@ BannerCard.args = {
   }
 };
 
-export const FlagCard = FlagTemplate.bind({});
+export const FlagCard: any = FlagTemplate.bind({});
 FlagCard.args = {
   title: "Card Title",
   bodyText: "Here is an example of some body text for this purely informational card",
@@ -275,7 +275,7 @@ FlagCard.argTypes ={
   }
 }
 
-export const InteractiveCard = InteractiveTemplate.bind({});
+export const InteractiveCard: any = InteractiveTemplate.bind({});
 InteractiveCard.args = {
   title: "Banner Card Title",
   bodyText: "Here is an example of some supplementary text for this purely informational card",
@@ -304,8 +304,7 @@ InteractiveCard.argTypes = {
   }
 };
 
-const InteractiveRadioListTemplate = ({ title, color, disabled, bodyText, withIcon, href, context, sx }) => {
-
+const InteractiveRadioListTemplate: any = ({ title, color, disabled, bodyText, withIcon, href, context, sx }) => {
   return ` 
     <cbp-form-field group
       label="Interactive Card Radio List"
@@ -382,7 +381,7 @@ const InteractiveRadioListTemplate = ({ title, color, disabled, bodyText, withIc
 };
 
 
-export const InteractiveRadioList = InteractiveRadioListTemplate.bind({});
+export const InteractiveRadioList: any = InteractiveRadioListTemplate.bind({});
 InteractiveRadioList.args = {
   title: "Banner Card Title",
   bodyText: "Here is an example of some supplementary text for this purely informational card",

--- a/packages/web-components/src/components/cbp-dialog/cbp-dialog.scss
+++ b/packages/web-components/src/components/cbp-dialog/cbp-dialog.scss
@@ -56,8 +56,6 @@ cbp-dialog {
 
   div[role=dialog] {
     opacity: 1;
-    display: flex;
-    flex-direction: column;
     position: fixed;
     overflow-y: auto;
     z-index: var(--cbp-z-index-level-top);
@@ -65,6 +63,17 @@ cbp-dialog {
     max-height: 90vh;
     box-shadow: var(--cbp-dialog-shadow);
     border-radius: var(--cbp-dialog-border-radius);
+
+    [slot=cbp-dialog-header] {
+      display: block;
+      
+      // Targets the tag rendered by slotted cbp-typography
+      > * {
+        display: flex;
+        align-items: center;
+        gap: var(--cbp-space-2x);
+      }
+    }
 
     .cbp-dialog-body {
       color: var(--cbp-dialog-color);

--- a/packages/web-components/src/components/cbp-dialog/cbp-dialog.stories.tsx
+++ b/packages/web-components/src/components/cbp-dialog/cbp-dialog.stories.tsx
@@ -118,8 +118,7 @@ const Template = ({ title, headingId, content, color, open, width, height, uid, 
             name="user"
             size="var(--cbp-space-5x)"
             ></cbp-icon>`
-        : ''}
-        ${title}
+        : ''}${title}
       </cbp-typography>` : ''}
 
       ${ content!='' ? `

--- a/packages/web-components/src/components/cbp-dialog/cbp-dialog.tsx
+++ b/packages/web-components/src/components/cbp-dialog/cbp-dialog.tsx
@@ -2,7 +2,7 @@ import { Component, Prop, Element, Method, Event, EventEmitter, Watch, Host, h }
 import { setCSSProps, getFocusableElements } from '../../utils/utils';
 
 /**
- * The Dialog component represents a dialog overlaid on top of the web page, which can be used similar 
+ * The Dialog component represents a dialog overlaid on top of the web page, which can be used similarly 
  * to an alert/confirm dialog or contain a small form.
  * 
  * @slot - The body content of the dialog goes in the default slot.

--- a/packages/web-components/src/components/cbp-drawer/cbp-drawer.stories.tsx
+++ b/packages/web-components/src/components/cbp-drawer/cbp-drawer.stories.tsx
@@ -22,6 +22,14 @@ export default {
       description: 'Accessibility text is required to label the drawer (dialog) and is applied as an `aria-label`.',
       control: 'text',
     },
+    panelHeading: {
+      name: 'Panel Heading (slotted)',
+      control: 'text',
+    },
+    panelContent: {
+      name: 'Panel Content (slotted)',
+      control: 'text',
+    },
     withIcon: {
       control: 'boolean',
     },
@@ -36,7 +44,7 @@ export default {
   },
 };
 
-const Template = ({ position, withIcon, open, persistAt, uid, accessibilityText, context, sx }) => {
+const Template = ({ position, open, persistAt, uid, accessibilityText, withIcon, panelHeading, panelContent, context, sx }) => {
   return `
     ${persistAt ? `<cbp-hide hide-at="${persistAt}">` : ''}
       <cbp-button
@@ -67,10 +75,11 @@ const Template = ({ position, withIcon, open, persistAt, uid, accessibilityText,
           tag="h3"
           variant="heading-lg"
         >
-          ${withIcon ? `<cbp-icon name='triangle-exclamation'></cbp-icon>` : ''}
-          Drawer Header
+          ${withIcon ? `<cbp-icon name='triangle-exclamation'></cbp-icon>` : ''}${panelHeading}
         </cbp-typography>
-        <p>Sidebar Content</p>
+
+        <p>${panelContent}</p>
+
       </cbp-panel>
     </cbp-drawer>
   `;
@@ -80,11 +89,13 @@ export const Drawer: any = Template.bind({});
 Drawer.args = {
   position: 'left',
   uid: 'drawer',
-  accessibilityText: 'Drawer Header'
+  accessibilityText: 'Drawer Header',
+  panelHeading: 'Drawer Header',
+  panelContent: 'Drawer Content'
 };
 
 
-const UserPreferencesTemplate = ({ position, open, persistAt, uid, accessibilityText, withIcon, context}) => {
+const UserPreferencesTemplate = ({ position, open, persistAt, uid, accessibilityText, panelHeading, panelContent, withIcon, context}) => {
   return `
     <cbp-button
       type="button"
@@ -120,11 +131,11 @@ const UserPreferencesTemplate = ({ position, open, persistAt, uid, accessibility
           tag="h3"
           variant="heading-lg"
         >
-        
-          ${withIcon ? `<cbp-icon name='user'></cbp-icon>` : ''}
-          User Preferences
+          ${withIcon ? `<cbp-icon name='user'></cbp-icon>` : ''}${panelHeading}
         </cbp-typography>
-        <p>Drawer Content</p>
+
+        <p>${panelContent}</p>
+
       </cbp-panel>
     </cbp-drawer>
   `;
@@ -135,5 +146,7 @@ UserPreferences.args = {
   position: 'right',
   uid: 'drawer',
   context: 'dark-always',
-  accessibilityText: 'User Preferences'
+  accessibilityText: 'User Preferences',
+  panelHeading: 'User Preferences',
+  panelContent: 'Drawer Content'
 };

--- a/packages/web-components/src/components/cbp-drawer/cbp-drawer.stories.tsx
+++ b/packages/web-components/src/components/cbp-drawer/cbp-drawer.stories.tsx
@@ -76,7 +76,7 @@ const Template = ({ position, withIcon, open, persistAt, uid, accessibilityText,
   `;
 };
 
-export const Drawer = Template.bind({});
+export const Drawer: any = Template.bind({});
 Drawer.args = {
   position: 'left',
   uid: 'drawer',
@@ -130,7 +130,7 @@ const UserPreferencesTemplate = ({ position, open, persistAt, uid, accessibility
   `;
 };
 
-export const UserPreferences = UserPreferencesTemplate.bind({});
+export const UserPreferences: any = UserPreferencesTemplate.bind({});
 UserPreferences.args = {
   position: 'right',
   uid: 'drawer',

--- a/packages/web-components/src/components/cbp-dropdown/cbp-dropdown.scss
+++ b/packages/web-components/src/components/cbp-dropdown/cbp-dropdown.scss
@@ -45,13 +45,13 @@
   --cbp-dropdown-attached-button-start-width: 0px;
   --cbp-dropdown-attached-button-end-width: 0px;
   --cbp-dropdown-multiselect-indent: 0px; // override for combobox
-
+  
+  
+  // icon => chevron-down from font-awesome 7.2.0
   // On dark "button" background
-  //icon => chevron-down from font-awesome 7.2.0
-  --cbp-dropdown-chevron-down: url('data:image/svg+xml,<svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" viewBox="0 0 640 640" fill="%23fcfcfc"><path d="M297.4 470.6C309.9 483.1 330.2 483.1 342.7 470.6L534.7 278.6C547.2 266.1 547.2 245.8 534.7 233.3C522.2 220.8 501.9 220.8 489.4 233.3L320 402.7L150.6 233.4C138.1 220.9 117.8 220.9 105.3 233.4C92.8 245.9 92.8 266.2 105.3 278.7L297.3 470.7z"/></svg>');
-  --cbp-dropdown-chevron-down-dark: url('data:image/svg+xml,<svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" viewBox="0 0 640 640" fill="%231b1b1b"><path d="M297.4 470.6C309.9 483.1 330.2 483.1 342.7 470.6L534.7 278.6C547.2 266.1 547.2 245.8 534.7 233.3C522.2 220.8 501.9 220.8 489.4 233.3L320 402.7L150.6 233.4C138.1 220.9 117.8 220.9 105.3 233.4C92.8 245.9 92.8 266.2 105.3 278.7L297.3 470.7z"/></svg>');
+  --cbp-dropdown-chevron-down: url('data:image/svg+xml,<svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" viewBox="0 0 448 512" fill="%23fcfcfc"><path d="M201.4 406.6c12.5 12.5 32.8 12.5 45.3 0l192-192c12.5-12.5 12.5-32.8 0-45.3s-32.8-12.5-45.3 0L224 338.7 54.6 169.4c-12.5-12.5-32.8-12.5-45.3 0s-12.5 32.8 0 45.3l192 192z"/></svg>');
+  --cbp-dropdown-chevron-down-dark: url('data:image/svg+xml,<svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" viewBox="0 0 448 512" fill="%231b1b1b"><path d="M201.4 406.6c12.5 12.5 32.8 12.5 45.3 0l192-192c12.5-12.5 12.5-32.8 0-45.3s-32.8-12.5-45.3 0L224 338.7 54.6 169.4c-12.5-12.5-32.8-12.5-45.3 0s-12.5 32.8 0 45.3l192 192z"/></svg>');
 }
-
 
 /* 
  * Dark Mode - display dark design based on mode or context
@@ -76,9 +76,9 @@ cbp-dropdown {
   // Adjustments for attached buttons e.g., pagination
   &:has([slot="cbp-dropdown-attached-button-start"]),
   &:has([slot="cbp-dropdown-attached-button-end"]) {
-    //icon => caret-down from font-awesome 7.2.0
-    --cbp-dropdown-chevron-down: url('data:image/svg+xml,<svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" viewBox="0 0 640 640" fill="%231b1b1b"><path d="M300.3 440.8C312.9 451 331.4 450.3 343.1 438.6L471.1 310.6C480.3 301.4 483 287.7 478 275.7C473 263.7 461.4 256 448.5 256L192.5 256C179.6 256 167.9 263.8 162.9 275.8C157.9 287.8 160.7 301.5 169.9 310.6L297.9 438.6L300.3 440.8z"/></svg>');
-    --cbp-dropdown-chevron-down-dark: url('data:image/svg+xml,<svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" viewBox="0 0 640 640" fill="%23fcfcfc"><path d="M300.3 440.8C312.9 451 331.4 450.3 343.1 438.6L471.1 310.6C480.3 301.4 483 287.7 478 275.7C473 263.7 461.4 256 448.5 256L192.5 256C179.6 256 167.9 263.8 162.9 275.8C157.9 287.8 160.7 301.5 169.9 310.6L297.9 438.6L300.3 440.8z"/></svg>');
+    // icon => caret-down from font-awesome 7.2.0
+    --cbp-dropdown-chevron-down: url('data:image/svg+xml,<svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" viewBox="0 0 320 512" fill="%231b1b1b"><path d="M140.3 376.8c12.6 10.2 31.1 9.5 42.8-2.2l128-128c9.2-9.2 11.9-22.9 6.9-34.9S301.4 192 288.5 192l-256 0c-12.9 0-24.6 7.8-29.6 19.8S.7 237.5 9.9 246.6l128 128 2.4 2.2z"/></svg>');
+    --cbp-dropdown-chevron-down-dark: url('data:image/svg+xml,<svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" viewBox="0 0 320 512" fill="%23fcfcfc"><path d="M140.3 376.8c12.6 10.2 31.1 9.5 42.8-2.2l128-128c9.2-9.2 11.9-22.9 6.9-34.9S301.4 192 288.5 192l-256 0c-12.9 0-24.6 7.8-29.6 19.8S.7 237.5 9.9 246.6l128 128 2.4 2.2z"/></svg>');
     
     button.cbp-custom-form-control {
       --cbp-dropdown-chevron: var(--cbp-dropdown-chevron-down);

--- a/packages/web-components/src/components/cbp-dropdown/cbp-dropdown.scss
+++ b/packages/web-components/src/components/cbp-dropdown/cbp-dropdown.scss
@@ -189,6 +189,7 @@ cbp-dropdown {
 
   .cbp-dropdown-multiselect-counter {
     display: inline-block;
+    flex-shrink: 0; // defensively protect against flex shrinkage
     color: var(--cbp-dropdown-menu-color-counter);
     background-color: var(--cbp-dropdown-menu-color-bg-counter);
     font-size: var(--cbp-font-size-subhead);

--- a/packages/web-components/src/components/cbp-expand/cbp-expand.scss
+++ b/packages/web-components/src/components/cbp-expand/cbp-expand.scss
@@ -66,7 +66,6 @@ cbp-expand {
   }
   
   .cbp-expand--control {
-    font-size: var(--cbp-expand-control-font-size);
     cursor: pointer;
 
     .cbp-expand--toggle {

--- a/packages/web-components/src/components/cbp-expand/cbp-expand.tsx
+++ b/packages/web-components/src/components/cbp-expand/cbp-expand.tsx
@@ -83,6 +83,7 @@ export class CbpExpand {
               class="cbp-expand--toggle"
               fill="ghost"
               color="secondary"
+              variant="square"
               width="var(--cbp-space-6x)"
               height="var(--cbp-space-6x)"
               context={this.context}

--- a/packages/web-components/src/components/cbp-file-input/cbp-file-input.scss
+++ b/packages/web-components/src/components/cbp-file-input/cbp-file-input.scss
@@ -255,7 +255,6 @@ cbp-file-input {
         --cbp-button-min-height: var(--cbp-space-7x);
         --cbp-button-width: var(--cbp-space-7x);
         --cbp-button-height: var(--cbp-space-7x);
-        --cbp-button-border-radius: var(--cbp-border-radius-circle);
         --cbp-button-color-hover: var(--cbp-color-text-lightest);
         --cbp-button-color-hover-dark: var(--cbp-color-text-darkest);
         --cbp-button-color-bg-hover: var(--cbp-color-interactive-secondary-darker);
@@ -265,7 +264,6 @@ cbp-file-input {
       }
     }
   }
-
 }
 
 // Hide the left icon if needed

--- a/packages/web-components/src/components/cbp-file-input/cbp-file-input.tsx
+++ b/packages/web-components/src/components/cbp-file-input/cbp-file-input.tsx
@@ -278,6 +278,7 @@ export class CbpFileInput {
                 <cbp-button
                   fill="ghost"
                   color="secondary"
+                  variant="circle"
                   value={`${index}`}
                   accessibilityText={ (this.files.length > 0 && this.multiple && !this.enhanced) ? 'Remove Files' : `Remove ${name}`}
                 >

--- a/packages/web-components/src/components/cbp-form-field/cbp-form-field.scss
+++ b/packages/web-components/src/components/cbp-form-field/cbp-form-field.scss
@@ -44,15 +44,10 @@
   --cbp-form-field-margin-bottom: var(--cbp-space-4x);
   --cbp-form-field-border-radius: var(--cbp-border-radius-soft);
 
-  // TechDebt: Ideally, it would be better if the icon could inherit the text color, but I can't seem to get this working so we have 2 copies with different colors
-  // On light bg
-  //--cbp-form-field-select-chevron: url('data:image/svg+xml,<svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" viewBox="0 0 512 512" fill="%231b1b1b"><path d="M233.4 406.6c12.5 12.5 32.8 12.5 45.3 0l192-192c12.5-12.5 12.5-32.8 0-45.3s-32.8-12.5-45.3 0L256 338.7 86.6 169.4c-12.5-12.5-32.8-12.5-45.3 0s-12.5 32.8 0 45.3l192 192z"/></svg>');
-  //--cbp-form-field-select-chevron-dark: url('data:image/svg+xml,<svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" viewBox="0 0 512 512" fill="%23fcfcfc"><path d="M233.4 406.6c12.5 12.5 32.8 12.5 45.3 0l192-192c12.5-12.5 12.5-32.8 0-45.3s-32.8-12.5-45.3 0L256 338.7 86.6 169.4c-12.5-12.5-32.8-12.5-45.3 0s-12.5 32.8 0 45.3l192 192z"/></svg>');
-  
-  // On dark "button" background
-  --cbp-form-field-select-chevron: url('data:image/svg+xml,<svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" viewBox="0 0 640 640" fill="%23fcfcfc"><path d="M297.4 470.6C309.9 483.1 330.2 483.1 342.7 470.6L534.7 278.6C547.2 266.1 547.2 245.8 534.7 233.3C522.2 220.8 501.9 220.8 489.4 233.3L320 402.7L150.6 233.4C138.1 220.9 117.8 220.9 105.3 233.4C92.8 245.9 92.8 266.2 105.3 278.7L297.3 470.7z"/></svg>');
-  --cbp-form-field-select-chevron-dark: url('data:image/svg+xml,<svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" viewBox="0 0 640 640" fill="%231b1b1b"><path d="M297.4 470.6C309.9 483.1 330.2 483.1 342.7 470.6L534.7 278.6C547.2 266.1 547.2 245.8 534.7 233.3C522.2 220.8 501.9 220.8 489.4 233.3L320 402.7L150.6 233.4C138.1 220.9 117.8 220.9 105.3 233.4C92.8 245.9 92.8 266.2 105.3 278.7L297.3 470.7z"/></svg>');
-
+  // icon => chevron-down from font-awesome 7.2.0
+  // light version on dark "button" background
+  --cbp-form-field-select-chevron: url('data:image/svg+xml,<svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" viewBox="0 0 448 512" fill="%23fcfcfc"><path d="M201.4 406.6c12.5 12.5 32.8 12.5 45.3 0l192-192c12.5-12.5 12.5-32.8 0-45.3s-32.8-12.5-45.3 0L224 338.7 54.6 169.4c-12.5-12.5-32.8-12.5-45.3 0s-12.5 32.8 0 45.3l192 192z"/></svg>');
+  --cbp-form-field-select-chevron-dark: url('data:image/svg+xml,<svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" viewBox="0 0 448 512" fill="%231b1b1b"><path d="M201.4 406.6c12.5 12.5 32.8 12.5 45.3 0l192-192c12.5-12.5 12.5-32.8 0-45.3s-32.8-12.5-45.3 0L224 338.7 54.6 169.4c-12.5-12.5-32.8-12.5-45.3 0s-12.5 32.8 0 45.3l192 192z"/></svg>');
 }
 
 // Displays dark design based on mode or context

--- a/packages/web-components/src/components/cbp-form-field/cbp-form-field.scss
+++ b/packages/web-components/src/components/cbp-form-field/cbp-form-field.scss
@@ -237,7 +237,7 @@ cbp-form-field {
   cbp-dropdown .cbp-custom-form-control {
     appearance: none;
     text-overflow: ellipsis;
-    padding-block: calc(var(--cbp-space-2x) - 2px) ; // Fixes Firefox vertical alignment
+    padding-block: calc(var(--cbp-space-2x) - var(--cbp-border-size-md)) ; // Fixes Firefox vertical alignment
 
     option {
       // only allows color and bgcolor to be changed in most browsers - these seem to be inherited in Chrome and Firefox already (not safari)

--- a/packages/web-components/src/components/cbp-icon/cbp-icon.scss
+++ b/packages/web-components/src/components/cbp-icon/cbp-icon.scss
@@ -19,7 +19,7 @@ cbp-icon {
   display: inline-flex;
   align-items: center;
   justify-content: center;
-  //vertical-align: top; // this improves placement next to plain text in most cases (e.g., cbp-usa-banner, cbp-loader, cbp-structured-list
+  vertical-align: text-top; // this improves placement (where flex isn't overridden) next to plain text in most cases (e.g., cbp-usa-banner, cbp-loader, cbp-structured-list); large circular loader is broken without.
 
   svg,
   // support as a wrapper for icons pulled in via external components (in the DOM or not) with greater specificity
@@ -28,6 +28,5 @@ cbp-icon {
     width: var(--cbp-icon-width);
     height: var(--cbp-icon-height);
     fill: var(--cbp-icon-color);
-    //vertical-align: top;
   }
 }

--- a/packages/web-components/src/components/cbp-icon/cbp-icon.scss
+++ b/packages/web-components/src/components/cbp-icon/cbp-icon.scss
@@ -14,10 +14,12 @@
 cbp-icon {
   --cbp-icon-width: var(--cbp-icon-size);
   --cbp-icon-height: var(--cbp-icon-size);
+  
+  // Use inline-flex as default and remove flex inside of link and button components
   display: inline-flex;
   align-items: center;
   justify-content: center;
-  vertical-align: text-top;
+  //vertical-align: middle;
 
   svg,
   // support as a wrapper for icons pulled in via external components (in the DOM or not) with greater specificity
@@ -26,6 +28,6 @@ cbp-icon {
     width: var(--cbp-icon-width);
     height: var(--cbp-icon-height);
     fill: var(--cbp-icon-color);
-    vertical-align: top;
+    //vertical-align: top;
   }
 }

--- a/packages/web-components/src/components/cbp-icon/cbp-icon.scss
+++ b/packages/web-components/src/components/cbp-icon/cbp-icon.scss
@@ -19,7 +19,7 @@ cbp-icon {
   display: inline-flex;
   align-items: center;
   justify-content: center;
-  //vertical-align: middle;
+  //vertical-align: top; // this improves placement next to plain text in most cases (e.g., cbp-usa-banner, cbp-loader, cbp-structured-list
 
   svg,
   // support as a wrapper for icons pulled in via external components (in the DOM or not) with greater specificity

--- a/packages/web-components/src/components/cbp-link/cbp-link.scss
+++ b/packages/web-components/src/components/cbp-link/cbp-link.scss
@@ -65,6 +65,15 @@ cbp-link {
     outline-color: var(--cbp-link-color-outline-focus);
     outline-offset: var(--cbp-space-1x);
 
+    cbp-icon {
+      display: inline-block; // remove the nested flex context, which causes issues
+
+      svg {
+        // renders about 1px higher than middle and looks better next to most text if sized similarly; without middle or text-top, affects text flow around it.
+        vertical-align: text-top;
+      }
+    }
+
     &:link {
       text-decoration: underline;
     }

--- a/packages/web-components/src/components/cbp-panel/cbp-panel.scss
+++ b/packages/web-components/src/components/cbp-panel/cbp-panel.scss
@@ -70,6 +70,17 @@ cbp-panel {
     cbp-icon {
       --cbp-icon-size: var(--cbp-space-6x);
     }
+
+    [slot=cbp-panel-header] {
+      display: block;
+      
+      // Targets the tag rendered by slotted cbp-typography
+      > * {
+        display: flex;
+        align-items: center;
+        gap: var(--cbp-space-3x);
+      }
+    }
   }
 
   .cbp-panel__content {

--- a/packages/web-components/src/components/cbp-panel/cbp-panel.stories.tsx
+++ b/packages/web-components/src/components/cbp-panel/cbp-panel.stories.tsx
@@ -62,8 +62,7 @@ const PanelTemplate = ({ role, headingLevel, header, headerId, content, ariaLabe
         variant="heading-lg"
         ${headerId ? `id="${headerId}"` : ''}
       >
-        ${showIcon ? `<cbp-icon name="star" sx='{"margin-right":"var(--cbp-space-4x)", "vertical-align":"text-top"}'></cbp-icon>` : ''}
-        ${header}
+        ${showIcon ? `<cbp-icon name="user" sx='{"margin-right":"var(--cbp-space-3x)"}'></cbp-icon>` : ''}${header}
       </cbp-typography>
 
       <p>${content}</p>

--- a/packages/web-components/src/components/cbp-panel/cbp-panel.stories.tsx
+++ b/packages/web-components/src/components/cbp-panel/cbp-panel.stories.tsx
@@ -62,7 +62,7 @@ const PanelTemplate = ({ role, headingLevel, header, headerId, content, ariaLabe
         variant="heading-lg"
         ${headerId ? `id="${headerId}"` : ''}
       >
-        ${showIcon ? `<cbp-icon name="user" sx='{"margin-right":"var(--cbp-space-3x)"}'></cbp-icon>` : ''}${header}
+        ${showIcon ? `<cbp-icon name="user"></cbp-icon>` : ''}${header}
       </cbp-typography>
 
       <p>${content}</p>

--- a/packages/web-components/src/components/cbp-panel/cbp-panel.stories.tsx
+++ b/packages/web-components/src/components/cbp-panel/cbp-panel.stories.tsx
@@ -8,7 +8,7 @@ export default {
       options: ['h2', 'h3', 'h4', 'h5', 'h6'],
     },
     header: {
-      name: 'header (slotted)',
+      name: 'Heading (slotted)',
       description: 'Text used as the panel header.',
       control: 'text',
     },
@@ -22,7 +22,7 @@ export default {
       control: 'boolean',
     },
     content: {
-      name: 'content (slotted)',
+      name: 'Content (slotted)',
       description: 'Placeholder text representing the panel contents, which can include HTML markup not supported in this story.',
       control: 'text',
     },

--- a/packages/web-components/src/components/cbp-table/cbp-table.scss
+++ b/packages/web-components/src/components/cbp-table/cbp-table.scss
@@ -321,6 +321,10 @@ cbp-table {
 
         &:has(button) {
           padding: 0;
+
+          cbp-icon {
+            display: inline-flex;
+          }
         }
 
         &:has(button:hover) {

--- a/packages/web-components/src/components/cbp-usa-banner/cbp-usa-banner.tsx
+++ b/packages/web-components/src/components/cbp-usa-banner/cbp-usa-banner.tsx
@@ -66,7 +66,7 @@ export class CbpUsaBanner {
               />
               <div>
                 <strong>Secure .gov websites use HTTPS</strong>
-                <p>A <strong>lock</strong> (<cbp-icon name="lock" size="var(--cbp-space-3x)" accessibilityText="lock icon"/>) or <strong>https://</strong> means you&#39;ve safely connected to the .gov website. Share sensitive information only on official, secure websites.</p>
+                <p>A <strong>lock</strong> (<cbp-icon name="lock" accessibilityText="lock icon"/>) or <strong>https://</strong> means you&#39;ve safely connected to the .gov website. Share sensitive information only on official, secure websites.</p>
               </div>
             </div>
           </div>

--- a/packages/web-components/src/stories/templates/templates.stories.tsx
+++ b/packages/web-components/src/stories/templates/templates.stories.tsx
@@ -423,7 +423,7 @@ function renderDrawer(items, drawerid, store){
               variant="heading-lg"
               id="panelheader"
             >
-              Application Name
+              ${items?.[0]?.label}
             </cbp-typography>
 
             <cbp-form-field 


### PR DESCRIPTION
* Simplify icon CSS after testing.
* Remove nested flex context for icons in links and buttons.
* Update icons embedding in CSS with proper FA7 versions in dropdown and form-field CSS.
* Update panel story with different icon and proper margin.
* Make all card, panel, and dialog headings use flex for proper icon alignment, removing margins from story where needed.
* Update icons embedding in CSS with proper FA7 versions in dropdown and form-field CSS.
* Fix dropdown and other custom form fields when font-size is not default by using relative token in the calculation.
* Defensively prevent flex context from affecting the shape of the badge.

I am still evaluating whether to add `vertical-align: text-top` to the default CSS of `cbp-icon`. This seems to make alignment in the flow of text with default icon/body text size work best.