### PR TITLE
Bugfix/cbp form field techdebt

### DIFF
--- a/packages/web-components/CHANGELOG.md
+++ b/packages/web-components/CHANGELOG.md
@@ -16,9 +16,9 @@ The React components are wrappers generated from this package and will share the
 * Updated how `valueChange` events are emitted by `cbp-form-field`, resolving cases of multiple events being emitted on a single change:
   * When a `cbp-dropdown`, `cbp-slider`, or `cbp-file-input` are nested in a `cbp-form-field`, `cbp-form-field` will not emit its own `valueChange` event because those components emit one, which bubbles and can be listed to on the `cbp-form-field` element or the form itself, already.
   * Updated `cbp-slider` to emit `valueChange` events according to native `change` events. Some were firing based on `input` events previously, causing an excess of `valueChange` events to be emitted.
-  * For checklists and radio lists, `cbp-form-field` (as a group) will listen for any `stateChanged` event from `cbp-checkbox` or `cbp-radio` and emit an appropriate `valueChange` event as follows:
-    * For a checkbox, all checked values within named checkboxes will be emitted as an array of values.
-    * For an unnamed checkbox (which cannot exist as part of a group), the value will be emitted if checked, otherwise the value will be reported as null.
+  * For checklists (including toggles) and radio lists, `cbp-form-field` (as a group) will listen for any `stateChanged` event from `cbp-checkbox` or `cbp-radio` and `toggleClick` from `cbp-toggle` and emit an appropriate `valueChange` event as follows:
+    * For a checkbox or toggle, all checked values within named checkboxes will be emitted as an array of values.
+    * For individually named checkboxes or toggles or an unnamed one (which cannot exist as part of a group), the value will be emitted if checked, otherwise the value will be reported as null.
     * For a radio list, only the value for the selected radio button is emitted.
   * Added the `name` key to all custom event emitted by form components.
 

--- a/packages/web-components/CHANGELOG.md
+++ b/packages/web-components/CHANGELOG.md
@@ -20,6 +20,7 @@ The React components are wrappers generated from this package and will share the
     * For a checkbox, all checked values within named checkboxes will be emitted as an array of values.
     * For an unnamed checkbox (which cannot exist as part of a group), the value will be emitted if checked, otherwise the value will be reported as null.
     * For a radio list, only the value for the selected radio button is emitted.
+  * Added the `name` key to all custom event emitted by form components.
 
 ## [0.9.0-beta.1] 06-29-2026
 

--- a/packages/web-components/CHANGELOG.md
+++ b/packages/web-components/CHANGELOG.md
@@ -6,10 +6,20 @@ The React components are wrappers generated from this package and will share the
 
 ## [unpublished] TBD
 
-* Imported and integrated the Float-UI library into `cbp-menu` to handle positioning and repositioning fallbacks when positioning goes off-screen.
+* Imported and integrated the Float-UI library into `cbp-menu`, `cbp-dropdown`, and `cbp-tooltip` to handle positioning and repositioning fallbacks when positioning goes off-screen.
 * BREAKING: Updated `cbp-icon` underlying CSS to address vertical alignment inconsistencies across several patterns.
   * Some patterns, such as panel, drawer, and dialog were updated to use flex within the heading, which eliminates the need to apply a margin to the icon directly (when present).
   * All icons in components and stories have been confirmed, but this change could potentially result in misaligned icons in custom code.
+* Updated `cbp-form-field` with fixes for field groups:
+  * Do not style all fields in error state when the group has the `error` property set.
+  * In this case, the group's description should be styled in an error state, and the specific fields in error within the group should have their own `error` property set to true.
+* Updated how `valueChange` events are emitted by `cbp-form-field`, resolving cases of multiple events being emitted on a single change:
+  * When a `cbp-dropdown`, `cbp-slider`, or `cbp-file-input` are nested in a `cbp-form-field`, `cbp-form-field` will not emit its own `valueChange` event because those components emit one, which bubbles and can be listed to on the `cbp-form-field` element or the form itself, already.
+  * Updated `cbp-slider` to emit `valueChange` events according to native `change` events. Some were firing based on `input` events previously, causing an excess of `valueChange` events to be emitted.
+  * For checklists and radio lists, `cbp-form-field` (as a group) will listen for any `stateChanged` event from `cbp-checkbox` or `cbp-radio` and emit an appropriate `valueChange` event as follows:
+    * For a checkbox, all checked values within named checkboxes will be emitted as an array of values.
+    * For an unnamed checkbox (which cannot exist as part of a group), the value will be emitted if checked, otherwise the value will be reported as null.
+    * For a radio list, only the value for the selected radio button is emitted.
 
 ## [0.9.0-beta.1] 06-29-2026
 

--- a/packages/web-components/src/components/cbp-checkbox/cbp-checkbox.stories.tsx
+++ b/packages/web-components/src/components/cbp-checkbox/cbp-checkbox.stories.tsx
@@ -56,8 +56,8 @@ const Template = ({ label, name, value, fieldId, checked, indeterminate, disable
       >
         <input 
           type="checkbox" 
-          name="${name}"
-          value="${value}"
+          ${name ? `name="${name}"` : ''}
+          ${value ? `value="${value}"` : ''}
           ${checked ? 'checked' : ''}
         />
         ${label}

--- a/packages/web-components/src/components/cbp-checkbox/cbp-checkbox.stories.tsx
+++ b/packages/web-components/src/components/cbp-checkbox/cbp-checkbox.stories.tsx
@@ -65,9 +65,9 @@ const Template = ({ label, name, value, fieldId, checked, indeterminate, disable
     `;
 };
 
-export const Checkbox = Template.bind({});
+export const Checkbox: any = Template.bind({});
 Checkbox.args = {
-  label: "Checkbox label",
+  label: "Insert checkbox label",
   name: "checkbox",
   value: "1",
 }

--- a/packages/web-components/src/components/cbp-checkbox/cbp-checkbox.tsx
+++ b/packages/web-components/src/components/cbp-checkbox/cbp-checkbox.tsx
@@ -52,6 +52,7 @@ export class CbpCheckbox {
     this.stateChanged.emit({
       host: this.host,
       nativeElement: this.formField,
+      name: this.formField.name,
       value: this.formField.value,
       checked: this.formField.checked,
       nativeEvent: e

--- a/packages/web-components/src/components/cbp-checkbox/cbp-checklist.stories.tsx
+++ b/packages/web-components/src/components/cbp-checkbox/cbp-checklist.stories.tsx
@@ -76,8 +76,8 @@ function generateCheckboxes(context, checkboxes) {
       >
         <input 
           type="checkbox" 
-          name="${name}"
-          value="${value}"
+          ${name ? `name="${name}"` : ''}
+          ${value ? `value="${value}"` : ''}
           ${checked ? 'checked' : ''}
           ${disabled ? 'disabled' : ''}
         />

--- a/packages/web-components/src/components/cbp-checkbox/cbp-checklist.stories.tsx
+++ b/packages/web-components/src/components/cbp-checkbox/cbp-checklist.stories.tsx
@@ -31,8 +31,8 @@ export default {
     },
   },
   args: {
-    label: "Checklist Group Label",
-    description: 'Field description.',
+    label: "Insert Checklist Group Label",
+    description: 'Insert group description.',
     checkboxes: [
       {
         label: "Checkbox 1",

--- a/packages/web-components/src/components/cbp-dropdown/cbp-dropdown.stories.tsx
+++ b/packages/web-components/src/components/cbp-dropdown/cbp-dropdown.stories.tsx
@@ -70,8 +70,8 @@ export default {
     },
   },
   args: {
-    label: 'Field Label',
-    description: 'Field description.',
+    label: 'Insert Field Label',
+    description: 'Insert field description.',
   },
 };
 

--- a/packages/web-components/src/components/cbp-dropdown/cbp-dropdown.tsx
+++ b/packages/web-components/src/components/cbp-dropdown/cbp-dropdown.tsx
@@ -161,7 +161,6 @@ export class CbpDropdown {
   @Event() populateCombobox: EventEmitter;
 
 
-
   @Listen('dropdownItemClick')
   handleDropdownItemClick(e) {
     const { host, label, value } = e.detail;
@@ -229,6 +228,7 @@ export class CbpDropdown {
       this.valueChange.emit({
         host: this.host,
         nativeElement: this.formField,
+        name: this.formField.name,
         value: this.value,
         label: this.selectedLabel,
         nativeEvent: e
@@ -239,6 +239,7 @@ export class CbpDropdown {
         {
           host: this.host,
           nativeElement: this.formField,
+          name: this.formField.name,
           value: this.value,
           label: this.selectedLabel,
           nativeEvent: e
@@ -365,6 +366,7 @@ export class CbpDropdown {
       this.valueChange.emit({
         host: this.host,
         nativeElement: this.formField,
+        name: this.formField.name,
         value: this.value,
         label: undefined,
         nativeEvent: e
@@ -375,6 +377,7 @@ export class CbpDropdown {
         {
           host: this.host,
           nativeElement: this.formField,
+          name: this.formField.name,
           value: this.value,
           label: undefined,
           nativeEvent: e

--- a/packages/web-components/src/components/cbp-dropdown/cbp-dropdown.tsx
+++ b/packages/web-components/src/components/cbp-dropdown/cbp-dropdown.tsx
@@ -228,7 +228,7 @@ export class CbpDropdown {
       this.valueChange.emit({
         host: this.host,
         nativeElement: this.formField,
-        name: this.formField.name,
+        name: this.name,
         value: this.value,
         label: this.selectedLabel,
         nativeEvent: e
@@ -239,7 +239,7 @@ export class CbpDropdown {
         {
           host: this.host,
           nativeElement: this.formField,
-          name: this.formField.name,
+          name: this.name,
           value: this.value,
           label: this.selectedLabel,
           nativeEvent: e
@@ -366,7 +366,7 @@ export class CbpDropdown {
       this.valueChange.emit({
         host: this.host,
         nativeElement: this.formField,
-        name: this.formField.name,
+        name: this.name,
         value: this.value,
         label: undefined,
         nativeEvent: e
@@ -377,7 +377,7 @@ export class CbpDropdown {
         {
           host: this.host,
           nativeElement: this.formField,
-          name: this.formField.name,
+          name: this.name,
           value: this.value,
           label: undefined,
           nativeEvent: e

--- a/packages/web-components/src/components/cbp-file-input/cbp-file-input.stories.tsx
+++ b/packages/web-components/src/components/cbp-file-input/cbp-file-input.stories.tsx
@@ -47,8 +47,8 @@ export default {
     },
   },
   args: {
-    label: 'Field Label',
-    description: 'Field description.',
+    label: 'Insert Field Label',
+    description: 'Insert field description.',
   },
 };
 

--- a/packages/web-components/src/components/cbp-form-field-wrapper/cbp-form-field-wrapper.stories.tsx
+++ b/packages/web-components/src/components/cbp-form-field-wrapper/cbp-form-field-wrapper.stories.tsx
@@ -46,8 +46,8 @@ export default {
     },
   },
   args: {
-    label: 'Field Label',
-    description: 'Field description.',
+    label: 'Insert Field Label',
+    description: 'Insert field description.',
     inputType: 'text'
   },
 };
@@ -79,7 +79,7 @@ const InputWithOverlaysTemplate = ({ label, description, inputType, overlayStart
   `;
 };
 
-export const InputWithOverlays = InputWithOverlaysTemplate.bind({});
+export const InputWithOverlays: any = InputWithOverlaysTemplate.bind({});
 InputWithOverlays.args = {
   name: 'textinput',
   value: '',
@@ -122,7 +122,7 @@ const FileInputTemplate = ({ label, description, overlayStart, overlayEnd, field
   `;
 };
 
-export const FileInput = FileInputTemplate.bind({});
+export const FileInput: any = FileInputTemplate.bind({});
 FileInput.storyName="File Input (Simple)"
 FileInput.args = {
   fieldId: 'file-input',
@@ -198,7 +198,7 @@ const NumericCounterTemplate = ({ label, description, inputType, overlayStart, o
   `;
 };
 
-export const NumericCounter = NumericCounterTemplate.bind({});
+export const NumericCounter: any = NumericCounterTemplate.bind({});
 NumericCounter.args = {
   label: 'Numeric Counter Field',
   description: 'This pattern requires some JavaScript to function, which can be found in the story source code.',
@@ -269,7 +269,7 @@ const PasswordTemplate = ({ label, description, inputType,  overlayStart, overla
   `;
 };
 
-export const Password = PasswordTemplate.bind({});
+export const Password: any = PasswordTemplate.bind({});
 Password.args = {
   label: 'Password',
   description: 'This pattern requires some JavaScript to function, which can be found in the story source code.',
@@ -317,7 +317,7 @@ const SearchTemplate = ({ label, description, inputType,  overlayStart, overlayE
   `;
 };
 
-export const Search = SearchTemplate.bind({});
+export const Search: any = SearchTemplate.bind({});
 Search.args = {
   label: 'Search',
   description: '',
@@ -366,9 +366,8 @@ const TimeInputTemplate = ({ label, description, fieldId, name, value, error, re
   `;
 };
 
-export const TimeInput = TimeInputTemplate.bind({});
+export const TimeInput: any = TimeInputTemplate.bind({});
 TimeInput.args = {
-  label: 'Field Title',
   description: '(HH:MM Format) UTC-6 America/New York',
   name: 'time',
   value: '',

--- a/packages/web-components/src/components/cbp-form-field/cbp-form-field-group.stories.tsx
+++ b/packages/web-components/src/components/cbp-form-field/cbp-form-field-group.stories.tsx
@@ -61,7 +61,7 @@ const FullNameTemplate = ({ label, labelSlotted, description, descriptionSlotted
 
       <cbp-flex 
         wrap="wrap"
-        gap="var(--cbp-space-4x)"
+        gap="0 var(--cbp-space-4x)"
         breakpoint="20rem"
       >
 
@@ -153,7 +153,7 @@ const PhoneTemplate = ({ label, labelSlotted, description, descriptionSlotted, f
 
       <cbp-flex 
         wrap="wrap"
-        gap="var(--cbp-space-4x)"
+        gap="0 var(--cbp-space-4x)"
         breakpoint="20rem"
       >
         <cbp-flex-item flex-basis="10rem" flex-shrink="0">
@@ -206,7 +206,7 @@ const GroupAsDividerTemplate = ({ label, labelSlotted, description, descriptionS
 
       <cbp-flex 
         wrap="wrap"
-        gap="var(--cbp-space-4x)"
+        gap="0 var(--cbp-space-4x)"
         breakpoint="20rem"
       >
 

--- a/packages/web-components/src/components/cbp-form-field/cbp-form-field-group.stories.tsx
+++ b/packages/web-components/src/components/cbp-form-field/cbp-form-field-group.stories.tsx
@@ -41,6 +41,115 @@ export default {
 };
 
 
+// Countries: 
+const Countries=[{"label":"Afghanistan"},{"label":"Albania"},{"label":"Algeria"},{"label":"Andaman Islands"},{"label":"Andorra"},{"label":"Angola"},{"label":"Anguilla"},{"label":"Annobon Island"},{"label":"Antigua"},{"label":"Antigua and Barbuda"},{"label":"Argentina"},{"label":"Armenia"},{"label":"Aruba"},{"label":"Ascension Island"},{"label":"Australia"},{"label":"Austria"},{"label":"Azerbaijan"},{"label":"Azores"},{"label":"Bahamas"},{"label":"Bahrain"},{"label":"Balearic Islands"},{"label":"Bangladesh"},{"label":"Barbados"},{"label":"Barbuda"},{"label":"Basse Terre"},{"label":"Belarus"},{"label":"Belau"},{"label":"Belgium"},{"label":"Belize"},{"label":"Benin"},{"label":"Bermuda"},{"label":"Bhutan"},{"label":"Bolivia"},{"label":"Bonaire"},{"label":"Bosnia and Herzegovina"},{"label":"Bosnia-Herzegovina"},{"label":"Botswana"},{"label":"Brazil"},{"label":"British Virgin Islands"},{"label":"Brunei"},{"label":"Bulgaria"},{"label":"Burkina Faso"},{"label":"Burma"},{"label":"Burundi"},{"label":"Byelarus"},{"label":"Cabinda"},{"label":"Caicos Islands"},{"label":"Cambodia"},{"label":"Cameroon"},{"label":"Canada"},{"label":"Canary Islands"},{"label":"Canton Islands"},{"label":"Cape Verde"},{"label":"Carriacou"},{"label":"Castelrosse Islands"},{"label":"Cayman Islands"},{"label":"Central African Rep"},{"label":"Chad"},{"label":"Channel Islands"},{"label":"Chile"},{"label":"China"},{"label":"Christmas Island"},{"label":"Cocos Islands"},{"label":"Colombia"},{"label":"Comoros"},{"label":"Congo"},{"label":"Cook Islands"},{"label":"Corsica"},{"label":"Costa Rica"},{"label":"Crete"},{"label":"Croatia"},{"label":"Cuba"},{"label":"Curacao"},{"label":"Cyprus"},{"label":"Czech Republic"},{"label":"Dem Rep of Congo"},{"label":"Denmark"},{"label":"Diego Garcia"},{"label":"Djibouti"},{"label":"Dodecanese Islands"},{"label":"Dominica"},{"label":"Dominican Republic"},{"label":"East Timor"},{"label":"Easter Island"},{"label":"Ecuador"},{"label":"Egypt"},{"label":"Eire"},{"label":"El Salvador"},{"label":"England"},{"label":"Equatorial Guinea"},{"label":"Eritrea"},{"label":"Estonia"},{"label":"Ethiopia"},{"label":"Falkland Islands"},{"label":"Faroe Islands"},{"label":"Fernando de Noronha"},{"label":"Fiji"},{"label":"Finland"},{"label":"France"},{"label":"French Guiana"},{"label":"French Polynesia"},{"label":"French West Indies"},{"label":"Gabon"},{"label":"Gambia"},{"label":"Georgia"},{"label":"Germany"},{"label":"Ghana"},{"label":"Gibraltar"},{"label":"Grand Cayman Island"},{"label":"Grand Terre"},{"label":"Grand Turk"},{"label":"Great Britain"},{"label":"Greece"},{"label":"Greenland"},{"label":"Grenada"},{"label":"Grenadine Islands"},{"label":"Guadeloupe"},{"label":"Guatemala"},{"label":"Guinea"},{"label":"Guinea-Bissau"},{"label":"Guyana"},{"label":"Haiti"},{"label":"Honduras"},{"label":"Hong Kong"},{"label":"Hungary"},{"label":"Iceland"},{"label":"India"},{"label":"Indonesia"},{"label":"Iran"},{"label":"Iraq"},{"label":"Ireland"},{"label":"Ireland, Republic of"},{"label":"Isle of Man"},{"label":"Israel"},{"label":"Italy"},{"label":"Jamaica"},{"label":"Jan Mayen Island"},{"label":"Japan"},{"label":"Jerusalem"},{"label":"Jordan"},{"label":"Kampuchea"},{"label":"Kazakhstan"},{"label":"Kenya"},{"label":"Kiribati"},{"label":"Kuwait"},{"label":"Kyrgyzstan"},{"label":"Laos"},{"label":"Latvia"},{"label":"Lebanon"},{"label":"Lesotho"},{"label":"Liberia"},{"label":"Libya"},{"label":"Liechtenstein"},{"label":"Lithuania"},{"label":"Little Cayman Island"},{"label":"Luxembourg"},{"label":"Macao"},{"label":"Macedonia"},{"label":"Madagascar"},{"label":"Madeira Islands"},{"label":"Malawi"},{"label":"Malaysia"},{"label":"Maldives"},{"label":"Mali"},{"label":"Malta"},{"label":"Marshall Islands"},{"label":"Martinique"},{"label":"Mauritania"},{"label":"Mauritius"},{"label":"Mexico"},{"label":"Micronesia"},{"label":"Midway Island"},{"label":"Miquelon Island"},{"label":"Moldova"},{"label":"Monaco"},{"label":"Mongolia"},{"label":"Montenegro"},{"label":"Montserrat"},{"label":"Morocco"},{"label":"Mozambique"},{"label":"Myanmar"},{"label":"Namibia"},{"label":"Nauru"},{"label":"Nepal"},{"label":"Netherlands"},{"label":"Netherlands Antilles"},{"label":"Nevis"},{"label":"New Caldonia"},{"label":"New Caledonia"},{"label":"New Guinea"},{"label":"New Hebrides"},{"label":"New Zealand"},{"label":"Nicaragua"},{"label":"Nicobar Islands"},{"label":"Niger"},{"label":"Nigeria"},{"label":"North Korea"},{"label":"Northern Ireland"},{"label":"Norway"},{"label":"Okinawa"},{"label":"Oman"},{"label":"Pagalu"},{"label":"Pakistan"},{"label":"Palau"},{"label":"Panama"},{"label":"Papua New Guinea"},{"label":"Paraguay"},{"label":"Peru"},{"label":"Petit Martinique"},{"label":"Philippines"},{"label":"Pitcairn Island"},{"label":"Poland"},{"label":"Portugal"},{"label":"Qatar"},{"label":"Republic of Congo"},{"label":"Republic of Georgia"},{"label":"Republic of Macedonia"},{"label":"Reunion"},{"label":"Romania"},{"label":"Russia"},{"label":"Rwanda"},{"label":"Ryukyu Islands"},{"label":"Saba"},{"label":"Samoa"},{"label":"San Marino"},{"label":"Sao Tome and Principe"},{"label":"Sardinia"},{"label":"Saudi Arabia"},{"label":"Scotland"},{"label":"Senegal"},{"label":"Serbia"},{"label":"Serbia and Montenegro"},{"label":"Seychelles"},{"label":"Sicily"},{"label":"Sierra Leone"},{"label":"Singapore"},{"label":"Slovak Republic"},{"label":"Slovakia"},{"label":"Slovenia"},{"label":"Solomon Islands"},{"label":"Somalia"},{"label":"Somaliland"},{"label":"Sombrero"},{"label":"South Africa"},{"label":"South Korea"},{"label":"Southwest Africa"},{"label":"Spain"},{"label":"Spanish Sahara"},{"label":"Sri Lanka"},{"label":"St Christopher"},{"label":"St Eustatius"},{"label":"St Helena"},{"label":"St Kitts"},{"label":"St Lucia"},{"label":"St Maarten"},{"label":"St Martin"},{"label":"St Pierre"},{"label":"St Vincent"},{"label":"Sudan"},{"label":"Sumatra"},{"label":"Suriname"},{"label":"Swaziland"},{"label":"Sweden"},{"label":"Switzerland"},{"label":"Syria"},{"label":"Tahiti"},{"label":"Taiwan"},{"label":"Tajikistan"},{"label":"Tanzania"},{"label":"Thailand"},{"label":"Timor"},{"label":"Togo"},{"label":"Tonga"},{"label":"Tortola"},{"label":"Trinidad and Tobago"},{"label":"Tristan da Cunha"},{"label":"Tunisia"},{"label":"Turkey"},{"label":"Turkmenistan"},{"label":"Turks and Caicos Is"},{"label":"Turks Islands"},{"label":"Tuvalu"},{"label":"Uganda"},{"label":"Ukraine"},{"label":"United Arab Emirates"},{"label":"United Kingdom"},{"label":"United States of America"},{"label":"Upper Volta"},{"label":"Uruguay"},{"label":"Uzbekistan"},{"label":"Vanuatu"},{"label":"Vatican City"},{"label":"Venezuela"},{"label":"Vietnam"},{"label":"Wake Island"},{"label":"Wales"},{"label":"Wallis and Futuna Is"},{"label":"Walvis Bay"},{"label":"Western Sahara"},{"label":"Western Samoa"},{"label":"Yemen"},{"label":"Yemen, Republic of"},{"label":"Zaire"},{"label":"Zambia"},{"label":"Zimbabwe"},{"label":"Cote D&apos;Ivoire"},{"label":"Rep of South Sudan"},{"label":"Kosovo"},{"label":"Alderney"},{"label":"Ascension"},{"label":"Brunei Darussalam"},{"label":"Guernsey"},{"label":"Ivory Coast"},{"label":"Jersey"},{"label":"Kowloon"},{"label":"Niue"},{"label":"Redonda"},{"label":"Santa Cruz Islands"},{"label":"Sark"},{"label":"St Bartholomew"},{"label":"St Christopher - Nevis"},{"label":"St Pierre and Miquelon"},{"label":"St Vincent - Grenadine"},{"label":"Syrian Arab Republic"},{"label":"Timor-Leste"},{"label":"Eswatini"}];
+
+
+
+
+const AddressTemplate = ({ label, labelSlotted, description, descriptionSlotted, fieldId, error, disabled, context, sx }) => {
+
+  // The native JSON objects may not be properly sorted (such as Countries, which has more appended to the end out of order),
+  // so sort them alphabetically.
+  
+  Countries.sort(function(a, b) {
+    return a.label.localeCompare(b.label);
+  });
+
+  return ` 
+    <cbp-form-field group
+      ${label ? `label="${label}"` : ''}
+      ${description ? `description="${description}"` : ''}
+      ${fieldId ? `field-id="${fieldId}"` : ''}
+      ${disabled ? `disabled` : ''}
+      ${error ? `error` : ''}
+      ${context && context != 'light-inverts' ? `context="${context}"` : ''}
+      ${sx ? `sx='${JSON.stringify(sx)}'` : ''}
+    >
+      ${ labelSlotted ? `<span slot="cbp-form-field-label">${labelSlotted}</span>` : ''}
+      ${ descriptionSlotted ? `<span slot="cbp-form-field-description">${descriptionSlotted}</span>` : ''}
+
+      <cbp-flex 
+        wrap="wrap"
+        gap="0 var(--cbp-space-4x)"
+        breakpoint="22.5rem"
+      >
+
+        <cbp-flex-item flex-grow="1" flex-basis="25ch">
+          <cbp-form-field
+            label="Street Address"
+          >
+            <input name="address1" type="text" />
+          </cbp-form-field>
+        </cbp-flex-item>
+
+        <cbp-flex-item flex-grow="1" flex-basis="25ch">
+          <cbp-form-field
+            label="Apartment, Suite, Building, Etc."
+          >
+            <input name="address2" type="text" />
+          </cbp-form-field>
+        </cbp-flex-item>
+
+        <cbp-flex-item flex-grow="1" flex-basis="25ch">
+          <cbp-form-field
+            label="Line 3"
+          >
+            <input name="address3" type="text" />
+          </cbp-form-field>
+        </cbp-flex-item>
+
+        <cbp-flex-item flex-grow="1" flex-basis="25ch">
+          <cbp-form-field
+            label="Line 4"
+          >
+            <input name="address4" type="text" />
+          </cbp-form-field>
+        </cbp-flex-item>
+
+        <cbp-flex-item flex-grow="1" flex-basis="25ch">
+          <cbp-form-field
+            label="City/Town"
+          >
+            <input name="city" type="text" />
+          </cbp-form-field>
+        </cbp-flex-item>
+
+        <cbp-flex-item flex-grow="1" flex-basis="25ch">
+          <cbp-form-field
+            label="State/Province/Region"
+          >
+            <input name="state" type="text" />
+          </cbp-form-field>
+        </cbp-flex-item>
+
+        <cbp-flex-item flex-grow="0" flex-basis="15ch">
+          <cbp-form-field
+            label="ZIP/Postal Code"
+          >
+            <input name="postalcode" type="text" />
+          </cbp-form-field>
+        </cbp-flex-item>
+
+        <cbp-flex-item flex-grow="2" flex-basis="20ch">
+          <cbp-form-field
+            label="Country"
+          >
+            <cbp-dropdown name="country" items='${JSON.stringify(Countries)}' />
+          </cbp-form-field>
+        </cbp-flex-item>
+
+      </cbp-flex>
+    </cbp-form-field>
+  `;
+};
+
+export const Address: any = AddressTemplate.bind({});
+Address.args = {
+  label:"Insert Group Label",
+  description: "Required.",
+};
+
 
 const Prefix='[{"label":"Attorney","value":"Attorney"},{"label":"Coach","value":"Coach"},{"label":"Dr.","value":"Dr."},{"label":"Father","value":"Father"},{"label":"Governor","value":"Governor"},{"label":"Honorable","value":"Honorable"},{"label":"Officer","value":"Officer"},{"label":"Master","value":"Master"},{"label":"Miss","value":"Miss"},{"label":"Mr.","value":"Mr."},{"label":"Mrs","value":"Mrs."},{"label":"Ms.","value":"Ms"},{"label":"President","value":"President"},{"label":"Professor","value":"Professor"},{"label":"Reverend","value":"Reverend"}]';
 const Suffix='[{"label":"I","value":"First"},{"label":"II","value":"Second"},{"label":"III","value":"Third"},{"label":"IV","value":"Fourth"},{"label":"IX","value":"Ninth"},{"label":"JR","value":"Junior"},{"label":"SR","value":"Senior"},{"label":"V","value":"Fifth"},{"label":"VI","value":"Sixth"},{"label":"VII","value":"Seventh"},{"label":"VIII","value":"Eighth"},{"label":"X","value":"Tenth"},{"label":"XI","value":"Eleventh"},{"label":"XII","value":"Twelfth"},{"label":"XIII","value":"Thirteenth"},{"label":"XIV","value":"Fourteenth"},{"label":"XV","value":"Fifteenth"},{"label":"XVI","value":"Sixteenth"},{"label":"XVII","value":"Seventeenth"}]';
@@ -62,7 +171,7 @@ const FullNameTemplate = ({ label, labelSlotted, description, descriptionSlotted
       <cbp-flex 
         wrap="wrap"
         gap="0 var(--cbp-space-4x)"
-        breakpoint="20rem"
+        breakpoint="22.5rem"
       >
 
         <cbp-flex-item
@@ -154,7 +263,7 @@ const PhoneTemplate = ({ label, labelSlotted, description, descriptionSlotted, f
       <cbp-flex 
         wrap="wrap"
         gap="0 var(--cbp-space-4x)"
-        breakpoint="20rem"
+        breakpoint="22.5rem"
       >
         <cbp-flex-item flex-basis="10rem" flex-shrink="0">
           <cbp-form-field label="Country Code">
@@ -184,14 +293,8 @@ Phone.args = {
 
 
 
-const GroupAsDividerTemplate = ({ label, labelSlotted, description, descriptionSlotted, fieldId, error, disabled, context, sx }) => {
+const GroupAsHeadingTemplate = ({ label, labelSlotted, description, descriptionSlotted, fieldId, error, disabled, context, sx }) => {
   return ` 
-    <cbp-typography tag="h3" divider="fill">
-      <cbp-icon name="user" size="1.5rem" sx='{"margin-inline-end":"var(--cbp-space-3x)"}'></cbp-icon>Applicant Information
-    </cbp-typography>
-
-    <br />
-
     <cbp-form-field group
       ${label ? `label="${label}"` : ''}
       ${description ? `description="${description}"` : ''}
@@ -207,7 +310,7 @@ const GroupAsDividerTemplate = ({ label, labelSlotted, description, descriptionS
       <cbp-flex 
         wrap="wrap"
         gap="0 var(--cbp-space-4x)"
-        breakpoint="20rem"
+        breakpoint="22.5rem"
       >
 
         <cbp-flex-item
@@ -266,7 +369,14 @@ const GroupAsDividerTemplate = ({ label, labelSlotted, description, descriptionS
   `;
 };
 
-export const GroupAsDivider: any = GroupAsDividerTemplate.bind({});
-GroupAsDivider.args = {
-  labelSlotted: `<cbp-typography tag="h3" divider="fill"><cbp-icon name="user" size="1.5rem" sx='{"margin-inline-end":"var(--cbp-space-3x)"}'></cbp-icon>Applicant Information</cbp-typography>`,
+export const GroupAsHeadingFill: any = GroupAsHeadingTemplate.bind({});
+GroupAsHeadingFill.storyName = "Group as Heading (Fill)";
+GroupAsHeadingFill.args = {
+  labelSlotted: `<cbp-typography tag="h3" divider="fill" sx='{"margin-block-end":"var(--cbp-space-2x)"}'><cbp-icon name="user" size="1.5rem" sx='{"margin-inline-end":"var(--cbp-space-3x)"}'></cbp-icon>Applicant Information</cbp-typography>`,
+};
+
+export const GroupAsHeadingUnderline: any = GroupAsHeadingTemplate.bind({});
+GroupAsHeadingUnderline.storyName = "Group as Heading (Underline)";
+GroupAsHeadingUnderline.args = {
+  labelSlotted: `<cbp-typography tag="h3" divider="underline" sx='{"margin-block-end":"var(--cbp-space-2x)"}'><cbp-icon name="user" size="1.5rem" sx='{"margin-inline-end":"var(--cbp-space-3x)"}'></cbp-icon>Applicant Information</cbp-typography>`,
 };

--- a/packages/web-components/src/components/cbp-form-field/cbp-form-field-group.stories.tsx
+++ b/packages/web-components/src/components/cbp-form-field/cbp-form-field-group.stories.tsx
@@ -1,0 +1,272 @@
+export default {
+  title: 'Forms/Form Field/Form Field Groups',
+  //tags: ['beta'],
+  argTypes: {
+    label: {
+      control: 'text',
+    },
+    labelSlotted: {
+      name: 'label (slotted)',
+      control: 'text',
+    },
+    description: {
+      control: 'text',
+    },
+    descriptionSlotted: {
+      name: 'description (slotted)',
+      control: 'text',
+    },
+    fieldId: {
+      control: 'text',
+    },
+    fields: {
+      name: 'Form fields (slotted)',
+      control: 'object',
+    },
+    error: {
+      control: 'boolean',
+    },
+    disabled: {
+      control: 'boolean',
+    },
+    context : {
+      control: 'select',
+      options: [ "light-inverts", "light-always", "dark-inverts", "dark-always"]
+    },
+    sx: {
+      description: 'Supports adding inline styles as an object of key-value pairs comprised of CSS properties and values. Values should reference design tokens when possible.',
+      control: 'object',
+    },
+  },
+};
+
+
+
+const Prefix='[{"label":"Attorney","value":"Attorney"},{"label":"Coach","value":"Coach"},{"label":"Dr.","value":"Dr."},{"label":"Father","value":"Father"},{"label":"Governor","value":"Governor"},{"label":"Honorable","value":"Honorable"},{"label":"Officer","value":"Officer"},{"label":"Master","value":"Master"},{"label":"Miss","value":"Miss"},{"label":"Mr.","value":"Mr."},{"label":"Mrs","value":"Mrs."},{"label":"Ms.","value":"Ms"},{"label":"President","value":"President"},{"label":"Professor","value":"Professor"},{"label":"Reverend","value":"Reverend"}]';
+const Suffix='[{"label":"I","value":"First"},{"label":"II","value":"Second"},{"label":"III","value":"Third"},{"label":"IV","value":"Fourth"},{"label":"IX","value":"Ninth"},{"label":"JR","value":"Junior"},{"label":"SR","value":"Senior"},{"label":"V","value":"Fifth"},{"label":"VI","value":"Sixth"},{"label":"VII","value":"Seventh"},{"label":"VIII","value":"Eighth"},{"label":"X","value":"Tenth"},{"label":"XI","value":"Eleventh"},{"label":"XII","value":"Twelfth"},{"label":"XIII","value":"Thirteenth"},{"label":"XIV","value":"Fourteenth"},{"label":"XV","value":"Fifteenth"},{"label":"XVI","value":"Sixteenth"},{"label":"XVII","value":"Seventeenth"}]';
+
+const FullNameTemplate = ({ label, labelSlotted, description, descriptionSlotted, fieldId, error, disabled, context, sx }) => {
+  return ` 
+    <cbp-form-field group
+      ${label ? `label="${label}"` : ''}
+      ${description ? `description="${description}"` : ''}
+      ${fieldId ? `field-id="${fieldId}"` : ''}
+      ${disabled ? `disabled` : ''}
+      ${error ? `error` : ''}
+      ${context && context != 'light-inverts' ? `context="${context}"` : ''}
+      ${sx ? `sx='${JSON.stringify(sx)}'` : ''}
+    >
+      ${ labelSlotted ? `<span slot="cbp-form-field-label">${labelSlotted}</span>` : ''}
+      ${ descriptionSlotted ? `<span slot="cbp-form-field-description">${descriptionSlotted}</span>` : ''}
+
+      <cbp-flex 
+        wrap="wrap"
+        gap="var(--cbp-space-4x)"
+        breakpoint="20rem"
+      >
+
+        <cbp-flex-item
+          flex-basis="10rem"
+          flex-shrink="0"
+        >
+          <cbp-form-field
+            label="Prefix"
+          >
+            <cbp-dropdown name="prefix" items='${Prefix}'></cbp-dropdown>
+          </cbp-form-field>
+        </cbp-flex-item>
+
+        <cbp-flex-item
+          flex-basis="10rem"
+          flex-grow="1"
+        >
+          <cbp-form-field
+            label="First Name"
+          >
+            <input name="firstname" type="text" />
+          </cbp-form-field>
+        </cbp-flex-item>
+
+        <cbp-form-field
+          label="M.I."
+          sx='{"width":"5ch"}'
+        >
+          <input name="middleinitial" type="text" maxlength="1" />
+        </cbp-form-field>
+
+        <cbp-flex-item
+          flex-basis="10rem"
+          flex-grow="1"
+        >
+          <cbp-form-field
+            label="Last Name"
+          >
+            <input name="lastname" type="text" />
+          </cbp-form-field>
+        </cbp-flex-item>
+
+        <cbp-flex-item
+          flex-basis="10rem"
+          flex-shrink="0"
+        >
+          <cbp-form-field
+            label="Suffix"
+          >
+            <cbp-dropdown name="suffix" items='${Suffix}'></cbp-dropdown>
+          </cbp-form-field>
+        </cbp-flex-item>
+
+      </cbp-flex>
+    </cbp-form-field>
+  `;
+};
+
+export const FullName: any = FullNameTemplate.bind({});
+FullName.args = {
+  label:"User's Full Name",
+  description: "Required.",
+};
+
+// test data obtained from https://gist.githubusercontent.com/pickletoni/021e2e18e83f33d16fee5daa308e6a4e/raw/fc6fd9127efd12d97a3d39f38befc784d6bcbf22/countryPhoneCodes.json
+const CountryCodesDataset='[{"country":"United States","code":"1","iso":"US"},{"country":"Afghanistan","code":"93","iso":"AF"},{"country":"Albania","code":"355","iso":"AL"},{"country":"Algeria","code":"213","iso":"DZ"},{"country":"American Samoa","code":"1-684","iso":"AS"},{"country":"Andorra","code":"376","iso":"AD"},{"country":"Angola","code":"244","iso":"AO"},{"country":"Anguilla","code":"1-264","iso":"AI"},{"country":"Antarctica","code":"672","iso":"AQ"},{"country":"Antigua and Barbuda","code":"1-268","iso":"AG"},{"country":"Argentina","code":"54","iso":"AR"},{"country":"Armenia","code":"374","iso":"AM"},{"country":"Aruba","code":"297","iso":"AW"},{"country":"Australia","code":"61","iso":"AU"},{"country":"Austria","code":"43","iso":"AT"},{"country":"Azerbaijan","code":"994","iso":"AZ"},{"country":"Bahamas","code":"1-242","iso":"BS"},{"country":"Bahrain","code":"973","iso":"BH"},{"country":"Bangladesh","code":"880","iso":"BD"},{"country":"Barbados","code":"1-246","iso":"BB"},{"country":"Belarus","code":"375","iso":"BY"},{"country":"Belgium","code":"32","iso":"BE"},{"country":"Belize","code":"501","iso":"BZ"},{"country":"Benin","code":"229","iso":"BJ"},{"country":"Bermuda","code":"1-441","iso":"BM"},{"country":"Bhutan","code":"975","iso":"BT"},{"country":"Bolivia","code":"591","iso":"BO"},{"country":"Bosnia and Herzegovina","code":"387","iso":"BA"},{"country":"Botswana","code":"267","iso":"BW"},{"country":"Brazil","code":"55","iso":"BR"},{"country":"British Indian Ocean Territory","code":"246","iso":"IO"},{"country":"British Virgin Islands","code":"1-284","iso":"VG"},{"country":"Brunei","code":"673","iso":"BN"},{"country":"Bulgaria","code":"359","iso":"BG"},{"country":"Burkina Faso","code":"226","iso":"BF"},{"country":"Burundi","code":"257","iso":"BI"},{"country":"Cambodia","code":"855","iso":"KH"},{"country":"Cameroon","code":"237","iso":"CM"},{"country":"Canada","code":"1","iso":"CA"},{"country":"Cape Verde","code":"238","iso":"CV"},{"country":"Cayman Islands","code":"1-345","iso":"KY"},{"country":"Central African Republic","code":"236","iso":"CF"},{"country":"Chad","code":"235","iso":"TD"},{"country":"Chile","code":"56","iso":"CL"},{"country":"China","code":"86","iso":"CN"},{"country":"Christmas Island","code":"61","iso":"CX"},{"country":"Cocos Islands","code":"61","iso":"CC"},{"country":"Colombia","code":"57","iso":"CO"},{"country":"Comoros","code":"269","iso":"KM"},{"country":"Cook Islands","code":"682","iso":"CK"},{"country":"Costa Rica","code":"506","iso":"CR"},{"country":"Croatia","code":"385","iso":"HR"},{"country":"Cuba","code":"53","iso":"CU"},{"country":"Curacao","code":"599","iso":"CW"},{"country":"Cyprus","code":"357","iso":"CY"},{"country":"Czech Republic","code":"420","iso":"CZ"},{"country":"Democratic Republic of the Congo","code":"243","iso":"CD"},{"country":"Denmark","code":"45","iso":"DK"},{"country":"Djibouti","code":"253","iso":"DJ"},{"country":"Dominica","code":"1-767","iso":"DM"},{"country":"Dominican Republic","code":"1-809, 1-829, 1-849","iso":"DO"},{"country":"East Timor","code":"670","iso":"TL"},{"country":"Ecuador","code":"593","iso":"EC"},{"country":"Egypt","code":"20","iso":"EG"},{"country":"El Salvador","code":"503","iso":"SV"},{"country":"Equatorial Guinea","code":"240","iso":"GQ"},{"country":"Eritrea","code":"291","iso":"ER"},{"country":"Estonia","code":"372","iso":"EE"},{"country":"Ethiopia","code":"251","iso":"ET"},{"country":"Falkland Islands","code":"500","iso":"FK"},{"country":"Faroe Islands","code":"298","iso":"FO"},{"country":"Fiji","code":"679","iso":"FJ"},{"country":"Finland","code":"358","iso":"FI"},{"country":"France","code":"33","iso":"FR"},{"country":"French Polynesia","code":"689","iso":"PF"},{"country":"Gabon","code":"241","iso":"GA"},{"country":"Gambia","code":"220","iso":"GM"},{"country":"Georgia","code":"995","iso":"GE"},{"country":"Germany","code":"49","iso":"DE"},{"country":"Ghana","code":"233","iso":"GH"},{"country":"Gibraltar","code":"350","iso":"GI"},{"country":"Greece","code":"30","iso":"GR"},{"country":"Greenland","code":"299","iso":"GL"},{"country":"Grenada","code":"1-473","iso":"GD"},{"country":"Guam","code":"1-671","iso":"GU"},{"country":"Guatemala","code":"502","iso":"GT"},{"country":"Guernsey","code":"44-1481","iso":"GG"},{"country":"Guinea","code":"224","iso":"GN"},{"country":"Guinea-Bissau","code":"245","iso":"GW"},{"country":"Guyana","code":"592","iso":"GY"},{"country":"Haiti","code":"509","iso":"HT"},{"country":"Honduras","code":"504","iso":"HN"},{"country":"Hong Kong","code":"852","iso":"HK"},{"country":"Hungary","code":"36","iso":"HU"},{"country":"Iceland","code":"354","iso":"IS"},{"country":"India","code":"91","iso":"IN"},{"country":"Indonesia","code":"62","iso":"ID"},{"country":"Iran","code":"98","iso":"IR"},{"country":"Iraq","code":"964","iso":"IQ"},{"country":"Ireland","code":"353","iso":"IE"},{"country":"Isle of Man","code":"44-1624","iso":"IM"},{"country":"Israel","code":"972","iso":"IL"},{"country":"Italy","code":"39","iso":"IT"},{"country":"Ivory Coast","code":"225","iso":"CI"},{"country":"Jamaica","code":"1-876","iso":"JM"},{"country":"Japan","code":"81","iso":"JP"},{"country":"Jersey","code":"44-1534","iso":"JE"},{"country":"Jordan","code":"962","iso":"JO"},{"country":"Kazakhstan","code":"7","iso":"KZ"},{"country":"Kenya","code":"254","iso":"KE"},{"country":"Kiribati","code":"686","iso":"KI"},{"country":"Kosovo","code":"383","iso":"XK"},{"country":"Kuwait","code":"965","iso":"KW"},{"country":"Kyrgyzstan","code":"996","iso":"KG"},{"country":"Laos","code":"856","iso":"LA"},{"country":"Latvia","code":"371","iso":"LV"},{"country":"Lebanon","code":"961","iso":"LB"},{"country":"Lesotho","code":"266","iso":"LS"},{"country":"Liberia","code":"231","iso":"LR"},{"country":"Libya","code":"218","iso":"LY"},{"country":"Liechtenstein","code":"423","iso":"LI"},{"country":"Lithuania","code":"370","iso":"LT"},{"country":"Luxembourg","code":"352","iso":"LU"},{"country":"Macao","code":"853","iso":"MO"},{"country":"Macedonia","code":"389","iso":"MK"},{"country":"Madagascar","code":"261","iso":"MG"},{"country":"Malawi","code":"265","iso":"MW"},{"country":"Malaysia","code":"60","iso":"MY"},{"country":"Maldives","code":"960","iso":"MV"},{"country":"Mali","code":"223","iso":"ML"},{"country":"Malta","code":"356","iso":"MT"},{"country":"Marshall Islands","code":"692","iso":"MH"},{"country":"Mauritania","code":"222","iso":"MR"},{"country":"Mauritius","code":"230","iso":"MU"},{"country":"Mayotte","code":"262","iso":"YT"},{"country":"Mexico","code":"52","iso":"MX"},{"country":"Micronesia","code":"691","iso":"FM"},{"country":"Moldova","code":"373","iso":"MD"},{"country":"Monaco","code":"377","iso":"MC"},{"country":"Mongolia","code":"976","iso":"MN"},{"country":"Montenegro","code":"382","iso":"ME"},{"country":"Montserrat","code":"1-664","iso":"MS"},{"country":"Morocco","code":"212","iso":"MA"},{"country":"Mozambique","code":"258","iso":"MZ"},{"country":"Myanmar","code":"95","iso":"MM"},{"country":"Namibia","code":"264","iso":"NA"},{"country":"Nauru","code":"674","iso":"NR"},{"country":"Nepal","code":"977","iso":"NP"},{"country":"Netherlands","code":"31","iso":"NL"},{"country":"Netherlands Antilles","code":"599","iso":"AN"},{"country":"New Caledonia","code":"687","iso":"NC"},{"country":"New Zealand","code":"64","iso":"NZ"},{"country":"Nicaragua","code":"505","iso":"NI"},{"country":"Niger","code":"227","iso":"NE"},{"country":"Nigeria","code":"234","iso":"NG"},{"country":"Niue","code":"683","iso":"NU"},{"country":"North Korea","code":"850","iso":"KP"},{"country":"Northern Mariana Islands","code":"1-670","iso":"MP"},{"country":"Norway","code":"47","iso":"NO"},{"country":"Oman","code":"968","iso":"OM"},{"country":"Pakistan","code":"92","iso":"PK"},{"country":"Palau","code":"680","iso":"PW"},{"country":"Palestine","code":"970","iso":"PS"},{"country":"Panama","code":"507","iso":"PA"},{"country":"Papua New Guinea","code":"675","iso":"PG"},{"country":"Paraguay","code":"595","iso":"PY"},{"country":"Peru","code":"51","iso":"PE"},{"country":"Philippines","code":"63","iso":"PH"},{"country":"Pitcairn","code":"64","iso":"PN"},{"country":"Poland","code":"48","iso":"PL"},{"country":"Portugal","code":"351","iso":"PT"},{"country":"Puerto Rico","code":"1-787, 1-939","iso":"PR"},{"country":"Qatar","code":"974","iso":"QA"},{"country":"Republic of the Congo","code":"242","iso":"CG"},{"country":"Reunion","code":"262","iso":"RE"},{"country":"Romania","code":"40","iso":"RO"},{"country":"Russia","code":"7","iso":"RU"},{"country":"Rwanda","code":"250","iso":"RW"},{"country":"Saint Barthelemy","code":"590","iso":"BL"},{"country":"Saint Helena","code":"290","iso":"SH"},{"country":"Saint Kitts and Nevis","code":"1-869","iso":"KN"},{"country":"Saint Lucia","code":"1-758","iso":"LC"},{"country":"Saint Martin","code":"590","iso":"MF"},{"country":"Saint Pierre and Miquelon","code":"508","iso":"PM"},{"country":"Saint Vincent and the Grenadines","code":"1-784","iso":"VC"},{"country":"Samoa","code":"685","iso":"WS"},{"country":"San Marino","code":"378","iso":"SM"},{"country":"Sao Tome and Principe","code":"239","iso":"ST"},{"country":"Saudi Arabia","code":"966","iso":"SA"},{"country":"Senegal","code":"221","iso":"SN"},{"country":"Serbia","code":"381","iso":"RS"},{"country":"Seychelles","code":"248","iso":"SC"},{"country":"Sierra Leone","code":"232","iso":"SL"},{"country":"Singapore","code":"65","iso":"SG"},{"country":"Sint Maarten","code":"1-721","iso":"SX"},{"country":"Slovakia","code":"421","iso":"SK"},{"country":"Slovenia","code":"386","iso":"SI"},{"country":"Solomon Islands","code":"677","iso":"SB"},{"country":"Somalia","code":"252","iso":"SO"},{"country":"South Africa","code":"27","iso":"ZA"},{"country":"South Korea","code":"82","iso":"KR"},{"country":"South Sudan","code":"211","iso":"SS"},{"country":"Spain","code":"34","iso":"ES"},{"country":"Sri Lanka","code":"94","iso":"LK"},{"country":"Sudan","code":"249","iso":"SD"},{"country":"Suriname","code":"597","iso":"SR"},{"country":"Svalbard and Jan Mayen","code":"47","iso":"SJ"},{"country":"Swaziland","code":"268","iso":"SZ"},{"country":"Sweden","code":"46","iso":"SE"},{"country":"Switzerland","code":"41","iso":"CH"},{"country":"Syria","code":"963","iso":"SY"},{"country":"Taiwan","code":"886","iso":"TW"},{"country":"Tajikistan","code":"992","iso":"TJ"},{"country":"Tanzania","code":"255","iso":"TZ"},{"country":"Thailand","code":"66","iso":"TH"},{"country":"Togo","code":"228","iso":"TG"},{"country":"Tokelau","code":"690","iso":"TK"},{"country":"Tonga","code":"676","iso":"TO"},{"country":"Trinidad and Tobago","code":"1-868","iso":"TT"},{"country":"Tunisia","code":"216","iso":"TN"},{"country":"Turkey","code":"90","iso":"TR"},{"country":"Turkmenistan","code":"993","iso":"TM"},{"country":"Turks and Caicos Islands","code":"1-649","iso":"TC"},{"country":"Tuvalu","code":"688","iso":"TV"},{"country":"U.S. Virgin Islands","code":"1-340","iso":"VI"},{"country":"Uganda","code":"256","iso":"UG"},{"country":"Ukraine","code":"380","iso":"UA"},{"country":"United Arab Emirates","code":"971","iso":"AE"},{"country":"United Kingdom","code":"44","iso":"GB"},{"country":"Uruguay","code":"598","iso":"UY"},{"country":"Uzbekistan","code":"998","iso":"UZ"},{"country":"Vanuatu","code":"678","iso":"VU"},{"country":"Vatican","code":"379","iso":"VA"},{"country":"Venezuela","code":"58","iso":"VE"},{"country":"Vietnam","code":"84","iso":"VN"},{"country":"Wallis and Futuna","code":"681","iso":"WF"},{"country":"Western Sahara","code":"212","iso":"EH"},{"country":"Yemen","code":"967","iso":"YE"},{"country":"Zambia","code":"260","iso":"ZM"},{"country":"Zimbabwe","code":"263","iso":"ZW"}]';
+
+const CountryCodes = JSON.stringify(JSON.parse(CountryCodesDataset).map( ({ iso, code }) => {
+  return {
+    "label": `${iso} +${code}`,
+    "value": code
+  }
+}));
+
+const PhoneTemplate = ({ label, labelSlotted, description, descriptionSlotted, fieldId, error, disabled, context, sx }) => {
+  return ` 
+    <cbp-form-field group
+      ${label ? `label="${label}"` : ''}
+      ${description ? `description="${description}"` : ''}
+      ${fieldId ? `field-id="${fieldId}"` : ''}
+      ${disabled ? `disabled` : ''}
+      ${error ? `error` : ''}
+      ${context && context != 'light-inverts' ? `context="${context}"` : ''}
+      ${sx ? `sx='${JSON.stringify(sx)}'` : ''}
+    >
+      ${ labelSlotted ? `<span slot="cbp-form-field-label">${labelSlotted}</span>` : ''}
+      ${ descriptionSlotted ? `<span slot="cbp-form-field-description">${descriptionSlotted}</span>` : ''}
+
+      <cbp-flex 
+        wrap="wrap"
+        gap="var(--cbp-space-4x)"
+        breakpoint="20rem"
+      >
+        <cbp-flex-item flex-basis="10rem" flex-shrink="0">
+          <cbp-form-field label="Country Code">
+            <cbp-dropdown name="countrycode" items='${CountryCodes}'></cbp-dropdown>
+          </cbp-form-field>
+        </cbp-flex-item>
+
+        <cbp-flex-item
+          flex-basis="10rem"
+          flex-grow="0"
+        >
+          <cbp-form-field label="Phone Number">
+            <input name="phonenumber" type="text" inputmode="numeric" />
+          </cbp-form-field>
+        </cbp-flex-item>
+
+        </cbp-flex>
+    </cbp-form-field>
+  `;
+};
+
+export const Phone: any = PhoneTemplate.bind({});
+Phone.args = {
+  label:"User's Phone Number",
+  description: "Required.",
+};
+
+
+
+const GroupAsDividerTemplate = ({ label, labelSlotted, description, descriptionSlotted, fieldId, error, disabled, context, sx }) => {
+  return ` 
+    <cbp-typography tag="h3" divider="fill">
+      <cbp-icon name="user" size="1.5rem" sx='{"margin-inline-end":"var(--cbp-space-3x)"}'></cbp-icon>Applicant Information
+    </cbp-typography>
+
+    <br />
+
+    <cbp-form-field group
+      ${label ? `label="${label}"` : ''}
+      ${description ? `description="${description}"` : ''}
+      ${fieldId ? `field-id="${fieldId}"` : ''}
+      ${disabled ? `disabled` : ''}
+      ${error ? `error` : ''}
+      ${context && context != 'light-inverts' ? `context="${context}"` : ''}
+      ${sx ? `sx='${JSON.stringify(sx)}'` : ''}
+    >
+      ${ labelSlotted ? `<span slot="cbp-form-field-label">${labelSlotted}</span>` : ''}
+      ${ descriptionSlotted ? `<span slot="cbp-form-field-description">${descriptionSlotted}</span>` : ''}
+
+      <cbp-flex 
+        wrap="wrap"
+        gap="var(--cbp-space-4x)"
+        breakpoint="20rem"
+      >
+
+        <cbp-flex-item
+          flex-basis="10rem"
+          flex-shrink="0"
+        >
+          <cbp-form-field
+            label="Prefix"
+          >
+            <cbp-dropdown name="prefix" items='${Prefix}'></cbp-dropdown>
+          </cbp-form-field>
+        </cbp-flex-item>
+
+        <cbp-flex-item
+          flex-basis="10rem"
+          flex-grow="1"
+        >
+          <cbp-form-field
+            label="First Name"
+          >
+            <input name="firstname" type="text" />
+          </cbp-form-field>
+        </cbp-flex-item>
+
+        <cbp-form-field
+          label="M.I."
+          sx='{"width":"5ch"}'
+        >
+          <input name="middleinitial" type="text" maxlength="1" />
+        </cbp-form-field>
+
+        <cbp-flex-item
+          flex-basis="10rem"
+          flex-grow="1"
+        >
+          <cbp-form-field
+            label="Last Name"
+          >
+            <input name="lastname" type="text" />
+          </cbp-form-field>
+        </cbp-flex-item>
+
+        <cbp-flex-item
+          flex-basis="10rem"
+          flex-shrink="0"
+        >
+          <cbp-form-field
+            label="Suffix"
+          >
+            <cbp-dropdown name="suffix" items='${Suffix}'></cbp-dropdown>
+          </cbp-form-field>
+        </cbp-flex-item>
+
+      </cbp-flex>
+    </cbp-form-field>
+  `;
+};
+
+export const GroupAsDivider: any = GroupAsDividerTemplate.bind({});
+GroupAsDivider.args = {
+  labelSlotted: `<cbp-typography tag="h3" divider="fill"><cbp-icon name="user" size="1.5rem" sx='{"margin-inline-end":"var(--cbp-space-3x)"}'></cbp-icon>Applicant Information</cbp-typography>`,
+};

--- a/packages/web-components/src/components/cbp-form-field/cbp-form-field.scss
+++ b/packages/web-components/src/components/cbp-form-field/cbp-form-field.scss
@@ -71,6 +71,7 @@ cbp-form-field {
   fieldset,
   legend {
     all: unset;
+    width: 100%;
   }
 
   fieldset{

--- a/packages/web-components/src/components/cbp-form-field/cbp-form-field.scss
+++ b/packages/web-components/src/components/cbp-form-field/cbp-form-field.scss
@@ -256,10 +256,6 @@ cbp-form-field {
 
   // Selects do not allow ::before pseudo element for a faux-button, so this is implemented differently than cbp-dropdown.
   select:not([multiple]):not([size]) {
-    // Simple chevron replacement, no background
-    //background: right var(--cbp-space-2x) top var(--cbp-space-3x) no-repeat var(--cbp-form-field-color-bg) var(--cbp-form-field-select-chevron);
-    //padding-inline-end: var(--cbp-space-5x);
-
     // Extract the width of the faux button for easier calculations
     --cbp-form-field-dropdown-faux-button-width: calc(var(--cbp-space-9x) - var(--cbp-border-size-md));
 
@@ -267,28 +263,23 @@ cbp-form-field {
     background: right calc( calc(var(--cbp-form-field-dropdown-faux-button-width) / 2 ) - 8px) top calc(1rem - 8px) no-repeat var(--cbp-form-field-select-chevron), 
                 right -0.4px top 0px repeat-y linear-gradient( 90deg, var(--cbp-form-field-color-bg) calc(100% - var(--cbp-form-field-dropdown-faux-button-width)), var(--cbp-form-field-color-border) var(--cbp-space-9x) );
     padding-inline-end: var(--cbp-space-9x);
-    
   }
 
-  // Leave commented styles until verified everything's correct. If so, these are being inherited and can be removed.
+  // Error states
   &[error] {
-    //--cbp-form-field-color: var(--cbp-color-text-darkest);
-    --cbp-form-field-color-bg: var(--cbp-color-danger-lighter);
-    --cbp-form-field-color-border: var(--cbp-color-danger-dark);
-    --cbp-form-field-color-border-hover: var(--cbp-color-danger-darker);
-    //--cbp-form-field-color-border-focus: var(--cbp-color-interactive-focus-dark);
-    //--cbp-form-field-color-label: var(--cbp-color-text-darkest);
     --cbp-form-field-color-description: var(--cbp-color-danger-dark);
-    //--cbp-form-field-color-placeholder: var(--cbp-color-text-dark);
-    
-    //--cbp-form-field-color-dark: var(--cbp-color-text-lightest);
-    --cbp-form-field-color-bg-dark: var(--cbp-color-danger-darker);
-    --cbp-form-field-color-border-dark: var(--cbp-color-danger-light);
-    --cbp-form-field-color-border-hover-dark: var(--cbp-color-danger-lighter);
-    //--cbp-form-field-color-border-focus-dark: var(--cbp-color-interactive-focus-light);
-    //--cbp-form-field-color-label-dark: var(--cbp-color-text-lightest);
     --cbp-form-field-color-description-dark: var(--cbp-color-danger-light);
-    //--cbp-form-field-color-placeholder-dark: var(--cbp-color-text-light);
+
+    // Only fields with errors within a group should be highlighted, not all fields in a group
+    &:not([group]) {
+      --cbp-form-field-color-bg: var(--cbp-color-danger-lighter);
+      --cbp-form-field-color-border: var(--cbp-color-danger-dark);
+      --cbp-form-field-color-border-hover: var(--cbp-color-danger-darker);
+
+      --cbp-form-field-color-bg-dark: var(--cbp-color-danger-darker);
+      --cbp-form-field-color-border-dark: var(--cbp-color-danger-light);
+      --cbp-form-field-color-border-hover-dark: var(--cbp-color-danger-lighter);
+    }
   }
 
   // Auto-filled input background color is set by the user agent stylesheet, so unfortunately there’s no way to override it.

--- a/packages/web-components/src/components/cbp-form-field/cbp-form-field.stories.tsx
+++ b/packages/web-components/src/components/cbp-form-field/cbp-form-field.stories.tsx
@@ -38,8 +38,8 @@ export default {
     },
   },
   args: {
-    label: 'Field Label',
-    description: 'Field description.',
+    label: 'Insert Field Label',
+    description: 'Insert field description.',
   },
 };
 

--- a/packages/web-components/src/components/cbp-form-field/cbp-form-field.tsx
+++ b/packages/web-components/src/components/cbp-form-field/cbp-form-field.tsx
@@ -75,6 +75,7 @@ export class CbpFormField {
     this.valueChange.emit({
       host: this.host,
       nativeElement: this.formField,
+      name: this.formField.name,
       value: this.formField.value,
       nativeEvent: e
     });

--- a/packages/web-components/src/components/cbp-form-field/cbp-form-field.tsx
+++ b/packages/web-components/src/components/cbp-form-field/cbp-form-field.tsx
@@ -88,39 +88,43 @@ export class CbpFormField {
     const fieldName = e.detail?.nativeElement.getAttribute('name');
     const isCheckbox:boolean = e.detail?.nativeElement.getAttribute('type') == "checkbox";
 
+    // Ignore checkboxes inside of a multi-select dropdown.
+    const ignoredField = e.detail?.nativeElement.closest('cbp-dropdown');
+
     // Determine if this is a checklist of same-named items or not.
     let checkedListItems;
     if(isCheckbox && fieldName != undefined) {
       checkedListItems = Array.from(this.host.querySelectorAll(`input[type="checkbox"][name="${fieldName}"]`));
     }
 
-    if(checkedListItems?.length > 1) {
-      // Get all same-named checkboxes/radios and report the values of all checked items in the list as an array
-      const checkedItems = Array.from(this.host.querySelectorAll(`input[type="checkbox"][name="${fieldName}"]:checked`));
-      let values = [];
-      checkedItems.forEach( item => {
-        values = [...values, item.getAttribute('value')];
-      });
+    if(!ignoredField) {
+      if(checkedListItems?.length > 1) {
+        // Get all same-named checkboxes/radios and report the values of all checked items in the list as an array
+        const checkedItems = Array.from(this.host.querySelectorAll(`input[type="checkbox"][name="${fieldName}"]:checked`));
+        let values = [];
+        checkedItems.forEach( item => {
+          values = [...values, item.getAttribute('value')];
+        });
 
-      // Emit the event (only if the fields are named)
-      this.valueChange.emit({
-        host: this.host,
-        nativeElement: e.detail?.nativeElement,
-        name: fieldName,
-        value: values,
-        nativeEvent: e.detail?.nativeEvent
-      });
-    }
-
-    // If the field was not named or is a radio, just emit a valueChange focused on the single item, returning a null value if unchecked
-    else {
-      this.valueChange.emit({
-        host: this.host,
-        nativeElement: e.detail?.nativeElement,
-        name: fieldName,
-        value: e.detail?.checked ? e.detail?.value : null,
-        nativeEvent: e.detail?.nativeEvent
-      });
+        // Emit the event (only if the fields are named)
+        this.valueChange.emit({
+          host: this.host,
+          nativeElement: e.detail?.nativeElement,
+          name: fieldName,
+          value: values,
+          nativeEvent: e.detail?.nativeEvent
+        });
+      }
+      // If the field was not named or is a radio, just emit a valueChange focused on the single item, returning a null value if unchecked
+      else {
+        this.valueChange.emit({
+          host: this.host,
+          nativeElement: e.detail?.nativeElement,
+          name: fieldName,
+          value: e.detail?.checked ? e.detail?.value : null,
+          nativeEvent: e.detail?.nativeEvent
+        });
+      }
     }
   }
 

--- a/packages/web-components/src/components/cbp-form-field/cbp-form-field.tsx
+++ b/packages/web-components/src/components/cbp-form-field/cbp-form-field.tsx
@@ -58,14 +58,20 @@ export class CbpFormField {
   @Prop() sx: any = {};
 
 
-  /** A custom event emitted when the the nested input is changed by user interaction. */
+  /** 
+   * A custom event emitted when a nested input is changed by user interaction.
+   * If the nested field is a component that already emits its own valueChange event 
+   * this component will not fire another, as the bubbled event will suffice.
+   */
   @Event() valueChange: EventEmitter;
 
 
-
-  // TechDebt: Seems to be firing twice with a different CurrentTarget on each instance (one on the component, the other on the document/root)
-  // TechDebt: needs testing with input groups
+  /*
+    Handles native change events for which event handlers were explicitly set up for.
+    (native change events do not bubble)
+  */
   handleChange(e) {
+    // emit valueChange event
     this.valueChange.emit({
       host: this.host,
       nativeElement: this.formField,
@@ -74,22 +80,40 @@ export class CbpFormField {
     });
   }
 
-  // Listen for valueChange events from components that may not emit a native change event.
-  @Listen('valueChange')
-  handleValueChange() {
-    //WIP
-    //console.log('cbp-form-field received valueChange event:', e);
-    //e.stopPropagation();
+  // Listen for checkbox and radio button changes to provide a roll-up of values via valueChange
+  @Listen('stateChanged')
+  handleStateChange(e) {
+    const fieldName = e.detail?.nativeElement.getAttribute('name');
+    const isCheckbox:boolean = e.detail?.nativeElement.getAttribute('type') == "checkbox";
 
-    // Make sure this event is not from itself before emitting a new one
-    /*
-    this.valueChange.emit({
-      host: this.host,
-      nativeElement: e.detail?.nativeElement,
-      value: this.formField?.value,
-      nativeEvent: e.detail?.nativeEvent
-    });
-    */
+    // Get all same-named checkboxes/radios and report the values of all checked items in the list as an array
+    if(isCheckbox && fieldName != undefined) {
+      const checkedItems = Array.from(this.host.querySelectorAll(`input[type="checkbox"][name="${fieldName}"]:checked`));
+      let values = [];
+      checkedItems.forEach( item => {
+        values = [...values, item.getAttribute('value')];
+      });
+
+      // Emit the event (only if the fields are named)
+      this.valueChange.emit({
+        host: this.host,
+        nativeElement: e.detail?.nativeElement,
+        name: fieldName,
+        value: values,
+        nativeEvent: e.detail?.nativeEvent
+      });
+    }
+
+    // If the field was not named or is a radio, just emit a valueChange focused on the single item, returning a null value if unchecked
+    else {
+      this.valueChange.emit({
+        host: this.host,
+        nativeElement: e.detail?.nativeElement,
+        name: fieldName,
+        value: e.detail?.checked ? e.detail?.value : null,
+        nativeEvent: e.detail?.nativeEvent
+      });
+    }
   }
 
 
@@ -163,8 +187,8 @@ export class CbpFormField {
   componentDidLoad() {
     // Moved this logic to componentDidLoad so that it works with buttons rendered by the component lifecycle (not just slotted), such as in file input.
     if (!this.group) {
-      // query the DOM for the slotted form field and wire it up for accessibility and attach an event listener to it
-      this.formField = this.host.querySelector('button[role=combobox],input,select,textarea');
+      // query the DOM for the slotted form field
+      this.formField = this.host.querySelector('input,select,textarea');
       //this.formFields = Array.from(this.host.querySelectorAll('button[role=combobox],input,select,textarea')) as any;
       
       // Treat nested components separately, as it's hard to modify their rendered content directly
@@ -174,15 +198,17 @@ export class CbpFormField {
       this.attachedButtons = this.host.querySelectorAll('[slot=cbp-form-field-attached-button] cbp-button');
       this.hasDescription = !!this.description || !!this.host.querySelector('[slot=cbp-form-field-description]');
 
+      // For single child/non-grouped form field, hook up the ID and aria-describedby and add an onChange listener where appropriate
       if (this.formField) {
         // If the slotted form field has an ID, use it; otherwise, set it.
         this.formField.getAttribute('id')
           ? this.fieldId = this.formField.getAttribute('id')
           : this.formField.setAttribute('id', `${this.fieldId}`);
         this.hasDescription && this.formField.setAttribute('aria-describedby',`${this.fieldId}-description`);
-        
-        // Listen for native change events
-        this.formField.addEventListener('change', (e) => this.handleChange(e));
+
+        // Listen for native change events (unless already handled by a custom component)
+        const ignoredField = this.formField.closest('cbp-dropdown,cbp-slider,cbp-file-input');
+        if(!ignoredField) this.formField.addEventListener('change', (e) => this.handleChange(e));
       }
 
       // Set the disabled/readonly/error states on load only if true. (The Watch decorators only listen for changes, not initial state)
@@ -196,8 +222,6 @@ export class CbpFormField {
         this.formFieldComponent.fieldId
           ? this.fieldId = this.formFieldComponent.fieldId
           : this.formFieldComponent.fieldId = this.fieldId;
-        // TechDebt: readonly should probably be removed, as it's not applicable to these components/inputs. Or maybe set the field disabled, because this could be applied to a group?
-        if (this.readonly) this.formFieldComponent.readonly=true;
         if (this.disabled) this.formFieldComponent.disabled=true;
         if (this.error) this.formFieldComponent.error=true;
       }
@@ -275,6 +299,7 @@ export class CbpFormField {
           <div
             id={`${this.fieldId}-description`}
             class="cbp-form-field-description"
+            hidden={!this.description && !this.host.querySelector('[slot=cbp-form-field-description]')}
           >
             {this.error && <cbp-icon name="triangle-exclamation" color="var(--cbp-form-field-color-description)" size="var(--cbp-space-3x)" sx='{"margin-inline-end":"var(--cbp-space-1x)"}'></cbp-icon>}
             {this.description}

--- a/packages/web-components/src/components/cbp-form-field/cbp-form-field.tsx
+++ b/packages/web-components/src/components/cbp-form-field/cbp-form-field.tsx
@@ -81,13 +81,20 @@ export class CbpFormField {
   }
 
   // Listen for checkbox and radio button changes to provide a roll-up of values via valueChange
+  @Listen('toggleClick')
   @Listen('stateChanged')
   handleStateChange(e) {
     const fieldName = e.detail?.nativeElement.getAttribute('name');
     const isCheckbox:boolean = e.detail?.nativeElement.getAttribute('type') == "checkbox";
 
-    // Get all same-named checkboxes/radios and report the values of all checked items in the list as an array
+    // Determine if this is a checklist of same-named items or not.
+    let checkedListItems;
     if(isCheckbox && fieldName != undefined) {
+      checkedListItems = Array.from(this.host.querySelectorAll(`input[type="checkbox"][name="${fieldName}"]`));
+    }
+
+    if(checkedListItems?.length > 1) {
+      // Get all same-named checkboxes/radios and report the values of all checked items in the list as an array
       const checkedItems = Array.from(this.host.querySelectorAll(`input[type="checkbox"][name="${fieldName}"]:checked`));
       let values = [];
       checkedItems.forEach( item => {

--- a/packages/web-components/src/components/cbp-form/cbp-form.tsx
+++ b/packages/web-components/src/components/cbp-form/cbp-form.tsx
@@ -39,7 +39,7 @@ export class CbpForm {
 
 
   handleFormData(e) {
-    // Referencing the native form event's formData seems to allow updating it before submission
+    // Referencing the native form formdata event seems to allow updating formData before submission
     let formData = e.formData;
     if(this.debug) console.log("cbp-form - listening for formData event: ", [...formData]);
     // Add files from enhanced/multi-file inputs

--- a/packages/web-components/src/components/cbp-listbox/cbp-listbox.stories.tsx
+++ b/packages/web-components/src/components/cbp-listbox/cbp-listbox.stories.tsx
@@ -44,8 +44,8 @@ export default {
     },
   },
   args: {
-    label: 'Field Label',
-    description: 'Field description.',
+    label: 'Insert Field Label',
+    description: 'Insert field description.',
   },
 };
 
@@ -113,7 +113,7 @@ const Template = ({ label, description, fieldId, name, error, readonly, disabled
   `;
 };
 
-export const Listbox = Template.bind({});
+export const Listbox: any = Template.bind({});
 Listbox.args = {
   label: "Listbox Example",
   description: "This listbox has a default list of suggestions supplied; typing is not required but filters the list further.",
@@ -178,7 +178,7 @@ const ListboxSearchTemplate = ({ label, description, fieldId, name, error, reado
   `;
 };
 
-export const ListboxSearch = ListboxSearchTemplate.bind({});
+export const ListboxSearch: any = ListboxSearchTemplate.bind({});
 ListboxSearch.storyName="Search with Suggestions"
 ListboxSearch.args = {
   label: "Search with Suggestions Listbox",

--- a/packages/web-components/src/components/cbp-radio/cbp-radio.stories.tsx
+++ b/packages/web-components/src/components/cbp-radio/cbp-radio.stories.tsx
@@ -54,9 +54,9 @@ const Template = ({ label, name, value, checked, disabled, context, sx }) => {
   `;
 };
 
-export const Radio = Template.bind({});
+export const Radio: any = Template.bind({});
 Radio.args = {
-  label: "Radio button label",
+  label: "Insert radio button label",
   name: "radio",
   value: "1",
 }

--- a/packages/web-components/src/components/cbp-radio/cbp-radio.stories.tsx
+++ b/packages/web-components/src/components/cbp-radio/cbp-radio.stories.tsx
@@ -45,8 +45,8 @@ const Template = ({ label, name, value, checked, disabled, context, sx }) => {
     >
       <input 
         type="radio" 
-        name="${name}"
-        value="${value}"
+        ${name ? `name="${name}"` : ''}
+        ${value ? `value="${value}"` : ''}
         ${checked ? 'checked' : ''}
       />
       ${label}

--- a/packages/web-components/src/components/cbp-radio/cbp-radio.tsx
+++ b/packages/web-components/src/components/cbp-radio/cbp-radio.tsx
@@ -46,6 +46,7 @@ export class CbpRadio {
     this.stateChanged.emit({
       host: this.host,
       nativeElement: this.formField,
+      name: this.formField.name,
       value: this.formField.value,
       checked: this.formField.checked,
       nativeEvent: e

--- a/packages/web-components/src/components/cbp-radio/cbp-radiolist.stories.tsx
+++ b/packages/web-components/src/components/cbp-radio/cbp-radiolist.stories.tsx
@@ -31,8 +31,8 @@ export default {
     },
   },
   args: {
-    label: "Radio List Group Label",
-    description: 'Field description.',
+    label: "Insert Radio List Group Label",
+    description: 'Insert group description.',
     radios: [
       {
         label: "Radio 1",

--- a/packages/web-components/src/components/cbp-radio/cbp-radiolist.stories.tsx
+++ b/packages/web-components/src/components/cbp-radio/cbp-radiolist.stories.tsx
@@ -76,8 +76,8 @@ function generateRadios(context, radios) {
       >
         <input 
           type="radio" 
-          name="${name}"
-          value="${value}"
+          ${name ? `name="${name}"` : ''}
+          ${value ? `value="${value}"` : ''}
           ${checked ? 'checked' : ''}
           ${disabled ? 'disabled' : ''}
         />

--- a/packages/web-components/src/components/cbp-slider/cbp-slider.stories.tsx
+++ b/packages/web-components/src/components/cbp-slider/cbp-slider.stories.tsx
@@ -51,8 +51,8 @@ export default {
     },
   },
   args: {
-    label: 'Field Label',
-    description: 'Field description.',
+    label: 'Insert Field Label',
+    description: 'Insert field description.',
   },
 };
 

--- a/packages/web-components/src/components/cbp-slider/cbp-slider.tsx
+++ b/packages/web-components/src/components/cbp-slider/cbp-slider.tsx
@@ -14,10 +14,10 @@ import { setCSSProps, createNamespaceKey } from '../../utils/utils';
 })
 export class CbpSlider {
 
-  private formFields: HTMLInputElement[] = [];  // You can't set a ref to an array index, so we'll construct the array after they've loaded.
+  private formFields: HTMLInputElement[] = [];
   private valueField1: HTMLInputElement;
   private valueField2: HTMLInputElement;
-  private valueFields: HTMLInputElement[] = [];
+  private valueFields: HTMLInputElement[] = [];  // You can't set a ref to an array index, so we'll construct the array after they've loaded.
   private initialValue: any; // Save the initial value to support reset functionality
 
   @Element() private host: HTMLElement;
@@ -120,8 +120,24 @@ export class CbpSlider {
     });
   }
   
-  // Sync the values regardless of which field was updated.
+
+  // Only emit the valueChange event on native change event for consistency.
   handleChange(e, i=0) {
+    // run this again to catch the other cases where an input event is not fired to sync the slider to the value
+    this.synchronizeFields(e,i);
+
+    // emit the valueChange event
+    this.valueChange.emit({
+      host: this.host,
+      nativeElement: this.formFields[i],
+      value: this.value,
+      nativeEvent: e
+    });
+  }
+
+
+  // Sync the values regardless of which field was updated.
+  synchronizeFields(e, i=0) {
     // normalize invalid values to the min or max
     let newValue = (!isNaN(e.target.value) && !isNaN(parseFloat(e.target.value))) ? e.target.value : this.min;
     
@@ -153,14 +169,6 @@ export class CbpSlider {
       ];
       this.updateRangeBoundaries();
     }
-
-    this.valueChange.emit({
-      host: this.host,
-      nativeElement: this.formFields[i],
-      value: this.value,
-      nativeEvent: e
-    });
-
     this.setSliderBar();
   }
 
@@ -242,6 +250,7 @@ export class CbpSlider {
           item.setAttribute('id', `${this.fieldId}${index == 1 ? '-end' : ''}`);
         }
       }
+
       if (this.value) item.setAttribute('value', this.variant == 'range' ? this.value[index] : this.value);
       if (this.min) item.setAttribute('min', `${this.min}`);
       if (this.max) item.setAttribute('max', `${this.max}`);
@@ -263,8 +272,10 @@ export class CbpSlider {
 
       // The input does not retain focus on Mac when clicked, so force it
       item.addEventListener('click', () => item.focus());
-      item.addEventListener('input', (e) => this.handleChange(e, index));
-          
+      item.addEventListener('input', (e) => this.synchronizeFields(e, index));
+      // Only emit the valueChange event on the actual change event for consistency
+      item.addEventListener('change', (e) => this.handleChange(e, index));
+      
       // Save the initial value after any parsing has been done
       this.initialValue = this.value;
     })
@@ -293,7 +304,7 @@ export class CbpSlider {
             aria-description="Slider 1 value"
             aria-invalid={this.error}
             ref={(el) => this.valueField1 = el}
-            onChange={ (e) => this.handleChange(e,0)}
+            onChange={ (e) => this.handleChange(e, 0)}
           />
         }
 

--- a/packages/web-components/src/components/cbp-slider/cbp-slider.tsx
+++ b/packages/web-components/src/components/cbp-slider/cbp-slider.tsx
@@ -130,6 +130,7 @@ export class CbpSlider {
     this.valueChange.emit({
       host: this.host,
       nativeElement: this.formFields[i],
+      name: this.formFields[i].name,
       value: this.value,
       nativeEvent: e
     });

--- a/packages/web-components/src/components/cbp-toggle/cbp-toggle.stories.tsx
+++ b/packages/web-components/src/components/cbp-toggle/cbp-toggle.stories.tsx
@@ -52,7 +52,7 @@ const Template = ({ label, checked, name, value, hideStatus, statusTextOn, statu
 
 export const Toggle: any = Template.bind({});
 Toggle.args = {
-  label: 'Toggle Label',
+  label: 'Insert Toggle Label',
   name: "toggle",
   value: "1",
   checked: false,
@@ -105,8 +105,8 @@ function generateToggles(items, labelWidth, hideStatus, statusTextOn, statusText
 const MultipleTemplate = ({ ToggleItems, labelWidth, hideStatus, statusTextOn, statusTextOff, disabled, context, sx }) => {
   return `
     <cbp-form-field group
-      label="Settings"
-      description="An example of multiple toggles in a form field group."
+      label="Insert Toggle Group Label"
+      description="Insert toggle group description."
     >
       ${generateToggles(ToggleItems, labelWidth, hideStatus, statusTextOn, statusTextOff, disabled, context, sx)} 
     </cbp-form-field>

--- a/packages/web-components/src/components/cbp-toggle/cbp-toggle.tsx
+++ b/packages/web-components/src/components/cbp-toggle/cbp-toggle.tsx
@@ -63,6 +63,7 @@ export class CbpToggle {
     this.toggleClick.emit({
       host: this.host,
       nativeElement: this.formField,
+      name: this.formField.name,
       value: this.formField.value,
       checked: this.formField.checked,
       nativeEvent: e
@@ -80,7 +81,6 @@ export class CbpToggle {
     this.checked = this.initialChecked;
     this.initialChecked ? this.formField?.setAttribute('checked','') : this?.formField.removeAttribute('checked');
   }
-
 
 
   @Watch('disabled')
@@ -131,14 +131,13 @@ export class CbpToggle {
 
 
   render() {
-      return (
-        <Host>
-          <label>
-            <slot />
-            {!this.hideStatus && <span>{this.checked ? this.statusTextOn : this.statusTextOff}</span>}
-          </label>
-        </Host>
-      );
+    return (
+      <Host>
+        <label>
+          <slot />
+          {!this.hideStatus && <span>{this.checked ? this.statusTextOn : this.statusTextOff}</span>}
+        </label>
+      </Host>
+    );
   }
-
 }

--- a/packages/web-components/src/components/cbp-typography/cbp-typography.scss
+++ b/packages/web-components/src/components/cbp-typography/cbp-typography.scss
@@ -43,6 +43,7 @@ cbp-typography {
   
   & > * {
     color: var(--cbp-typography-color);
+    font-style: initial;
   }
 
   &[variant=heading-xxl] > *, h1,
@@ -160,105 +161,107 @@ cbp-typography {
 
   
   &[size="1"] > * {
-    font-size: var(--cbp-font-size-1);
+    //font-size: var(--cbp-font-size-1);
     line-height: var(--cbp-line-height-1);
   }
   
   &[size="2"] > * {
-    font-size: var(--cbp-font-size-2);
+    //font-size: var(--cbp-font-size-2);
     line-height: var(--cbp-line-height-2);
   }
 
   &[size="3"] > * {
-    font-size: var(--cbp-font-size-3);
+    //font-size: var(--cbp-font-size-3);
     line-height: var(--cbp-line-height-3);
   }
 
   &[size="4"] > * {
-    font-size: var(--cbp-font-size-4);
+    //font-size: var(--cbp-font-size-4);
     line-height: var(--cbp-line-height-4);
   }
 
   &[size="5"] > * {
-    font-size: var(--cbp-font-size-5);
+    //font-size: var(--cbp-font-size-5);
     line-height: var(--cbp-line-height-4);
   }
 
   &[size="6"] > * {
-    font-size: var(--cbp-font-size-6);
+    //font-size: var(--cbp-font-size-6);
     line-height: var(--cbp-line-height-4);
   }
 
   &[size="7"] > * {
-    font-size: var(--cbp-font-size-7);
+    //font-size: var(--cbp-font-size-7);
     line-height: var(--cbp-line-height-5);
   }
   
   &[size="8"] > * {
-    font-size: var(--cbp-font-size-8);
+    //font-size: var(--cbp-font-size-8);
     line-height: var(--cbp-line-height-6);
   }
   
   &[size="9"] > * {
-    font-size: var(--cbp-font-size-9);
+    //font-size: var(--cbp-font-size-9);
     line-height: var(--cbp-line-height-7);
   }
   
   &[size="10"] > * {
-    font-size: var(--cbp-font-size-10);
+    //font-size: var(--cbp-font-size-10);
     line-height: var(--cbp-line-height-8);
   }
   
   &[size="11"] > * {
-    font-size: var(--cbp-font-size-11);
+    //font-size: var(--cbp-font-size-11);
     line-height: var(--cbp-line-height-9);
   }
   
   &[size="12"] > * {
-    font-size: var(--cbp-font-size-12);
+    //font-size: var(--cbp-font-size-12);
     line-height: var(--cbp-line-height-10);
   }
   
   &[size="13"] > * {
-    font-size: var(--cbp-font-size-13);
+    //font-size: var(--cbp-font-size-13);
     line-height: var(--cbp-line-height-11);
   }
   
   &[size="14"] > * {
-    font-size: var(--cbp-font-size-14);
+    //font-size: var(--cbp-font-size-14);
     line-height: var(--cbp-line-height-12);
   }
   
   &[size="15"] > * {
-    font-size: var(--cbp-font-size-15);
+    //font-size: var(--cbp-font-size-15);
     line-height: var(--cbp-line-height-13);
   }
   
   &[size="16"] > * {
-    font-size: var(--cbp-font-size-16);
+    //font-size: var(--cbp-font-size-16);
     line-height: var(--cbp-line-height-14);
   }
   
   &[size="17"] > * {
-    font-size: var(--cbp-font-size-17);
+    //font-size: var(--cbp-font-size-17);
     line-height: var(--cbp-line-height-15);
   }
   
   &[size="18"] > * {
-    font-size: var(--cbp-font-size-18);
+    //font-size: var(--cbp-font-size-18);
     line-height: var(--cbp-line-height-16);
   }
 
   &[size="19"] > * {
-    font-size: var(--cbp-font-size-19);
+    //font-size: var(--cbp-font-size-19);
     line-height: var(--cbp-line-height-17);
   }
 
   &[size="20"] > * {
-    font-size: var(--cbp-font-size-20);
+    //font-size: var(--cbp-font-size-20);
     line-height: var(--cbp-line-height-18);
   }
 
+
+  /*
   &[line-height="1"] > * {
     line-height: var(--cbp-line-height-1);
   }
@@ -330,7 +333,9 @@ cbp-typography {
   &[line-height="18"] > * {
     line-height: var(--cbp-line-height-18);
   }
-  
+  */
+
+  /*
   &[font-weight=thin] > * {
     font-weight: var(--cbp-font-weight-thin)
   }
@@ -354,4 +359,5 @@ cbp-typography {
   &[font-weight=black] > * {
     font-weight: var(--cbp-font-weight-black)
   }
+  */
 }

--- a/packages/web-components/src/components/cbp-typography/cbp-typography.tsx
+++ b/packages/web-components/src/components/cbp-typography/cbp-typography.tsx
@@ -44,6 +44,9 @@ export class CbpTypography {
       this.sx = JSON.parse(this.sx) || {};
     }
     setCSSProps(this.renderedTag, {
+      'font-size': this.size ? `var(--cbp-font-size-${this.size})` : undefined,
+      'line-height': this.lineHeight ? `var(--cbp-line-height-${this.lineHeight})` : undefined,
+      'font-weight': this.fontWeight ? `var(--cbp-font-weight-${this.fontWeight})` : undefined,
       ...this.sx
     });
   }


### PR DESCRIPTION
* Create form field group stories.
* Add some stories/POCs for form field groups as dividers.
* Fix gaps when flex wraps in stories.
* Use "Insert" verbiage in stories for form labels and descriptions.
* Fix issues with checkbox and radio stories (causing major issues with parent event handling)
* Update cbp-form-field to omit valueChange events from components that already emit their own.
* Refactor slider to only emit its valueChange event on native change (not input)
* Only fields with errors within a group should be highlighted, not all fields within that group.
* Refactor typography to leverage setCSSProps over hard coding some tokens in CSS.
* Update typography to work within a form field group/legend tag.

Much of the techDebt fixed revolved around multiple valueChange events firing. These appear to be fixed by ensuring that `cbp-form-field` does not emit events when a child component is doing it already.

Most of the event updates can be tested/validated by inspecting the `cbp-form-field` and executing the following in the console:

```JavaScript
$0.addEventListener('valueChange', (e) => {console.log(e)});
```